### PR TITLE
feat: prove `lintegral_sup_rpow_edist_le_sum(_of_le_one)`

### DIFF
--- a/BrownianMotion/Continuity/IsKolmogorovProcess.lean
+++ b/BrownianMotion/Continuity/IsKolmogorovProcess.lean
@@ -277,19 +277,41 @@ lemma lintegral_sup_rpow_edist_le_of_minimal_cover (hp : 1 ≤ p)
     (hε : ∀ n, ε n ≤ EMetric.diam J)
     (hC : ∀ n, IsCover (C n) (ε n) J) (hC_subset : ∀ n, (C n : Set T) ⊆ J)
     (hC_card : ∀ n, #(C n) = internalCoveringNumber (ε n) J)
-    {c₁ : ℝ≥0} {d : ℝ} (hc₁_pos : 0 < c₁) (hd_pos : 0 < d) (hdq : d < q)
+    {c₁ : ℝ≥0∞} {d : ℝ} (hd_pos : 0 < d) (hdq : d ≤ q)
     (h_cov : HasBoundedInternalCoveringNumber J c₁ d)
     (hm : m ≤ k) :
     ∫⁻ ω, ⨆ (t) (ht : t ∈ C k), edist (X t ω) (X (chainingSequence hC ht m) ω) ^ p ∂P
       ≤ M * c₁
         * (∑ j ∈ Finset.range (k - m), ε (m + j + 1) ^ (- d / p) * ε (m + j) ^ (q / p)) ^ p := by
-  sorry
+  refine (lintegral_sup_rpow_edist_le_sum hp hX ?_ hC hC_subset hm).trans ?_
+  · exact (hd_pos.trans_le hdq).le -- `positivity` fails?
+  rw [mul_assoc]
+  gcongr _ * ?_
+  have hC_card' n : (#(C n) : ℝ≥0∞) = internalCoveringNumber (ε n) J := mod_cast hC_card n
+  simp_rw [hC_card']
+  calc (∑ x ∈ Finset.range (k - m), (internalCoveringNumber (ε (m + x + 1)) J) ^ (1 / p)
+      * ε (m + x) ^ (q / p)) ^ p
+  _ ≤ (∑ x ∈ Finset.range (k - m), (c₁ * (ε (m + x + 1))⁻¹ ^ d) ^ (1 / p)
+      * ε (m + x) ^ (q / p)) ^ p := by
+    gcongr with x hx
+    exact h_cov (ε (m + x + 1)) (hε _)
+  _ = c₁ * (∑ x ∈ Finset.range (k - m), ((ε (m + x + 1))⁻¹ ^ (d / p))
+      * ε (m + x) ^ (q / p)) ^ p := by
+    have : c₁= (c₁ ^ (1 / p)) ^ p := by rw [← ENNReal.rpow_mul]; field_simp
+    conv_rhs => rw [this]
+    rw [← ENNReal.mul_rpow_of_nonneg _ _ (by positivity), Finset.mul_sum]
+    congr with i
+    rw [ENNReal.mul_rpow_of_nonneg _ _ (by positivity), ← ENNReal.rpow_mul, mul_assoc]
+    field_simp
+  _ = c₁ * (∑ j ∈ Finset.range (k - m), ε (m + j + 1) ^ (-d / p) * ε (m + j) ^ (q / p)) ^ p := by
+    congr with i
+    rw [ENNReal.inv_rpow, neg_div, ENNReal.rpow_neg]
 
 lemma lintegral_sup_rpow_edist_le_of_minimal_cover_two (hp : 1 ≤ p)
     (hX : IsKolmogorovProcess X P p q M) {ε₀ : ℝ≥0∞} (hε : ε₀ ≤ EMetric.diam J)
     (hC : ∀ n, IsCover (C n) (ε₀ * 2⁻¹ ^ n) J) (hC_subset : ∀ n, (C n : Set T) ⊆ J)
     (hC_card : ∀ n, #(C n) = internalCoveringNumber (ε₀ * 2⁻¹ ^ n) J)
-    {c₁ : ℝ≥0} {d : ℝ} (hc₁_pos : 0 < c₁) (hd_pos : 0 < d) (hdq : d < q)
+    {c₁ : ℝ≥0∞} {d : ℝ} (hd_pos : 0 < d) (hdq : d < q)
     (h_cov : HasBoundedInternalCoveringNumber J c₁ d)
     (hm : m ≤ k) :
     ∫⁻ ω, ⨆ (t) (ht : t ∈ C k), edist (X t ω) (X (chainingSequence hC ht m) ω) ^ p ∂P
@@ -329,19 +351,28 @@ lemma lintegral_sup_rpow_edist_le_of_minimal_cover_of_le_one (hp_pos : 0 < p) (h
     (hε : ∀ n, ε n ≤ EMetric.diam J)
     (hC : ∀ n, IsCover (C n) (ε n) J) (hC_subset : ∀ n, (C n : Set T) ⊆ J)
     (hC_card : ∀ n, #(C n) = internalCoveringNumber (ε n) J)
-    {c₁ : ℝ≥0} {d : ℝ} (hc₁_pos : 0 < c₁) (hd_pos : 0 < d) (hdq : d < q)
+    {c₁ : ℝ≥0∞} {d : ℝ} (hd_pos : 0 < d) (hdq : d ≤ q)
     (h_cov : HasBoundedInternalCoveringNumber J c₁ d)
     (hm : m ≤ k) :
     ∫⁻ ω, ⨆ (t) (ht : t ∈ C k), edist (X t ω) (X (chainingSequence hC ht m) ω) ^ p ∂P
       ≤ M * c₁
         * ∑ j ∈ Finset.range (k - m), ε (m + j + 1) ^ (- d) * ε (m + j) ^ q := by
-  sorry
+  refine (lintegral_sup_rpow_edist_le_sum_of_le_one hp_pos hp ?_ hX hC hC_subset hm).trans ?_
+  · exact (hd_pos.trans_le hdq).le -- `positivity` fails?
+  simp_rw [Finset.mul_sum, mul_assoc]
+  gcongr ∑ i ∈ _, _ * ?_ with i hi
+  rw [← mul_assoc]
+  gcongr
+  refine le_trans (le_of_eq ?_) ((h_cov (ε (m + i + 1)) (hε _)).trans_eq ?_)
+  · norm_cast
+    exact hC_card _
+  · rw [ENNReal.inv_rpow, ENNReal.rpow_neg]
 
 lemma lintegral_sup_rpow_edist_le_of_minimal_cover_two_of_le_one (hp_pos : 0 < p) (hp : p ≤ 1)
     (hX : IsKolmogorovProcess X P p q M) {ε₀ : ℝ≥0∞} (hε : ε₀ ≤ EMetric.diam J)
     (hC : ∀ n, IsCover (C n) (ε₀ * 2⁻¹ ^ n) J) (hC_subset : ∀ n, (C n : Set T) ⊆ J)
     (hC_card : ∀ n, #(C n) = internalCoveringNumber (ε₀ * 2⁻¹ ^ n) J)
-    {c₁ : ℝ≥0} {d : ℝ} (hc₁_pos : 0 < c₁) (hd_pos : 0 < d) (hdq : d < q)
+    {c₁ : ℝ≥0∞} {d : ℝ} (hd_pos : 0 < d) (hdq : d < q)
     (h_cov : HasBoundedInternalCoveringNumber J c₁ d)
     (hm : m ≤ k) :
     ∫⁻ ω, ⨆ (t) (ht : t ∈ C k), edist (X t ω) (X (chainingSequence hC ht m) ω) ^ p ∂P

--- a/BrownianMotion/Continuity/IsKolmogorovProcess.lean
+++ b/BrownianMotion/Continuity/IsKolmogorovProcess.lean
@@ -32,12 +32,17 @@ theorem Finset.iSup_sum_le {α ι : Type*} {β : Sort*} [CompleteLattice α] [Ad
   | empty => simp
   | insert i I hi ih => simpa only [Finset.sum_insert hi] using (iSup_add_le _ _).trans (by gcongr)
 
+lemma Finset.sup_le_sum {α β : Type*} [AddCommMonoid β] [LinearOrder β] [OrderBot β]
+    [IsOrderedAddMonoid β] (s : Finset α) (f : α → β) (hfs : ∀ i ∈ s, 0 ≤ f i) :
+    s.sup f ≤ ∑ a ∈ s, f a :=
+  Finset.sup_le_iff.2 (fun _ hb => Finset.single_le_sum hfs hb)
+
 end Aux
 
 namespace ProbabilityTheory
 
 variable {T Ω E : Type*} [PseudoEMetricSpace T] {mΩ : MeasurableSpace Ω}
-  [PseudoEMetricSpace E] [MeasurableSpace E] [BorelSpace E]
+  [PseudoEMetricSpace E]
   {p q : ℝ} {M : ℝ≥0}
   {P : Measure Ω}
   {X : T → Ω → E}
@@ -48,6 +53,8 @@ structure IsKolmogorovProcess (X : T → Ω → E) (P : Measure Ω) (p q : ℝ) 
     ∫⁻ ω, (edist (X s ω) (X t ω)) ^ p ∂P ≤ M * edist s t ^ q
 
 section Measurability
+
+variable [MeasurableSpace E] [BorelSpace E]
 
 lemma IsKolmogorovProcess.aemeasurable (hX : IsKolmogorovProcess X P p q M) (s : T) :
     AEMeasurable (X s) P := by
@@ -87,12 +94,6 @@ lemma IsKolmogorovProcess.aemeasurable_edist (hX : IsKolmogorovProcess X P p q M
 
 end Measurability
 
-lemma Finset.sup_le_sum {α β : Type*} [AddCommMonoid β] [LinearOrder β] [OrderBot β]
-    [IsOrderedAddMonoid β] (s : Finset α) (f : α → β) (hfs : ∀ i ∈ s, 0 ≤ f i) :
-    s.sup f ≤ ∑ a ∈ s, f a :=
-  Finset.sup_le_iff.2 (fun _ hb => Finset.single_le_sum hfs hb)
-
-omit [MeasurableSpace E] [BorelSpace E] in
 lemma lintegral_sup_rpow_edist_le_card_mul_rpow (hq : 0 ≤ q) (hX : IsKolmogorovProcess X P p q M)
     {ε : ℝ≥0∞} (C : Finset (T × T)) (hC : ∀ u ∈ C, edist u.1 u.2 ≤ ε) :
     ∫⁻ ω, ⨆ u ∈ C, edist (X u.1 ω) (X u.2 ω) ^ p ∂P
@@ -105,7 +106,6 @@ lemma lintegral_sup_rpow_edist_le_card_mul_rpow (hq : 0 ≤ q) (hX : IsKolmogoro
   _ ≤ ∑ u ∈ C, M * ε ^ q := by gcongr; apply hC; assumption
   _ = #C * M * ε ^ q := by simp [mul_assoc]
 
-omit [MeasurableSpace E] [BorelSpace E] in
 lemma lintegral_sup_rpow_edist_le_card_mul_rpow_of_dist_le (hp : 0 < p) (hq : 0 ≤ q)
     (hX : IsKolmogorovProcess X P p q M) {J : Finset T} {a c : ℝ≥0∞} {n : ℕ}
     (hJ_card : #J ≤ a ^ n) (ha : 1 < a) :
@@ -140,7 +140,6 @@ section FirstTerm
 
 variable {J : Set T}
 
-omit [MeasurableSpace E] [BorelSpace E] in
 lemma lintegral_sup_rpow_edist_cover_of_dist_le (hp : 0 < p) (hq : 0 ≤ q)
     (hX : IsKolmogorovProcess X P p q M) {C : Finset T} {ε : ℝ≥0∞}
     (hC_card : #C = internalCoveringNumber ε J)
@@ -195,7 +194,6 @@ section SecondTerm
 
 variable {J : Set T} {C : ℕ → Finset T} {ε : ℕ → ℝ≥0∞} {j k m : ℕ}
 
-omit [MeasurableSpace E] [BorelSpace E] in
 lemma lintegral_sup_rpow_edist_succ (hq : 0 ≤ q) (hX : IsKolmogorovProcess X P p q M)
     (hC : ∀ n, IsCover (C n) (ε n) J) (hC_subset : ∀ n, (C n : Set T) ⊆ J) (hjk : j < k) :
     ∫⁻ ω, ⨆ (t) (ht : t ∈ C k),
@@ -229,7 +227,6 @@ lemma lintegral_sup_rpow_edist_succ (hq : 0 ≤ q) (hX : IsKolmogorovProcess X P
   simp only [Function.Embedding.coeFn_mk, f₀]
   apply edist_chainingSequence_add_one_self _ hC_subset
 
-omit [MeasurableSpace E] [BorelSpace E] in
 lemma lintegral_sup_rpow_edist_le_sum_rpow (hp : 1 ≤ p) (hX : IsKolmogorovProcess X P p q M)
     (hC : ∀ n, IsCover (C n) (ε n) J) (hm : m ≤ k) :
     ∫⁻ ω, ⨆ (t) (ht : t ∈ C k), edist (X t ω) (X (chainingSequence hC ht m) ω) ^ p ∂P
@@ -250,18 +247,37 @@ lemma lintegral_sup_rpow_edist_le_sum_rpow (hp : 1 ≤ p) (hX : IsKolmogorovProc
   gcongr
   exact edist_chainingSequence_le_sum_edist (X · ω) hm
 
-lemma lintegral_sup_rpow_edist_le_sum (hp : 1 ≤ p) (hX : IsKolmogorovProcess X P p q M)
+lemma lintegral_sup_rpow_edist_le_sum (hp : 1 ≤ p) (hX : IsKolmogorovProcess X P p q M) (hq : 0 ≤ q)
     (hC : ∀ n, IsCover (C n) (ε n) J) (hC_subset : ∀ n, (C n : Set T) ⊆ J) (hm : m ≤ k) :
     ∫⁻ ω, ⨆ (t) (ht : t ∈ C k), edist (X t ω) (X (chainingSequence hC ht m) ω) ^ p ∂P
       ≤ M * (∑ i ∈ Finset.range (k - m), #(C (m + i + 1)) ^ (1 / p)
               * ε (m + i) ^ (q / p)) ^ p := by
-  sorry
+  refine (lintegral_sup_rpow_edist_le_sum_rpow hp hX hC hm).trans ?_
+  calc (∑ i ∈ Finset.range (k - m),
+      (∫⁻ ω, ⨆ (t) (ht : t ∈ C k), edist (X (chainingSequence hC ht (m + i)) ω)
+        (X (chainingSequence hC ht (m + i + 1)) ω) ^ p ∂P) ^ (1 / p)) ^ p
+  _ ≤ (∑ i ∈ Finset.range (k - m), (#(C (m + i + 1)) * M * ε (m + i) ^ q) ^ (1 / p)) ^ p := by
+    gcongr with i hi
+    refine (lintegral_sup_rpow_edist_succ hq hX _ hC_subset ?_).trans_eq (by ring)
+    simp only [Finset.mem_range] at hi
+    omega
+  _ = (∑ i ∈ Finset.range (k - m),
+      M ^ (1 / p) * #(C (m + i + 1)) ^ (1 / p) * ε (m + i) ^ (q / p)) ^ p := by
+    congr with i
+    rw [ENNReal.mul_rpow_of_nonneg _ _ (by positivity),
+      ENNReal.mul_rpow_of_nonneg _ _ (by positivity), ← ENNReal.rpow_mul]
+    ring_nf
+  _ = M * (∑ i ∈ Finset.range (k - m), #(C (m + i + 1)) ^ (1 / p) * ε (m + i) ^ (q / p)) ^ p := by
+    simp_rw [mul_assoc]
+    rw [← Finset.mul_sum, ENNReal.mul_rpow_of_nonneg _ _ (by positivity), ← ENNReal.rpow_mul]
+    field_simp
 
-lemma lintegral_sup_rpow_edist_le_of_minimal_cover (hp : 1 ≤ p) (hX : IsKolmogorovProcess X P p q M)
+lemma lintegral_sup_rpow_edist_le_of_minimal_cover (hp : 1 ≤ p)
+    (hX : IsKolmogorovProcess X P p q M)
     (hε : ∀ n, ε n ≤ EMetric.diam J)
     (hC : ∀ n, IsCover (C n) (ε n) J) (hC_subset : ∀ n, (C n : Set T) ⊆ J)
     (hC_card : ∀ n, #(C n) = internalCoveringNumber (ε n) J)
-    {c₁ : ℝ≥0} {d : ℝ} (hc₁_pos : 0 < c₁) (hd_pos : 0 < d)
+    {c₁ : ℝ≥0} {d : ℝ} (hc₁_pos : 0 < c₁) (hd_pos : 0 < d) (hdq : d < q)
     (h_cov : HasBoundedInternalCoveringNumber J c₁ d)
     (hm : m ≤ k) :
     ∫⁻ ω, ⨆ (t) (ht : t ∈ C k), edist (X t ω) (X (chainingSequence hC ht m) ω) ^ p ∂P
@@ -273,14 +289,13 @@ lemma lintegral_sup_rpow_edist_le_of_minimal_cover_two (hp : 1 ≤ p)
     (hX : IsKolmogorovProcess X P p q M) {ε₀ : ℝ≥0∞} (hε : ε₀ ≤ EMetric.diam J)
     (hC : ∀ n, IsCover (C n) (ε₀ * 2⁻¹ ^ n) J) (hC_subset : ∀ n, (C n : Set T) ⊆ J)
     (hC_card : ∀ n, #(C n) = internalCoveringNumber (ε₀ * 2⁻¹ ^ n) J)
-    {c₁ : ℝ≥0} {d : ℝ} (hc₁_pos : 0 < c₁) (hd_pos : 0 < d)
+    {c₁ : ℝ≥0} {d : ℝ} (hc₁_pos : 0 < c₁) (hd_pos : 0 < d) (hdq : d < q)
     (h_cov : HasBoundedInternalCoveringNumber J c₁ d)
     (hm : m ≤ k) :
     ∫⁻ ω, ⨆ (t) (ht : t ∈ C k), edist (X t ω) (X (chainingSequence hC ht m) ω) ^ p ∂P
       ≤ 2 ^ d * M * c₁ * (2 * ε₀ * 2⁻¹ ^ m) ^ (q - d) / (2 ^ ((q - d) / p) - 1) ^ p := by
   sorry
 
-omit [MeasurableSpace E] [BorelSpace E] in
 lemma lintegral_sup_rpow_edist_le_sum_rpow_of_le_one (hp_pos : 0 < p) (hp : p ≤ 1)
     (hX : IsKolmogorovProcess X P p q M)
     (hC : ∀ n, IsCover (C n) (ε n) J) (hm : m ≤ k) :
@@ -297,19 +312,24 @@ lemma lintegral_sup_rpow_edist_le_sum_rpow_of_le_one (hp_pos : 0 < p) (hp : p �
   gcongr
   exact edist_chainingSequence_le_sum_edist (X · ω) hm
 
-lemma lintegral_sup_rpow_edist_le_sum_of_le_one (hp_pos : 0 < p) (hp : p ≤ 1)
+lemma lintegral_sup_rpow_edist_le_sum_of_le_one (hp_pos : 0 < p) (hp : p ≤ 1) (hq : 0 ≤ q)
     (hX : IsKolmogorovProcess X P p q M)
     (hC : ∀ n, IsCover (C n) (ε n) J) (hC_subset : ∀ n, (C n : Set T) ⊆ J) (hm : m ≤ k) :
     ∫⁻ ω, ⨆ (t) (ht : t ∈ C k), edist (X t ω) (X (chainingSequence hC ht m) ω) ^ p ∂P
       ≤ M * ∑ i ∈ Finset.range (k - m), #(C (m + i + 1)) * ε (m + i) ^ q := by
-  sorry
+  refine (lintegral_sup_rpow_edist_le_sum_rpow_of_le_one hp_pos hp hX hC hm).trans ?_
+  rw [Finset.mul_sum]
+  gcongr with i hi
+  refine (lintegral_sup_rpow_edist_succ hq hX _ hC_subset ?_).trans_eq (by ring)
+  simp only [Finset.mem_range] at hi
+  omega
 
 lemma lintegral_sup_rpow_edist_le_of_minimal_cover_of_le_one (hp_pos : 0 < p) (hp : p ≤ 1)
     (hX : IsKolmogorovProcess X P p q M)
     (hε : ∀ n, ε n ≤ EMetric.diam J)
     (hC : ∀ n, IsCover (C n) (ε n) J) (hC_subset : ∀ n, (C n : Set T) ⊆ J)
     (hC_card : ∀ n, #(C n) = internalCoveringNumber (ε n) J)
-    {c₁ : ℝ≥0} {d : ℝ} (hc₁_pos : 0 < c₁) (hd_pos : 0 < d)
+    {c₁ : ℝ≥0} {d : ℝ} (hc₁_pos : 0 < c₁) (hd_pos : 0 < d) (hdq : d < q)
     (h_cov : HasBoundedInternalCoveringNumber J c₁ d)
     (hm : m ≤ k) :
     ∫⁻ ω, ⨆ (t) (ht : t ∈ C k), edist (X t ω) (X (chainingSequence hC ht m) ω) ^ p ∂P
@@ -321,7 +341,7 @@ lemma lintegral_sup_rpow_edist_le_of_minimal_cover_two_of_le_one (hp_pos : 0 < p
     (hX : IsKolmogorovProcess X P p q M) {ε₀ : ℝ≥0∞} (hε : ε₀ ≤ EMetric.diam J)
     (hC : ∀ n, IsCover (C n) (ε₀ * 2⁻¹ ^ n) J) (hC_subset : ∀ n, (C n : Set T) ⊆ J)
     (hC_card : ∀ n, #(C n) = internalCoveringNumber (ε₀ * 2⁻¹ ^ n) J)
-    {c₁ : ℝ≥0} {d : ℝ} (hc₁_pos : 0 < c₁) (hd_pos : 0 < d)
+    {c₁ : ℝ≥0} {d : ℝ} (hc₁_pos : 0 < c₁) (hd_pos : 0 < d) (hdq : d < q)
     (h_cov : HasBoundedInternalCoveringNumber J c₁ d)
     (hm : m ≤ k) :
     ∫⁻ ω, ⨆ (t) (ht : t ∈ C k), edist (X t ω) (X (chainingSequence hC ht m) ω) ^ p ∂P
@@ -342,7 +362,7 @@ lemma second_term_bound {C : ℕ → Finset T} {k m : ℕ} (hp_pos : 0 < p)
     (hX : IsKolmogorovProcess X P p q M) {ε₀ : ℝ≥0∞} (hε : ε₀ ≤ EMetric.diam J)
     (hC : ∀ n, IsCover (C n) (ε₀ * 2⁻¹ ^ n) J) (hC_subset : ∀ n, (C n : Set T) ⊆ J)
     (hC_card : ∀ n, #(C n) = internalCoveringNumber (ε₀ * 2⁻¹ ^ n) J)
-    {c₁ : ℝ≥0} {d : ℝ} (hc₁_pos : 0 < c₁) (hd_pos : 0 < d)
+    {c₁ : ℝ≥0} {d : ℝ} (hc₁_pos : 0 < c₁) (hd_pos : 0 < d) (hdq : d < q)
     (h_cov : HasBoundedInternalCoveringNumber J c₁ d)
     (hm : m ≤ k) :
     ∫⁻ ω, ⨆ (t) (ht : t ∈ C k), edist (X t ω) (X (chainingSequence hC ht m) ω) ^ p ∂P

--- a/blueprint/src/chapters/kolmogorov_chentsov.tex
+++ b/blueprint/src/chapters/kolmogorov_chentsov.tex
@@ -832,7 +832,7 @@ Then for $p \ge 1$ and $m \le k$,
 \end{align*}
 \end{lemma}
 
-\begin{proof}
+\begin{proof}\leanok
   \uses{lem:integral_sup_rpow_dist_succ, lem:integral_sup_dist_le_sum_rpow}
 Put together Lemma~\ref{lem:integral_sup_rpow_dist_succ} and Lemma~\ref{lem:integral_sup_dist_le_sum_rpow}.
 \end{proof}
@@ -940,7 +940,7 @@ For $0 < p \le 1$ and $m \le k$,
 \end{align*}
 \end{lemma}
 
-\begin{proof}
+\begin{proof}\leanok
   \uses{lem:integral_sup_rpow_dist_succ, lem:integral_sup_dist_le_sum_rpow_of_le_one}
 Put together Lemma~\ref{lem:integral_sup_rpow_dist_succ} and Lemma~\ref{lem:integral_sup_dist_le_sum_rpow_of_le_one}.
 \end{proof}

--- a/blueprint/src/chapters/kolmogorov_chentsov.tex
+++ b/blueprint/src/chapters/kolmogorov_chentsov.tex
@@ -853,7 +853,7 @@ Then for $p \ge 1$ and $m \le k$,
 \end{align*}
 \end{lemma}
 
-\begin{proof}
+\begin{proof}\leanok
   \uses{lem:integral_sup_rpow_dist_le_sum, def:HasBoundedInternalCoveringNumber}
 By Lemma~\ref{lem:integral_sup_rpow_dist_le_sum}, we have
 \begin{align*}
@@ -961,7 +961,7 @@ Then for $p \le 1$ and $m \le k$,
 \end{align*}
 \end{lemma}
 
-\begin{proof}
+\begin{proof}\leanok
   \uses{lem:integral_sup_rpow_dist_le_sum_of_le_one, def:HasBoundedInternalCoveringNumber}
 By Lemma~\ref{lem:integral_sup_rpow_dist_le_sum_of_le_one}, we have
 \begin{align*}


### PR DESCRIPTION
as well as `lintegral_sup_rpow_edist_le_of_minimal_cover(_of_le_one)`