### PR TITLE
feat: Prove `internalCoveringNumber_eq_one_of_diam_le`

### DIFF
--- a/BrownianMotion/Continuity/CoveringNumber.lean
+++ b/BrownianMotion/Continuity/CoveringNumber.lean
@@ -72,13 +72,42 @@ lemma internalCoveringNumber_eq_one_of_diam_le [PseudoEMetricSpace E] {r : ℝ�
         · exact le_iSup₂ (α := ENNReal) a ha
         · exact le_iSup₂ (α := ENNReal) b hb
       _ ≤ _ := by simp [C]
-  ·
-    sorry
+  · apply le_iInf₂ (α := ℕ∞)
+    intro C hC
+    apply le_iInf (α := ℕ∞)
+    intro hCoverC
+    by_contra hcontra
+    push_neg at hcontra
+    apply (ENat.lt_one_iff_eq_zero).mp at hcontra
+    simp at hcontra
+    have ⟨a, ha⟩ := h_nonempty
+    rcases hCoverC a ha with ⟨c,hc⟩
+    subst hcontra
+    simp_all only [Finset.coe_empty, Set.empty_subset, Set.mem_empty_iff_false, false_and]
 
 lemma internalCoveringNumber_le_one_of_diam_le [PseudoEMetricSpace E] {r : ℝ≥0∞} {A : Set E}
     (hA : EMetric.diam A ≤ r) :
     internalCoveringNumber r A ≤ 1 := by
-  sorry
+  by_cases h_emptyA : A.Nonempty
+  · refine le_of_eq ?_
+    refine internalCoveringNumber_eq_one_of_diam_le h_emptyA hA
+  · push_neg at h_emptyA
+    let C := (∅ : Finset E)
+    have hC : ↑C ⊆ A := by simp [C]
+    have hCover : IsCover (↑C) r A := by
+      simp only [IsCover]
+      intro a ha
+      subst h_emptyA
+      simp_all only [EMetric.diam_empty, zero_le, Finset.coe_empty,
+                    subset_refl, Set.mem_empty_iff_false, C]
+    calc
+      _ ≤ _ := iInf₂_le (α := ℕ∞) C hC
+      _ ≤ C.card := by
+        refine iInf_le (α := ℕ∞) _ hCover
+    subst h_emptyA
+    simp_all only [EMetric.diam_empty, zero_le, Finset.coe_empty,
+                   subset_refl, Finset.card_empty, CharP.cast_eq_zero, C]
+
 
 @[simp]
 lemma isSeparated_empty [EDist E] (r : ℝ≥0∞) : IsSeparated (∅ : Set E) r := by

--- a/BrownianMotion/Continuity/CoveringNumber.lean
+++ b/BrownianMotion/Continuity/CoveringNumber.lean
@@ -47,6 +47,10 @@ lemma EMetric.isCover_iff [PseudoEMetricSpace E] {C : Set E} {ε : ℝ≥0∞} {
     IsCover C ε A ↔ A ⊆ ⋃ x ∈ C, EMetric.closedBall x ε := by
   simp [IsCover, Set.subset_def]
 
+lemma EMetric.not_isCover_empty [EDist E] (ε : ℝ≥0∞) (A : Set E) (h_nonempty : A.Nonempty) :
+    ¬ IsCover (∅ : Set E) ε A := by
+  simpa [IsCover]
+
 lemma isCover_singleton_of_diam_le [PseudoEMetricSpace E] {ε : ℝ≥0∞} {A : Set E} {a : E}
     (hA : EMetric.diam A ≤ ε) (ha : a ∈ A) :
     IsCover ({a} : Set E) ε A := by
@@ -72,41 +76,28 @@ lemma internalCoveringNumber_eq_one_of_diam_le [PseudoEMetricSpace E] {r : ℝ�
         · exact le_iSup₂ (α := ENNReal) a ha
         · exact le_iSup₂ (α := ENNReal) b hb
       _ ≤ _ := by simp [C]
-  · apply le_iInf₂ (α := ℕ∞)
-    intro C hC
-    apply le_iInf (α := ℕ∞)
-    intro hCoverC
-    by_contra hcontra
-    push_neg at hcontra
+  · refine le_iInf₂ (α := ℕ∞) fun C hC ↦ ?_
+    refine le_iInf (α := ℕ∞) fun hCoverC ↦ ?_
+    by_contra! hcontra
     apply (ENat.lt_one_iff_eq_zero).mp at hcontra
-    simp at hcontra
-    have ⟨a, ha⟩ := h_nonempty
-    rcases hCoverC a ha with ⟨c,hc⟩
-    subst hcontra
-    simp_all only [Finset.coe_empty, Set.empty_subset, Set.mem_empty_iff_false, false_and]
+    simp only [Nat.cast_eq_zero, Finset.card_eq_zero] at hcontra
+    rw [hcontra, Finset.coe_empty] at hCoverC
+    exact EMetric.not_isCover_empty r _ h_nonempty hCoverC
 
 lemma internalCoveringNumber_le_one_of_diam_le [PseudoEMetricSpace E] {r : ℝ≥0∞} {A : Set E}
     (hA : EMetric.diam A ≤ r) :
     internalCoveringNumber r A ≤ 1 := by
   by_cases h_emptyA : A.Nonempty
-  · refine le_of_eq ?_
-    refine internalCoveringNumber_eq_one_of_diam_le h_emptyA hA
+  · exact le_of_eq (internalCoveringNumber_eq_one_of_diam_le h_emptyA hA)
   · push_neg at h_emptyA
     let C := (∅ : Finset E)
-    have hC : ↑C ⊆ A := by simp [C]
     have hCover : IsCover (↑C) r A := by
-      simp only [IsCover]
       intro a ha
-      subst h_emptyA
-      simp_all only [EMetric.diam_empty, zero_le, Finset.coe_empty,
-                    subset_refl, Set.mem_empty_iff_false, C]
+      simp [h_emptyA] at ha
     calc
-      _ ≤ _ := iInf₂_le (α := ℕ∞) C hC
-      _ ≤ C.card := by
-        refine iInf_le (α := ℕ∞) _ hCover
-    subst h_emptyA
-    simp_all only [EMetric.diam_empty, zero_le, Finset.coe_empty,
-                   subset_refl, Finset.card_empty, CharP.cast_eq_zero, C]
+      _ ≤ _ := iInf₂_le (α := ℕ∞) C (by simp [C])
+      _ ≤ C.card := iInf_le (α := ℕ∞) _ hCover
+    simp [C]
 
 
 @[simp]

--- a/BrownianMotion/Continuity/CoveringNumber.lean
+++ b/BrownianMotion/Continuity/CoveringNumber.lean
@@ -58,7 +58,22 @@ lemma isCover_singleton_of_diam_le [PseudoEMetricSpace E] {ε : ℝ≥0∞} {A :
 lemma internalCoveringNumber_eq_one_of_diam_le [PseudoEMetricSpace E] {r : ℝ≥0∞} {A : Set E}
     (h_nonempty : A.Nonempty) (hA : EMetric.diam A ≤ r) :
     internalCoveringNumber r A = 1 := by
-  sorry
+  simp [internalCoveringNumber]
+  refine le_antisymm ?_ ?_
+  · have ⟨a, ha⟩ := h_nonempty
+    let C := ({a} : Finset E)
+    have hC : ↑C ⊆ A := by simp [C, ha]
+    calc
+      _ ≤ _ := iInf₂_le (α := ℕ∞) C hC
+      _ ≤ C.card := by
+        refine iInf_le (α := ℕ∞) _ fun b hb ↦ ⟨a, by simp [C], hA.trans' ?_⟩
+        simp only [EMetric.diam, C]
+        trans ⨆ y ∈ A, edist b y
+        · exact le_iSup₂ (α := ENNReal) a ha
+        · exact le_iSup₂ (α := ENNReal) b hb
+      _ ≤ _ := by simp [C]
+  ·
+    sorry
 
 lemma internalCoveringNumber_le_one_of_diam_le [PseudoEMetricSpace E] {r : ℝ≥0∞} {A : Set E}
     (hA : EMetric.diam A ≤ r) :

--- a/blueprint/src/chapters/kolmogorov_chentsov.tex
+++ b/blueprint/src/chapters/kolmogorov_chentsov.tex
@@ -67,7 +67,7 @@ $N^{ext}_\varepsilon(A) \le N^{int}_\varepsilon(A)$.
 If $\mathrm{diam}(A) \le \varepsilon$ and $A$ is nonempty, then $N^{int}_\varepsilon(A) = 1$.
 \end{lemma}
 
-\begin{proof}
+\begin{proof}\leanok
 
 \end{proof}
 


### PR DESCRIPTION
Proofs of `internalCoveringNumber_eq_one_of_diam_le` and `internalCoveringNumber_le_one_of_diam_le`.

We also added the lemma `EMetric.not_isCover_empty`.

Co-authored-by: @StochasticMouse