### PR TITLE
More API about ContinuousBilinForm

### DIFF
--- a/BrownianMotion.lean
+++ b/BrownianMotion.lean
@@ -1,5 +1,6 @@
 import BrownianMotion.Auxiliary.ContinuousBilinForm
 import BrownianMotion.Auxiliary.ENNReal
+import BrownianMotion.Auxiliary.LinearAlgebra
 import BrownianMotion.Auxiliary.MeanInequalities
 import BrownianMotion.Auxiliary.MeasureTheory
 import BrownianMotion.Continuity.Chaining

--- a/BrownianMotion/Auxiliary/ContinuousBilinForm.lean
+++ b/BrownianMotion/Auxiliary/ContinuousBilinForm.lean
@@ -125,7 +125,7 @@ variable (M : Matrix n n 𝕜) (b : Basis n 𝕜 E)
 noncomputable
 def ofMatrix : ContinuousBilinForm 𝕜 E :=
   haveI : FiniteDimensional 𝕜 E := FiniteDimensional.of_fintype_basis b
-  LinearMap.mkContinuous₂_of_finiteDimensional (M.toBilin b)
+  LinearMap.mkContinuous₂OfFiniteDimensional (M.toBilin b)
 
 lemma ofMatrix_apply' (x y : E) : ofMatrix M b x y = M.toBilin b x y := rfl
 

--- a/BrownianMotion/Auxiliary/ContinuousBilinForm.lean
+++ b/BrownianMotion/Auxiliary/ContinuousBilinForm.lean
@@ -1,3 +1,4 @@
+import BrownianMotion.Auxiliary.LinearAlgebra
 import Mathlib.LinearAlgebra.Matrix.BilinearForm
 import Mathlib.LinearAlgebra.Matrix.SchurComplement
 
@@ -7,14 +8,19 @@ import Mathlib.LinearAlgebra.Matrix.SchurComplement
 
 open scoped Matrix
 
-variable (𝕜 E : Type*) [RCLike 𝕜] [NormedAddCommGroup E] [NormedSpace 𝕜 E]
-
-/- The type of continuous bilinear forms. -/
-abbrev ContinuousBilinForm := E →L[𝕜] E →L[𝕜] 𝕜
-
-variable {𝕜 E} (f : ContinuousBilinForm 𝕜 E)
-
 namespace ContinuousBilinForm
+
+variable {𝕜 E n : Type*} [NormedAddCommGroup E]
+
+section RCLike
+
+variable [RCLike 𝕜] [NormedSpace 𝕜 E]
+
+variable (𝕜 E) in
+/- The type of continuous bilinear forms. -/
+abbrev _root_.ContinuousBilinForm := E →L[𝕜] E →L[𝕜] 𝕜
+
+variable (f : ContinuousBilinForm 𝕜 E) (b : Basis n 𝕜 E)
 
 /-- The underlying bilinear form of a continuous bilinear form -/
 def toBilinForm : LinearMap.BilinForm 𝕜 E where
@@ -25,11 +31,15 @@ def toBilinForm : LinearMap.BilinForm 𝕜 E where
 @[simp]
 lemma toBilinForm_apply (x y : E) : f.toBilinForm x y = f x y := rfl
 
-variable {n : Type*} (b : Basis n 𝕜 E)
+section IsSymm
 
 /-- A continuous bilinear form `f` is symmetric if for any `x, y` we have `f x y = f y x`. -/
 structure IsSymm : Prop where
   map_symm : ∀ x y, f x y = f y x
+
+lemma isSymm_def : f.IsSymm ↔ ∀ x y, f x y = f y x where
+  mp := fun ⟨h⟩ ↦ h
+  mpr h := ⟨h⟩
 
 variable {f}
 
@@ -56,10 +66,6 @@ lemma ext_iff_of_isSymm {g : ContinuousBilinForm 𝕜 E} (hf : IsSymm f) (hg : I
 
 variable (f)
 
-lemma isSymm_def : f.IsSymm ↔ ∀ x y, f x y = f y x where
-  mp := fun ⟨h⟩ ↦ h
-  mpr h := ⟨h⟩
-
 lemma isSymm_iff_basis : f.IsSymm ↔ ∀ i j, f (b i) (b j) = f (b j) (b i) where
   mp := fun ⟨h⟩ i j ↦ h _ _
   mpr := by
@@ -77,7 +83,13 @@ lemma isSymm_iff_basis : f.IsSymm ↔ ∀ i j, f (b i) (b j) = f (b j) (b i) whe
     obtain ⟨j, rfl⟩ := iy h₂
     rw [h]
 
+end IsSymm
+
+section Matrix
+
 variable [Fintype n] [DecidableEq n]
+
+section toMatrix
 
 /-- A continuous bilinear map on a finite dimensional space can be represented by a matrix. -/
 noncomputable def toMatrix : Matrix n n 𝕜 :=
@@ -104,6 +116,41 @@ lemma apply_eq_dotProduct_toMatrix_mulVec (x y : E) :
   refine Finset.sum_congr rfl (fun i _ ↦ Finset.sum_congr rfl fun j _ ↦ ?_)
   ring
 
+end toMatrix
+
+section ofMatrix
+
+variable (M : Matrix n n 𝕜) (b : Basis n 𝕜 E)
+
+noncomputable
+def ofMatrix : ContinuousBilinForm 𝕜 E :=
+  haveI : FiniteDimensional 𝕜 E := FiniteDimensional.of_fintype_basis b
+  LinearMap.mkContinuous₂_of_finiteDimensional (M.toBilin b)
+
+lemma ofMatrix_apply' (x y : E) : ofMatrix M b x y = M.toBilin b x y := rfl
+
+open scoped Matrix in
+lemma ofMatrix_apply (x y : E) :
+    ofMatrix M b x y = b.repr x ⬝ᵥ M *ᵥ b.repr y := by
+  simp [ofMatrix_apply', Matrix.toBilin_apply, dotProduct, Matrix.mulVec, Finset.mul_sum, mul_assoc]
+
+lemma ofMatrix_basis (i j : n) : ofMatrix M b (b i) (b j) = M i j := by
+  simp [ofMatrix_apply, Finsupp.single_eq_pi_single, Matrix.mulVec_single_one]
+
+lemma toMatrix_ofMatrix : ofMatrix (f.toMatrix b) b = f := by
+  ext x y
+  rw [ofMatrix_apply, f.apply_eq_dotProduct_toMatrix_mulVec b]
+
+lemma ofMatrix_toMatrix : (ofMatrix M b).toMatrix b = M := by
+  ext i j
+  rw [toMatrix_apply, ofMatrix_basis]
+
+end ofMatrix
+
+end Matrix
+
+section IsPos
+
 /-- A continuous bilinear map `f` is positive if for any `0 ≤ x`, `0 ≤ re (f x x)` -/
 structure IsPos : Prop where
   nonneg_re_apply_self : ∀ x, 0 ≤ RCLike.re (f x x)
@@ -112,14 +159,35 @@ lemma isPos_def : f.IsPos ↔ ∀ x, 0 ≤ RCLike.re (f x x) where
   mp := fun ⟨h⟩ ↦ h
   mpr h := ⟨h⟩
 
+section Real
+
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] (f : ContinuousBilinForm ℝ E)
     (b : Basis n ℝ E)
 
 lemma isPos_def_real : f.IsPos ↔ ∀ x, 0 ≤ f x x := by simp [isPos_def]
 
+variable {f} in
+lemma IsPos.nonneg_apply_self (hf : IsPos f) (x : E) : 0 ≤ f x x := f.isPos_def_real.1 hf x
+
+variable [Fintype n] [DecidableEq n]
+
 lemma isSymm_iff_isHermitian_toMatrix : f.IsSymm ↔ (f.toMatrix b).IsHermitian := by
   rw [isSymm_iff_basis f b, Matrix.IsHermitian.ext_iff]
   simp [Eq.comm]
+
+end Real
+
+end IsPos
+
+end RCLike
+
+section Real
+
+section NormedSpace
+
+variable [NormedSpace ℝ E] (f : ContinuousBilinForm ℝ E) (b : Basis n ℝ E)
+
+section IsPosSemidef
 
 /-- A continuous bilinear map is positive semidefinite if it is symmetric and positive. We only
 define it for the real field, because for the complex case we may want to consider sesquilinear
@@ -138,8 +206,9 @@ lemma isPosSemidef_iff : f.IsPosSemidef ↔ f.IsSymm ∧ f.IsPos where
   mp h := ⟨h.isSymm, h.isPos⟩
   mpr := fun ⟨h₁, h₂⟩ ↦ ⟨h₁, h₂⟩
 
-lemma isPosSemidef_iff_posSemidef_toMatrix {f : ContinuousBilinForm ℝ E} (b : Basis n ℝ E) :
-    f.IsPosSemidef ↔ (f.toMatrix b).PosSemidef := by
+variable {f} [Fintype n] [DecidableEq n]
+
+lemma isPosSemidef_iff_posSemidef_toMatrix : f.IsPosSemidef ↔ (f.toMatrix b).PosSemidef := by
   rw [isPosSemidef_iff, Matrix.PosSemidef]
   apply and_congr (f.isSymm_iff_isHermitian_toMatrix b)
   rw [isPos_def]
@@ -148,5 +217,46 @@ lemma isPosSemidef_iff_posSemidef_toMatrix {f : ContinuousBilinForm ℝ E} (b : 
     exact h _
   · rw [apply_eq_dotProduct_toMatrix_mulVec f b]
     exact h _
+
+end IsPosSemidef
+
+end NormedSpace
+
+section InnerProductSpace
+
+variable [InnerProductSpace ℝ E]
+
+open scoped InnerProductSpace
+
+variable (E) in
+/-- The inner product as continuous bilinear form. -/
+protected noncomputable def inner : ContinuousBilinForm ℝ E :=
+  letI f : LinearMap.BilinForm ℝ E := LinearMap.mk₂ ℝ
+    (fun x y ↦ ⟪x, y⟫_ℝ)
+    inner_add_left
+    (fun c m n ↦ real_inner_smul_left m n c)
+    inner_add_right
+    (fun c m n ↦ real_inner_smul_right m n c)
+  f.mkContinuous₂ 1 <| by
+    intro x y
+    simp only [LinearMap.mk₂_apply, Real.norm_eq_abs, one_mul, f]
+    exact abs_real_inner_le_norm x y
+
+@[simp]
+lemma inner_apply (x y : E) : ContinuousBilinForm.inner E x y = ⟪x, y⟫_ℝ := rfl
+
+lemma isPosSemidef_inner : IsPosSemidef (ContinuousBilinForm.inner E) where
+  map_symm := by simp [real_inner_comm]
+  nonneg_re_apply_self x := real_inner_self_nonneg
+
+variable [Fintype n] [DecidableEq n] (b : OrthonormalBasis n ℝ E)
+
+lemma inner_toMatrix_eq_one : (ContinuousBilinForm.inner E).toMatrix b.toBasis = 1 := by
+  ext i j
+  simp [Matrix.one_apply, b.inner_eq]
+
+end InnerProductSpace
+
+end Real
 
 end ContinuousBilinForm

--- a/BrownianMotion/Auxiliary/LinearAlgebra.lean
+++ b/BrownianMotion/Auxiliary/LinearAlgebra.lean
@@ -1,0 +1,55 @@
+import Mathlib.Analysis.InnerProductSpace.PiL2
+
+section mkContinuous₂
+
+namespace LinearMap
+
+variable {E F G 𝕜 : Type*} [NormedAddCommGroup E]
+    [NormedAddCommGroup F] [NormedAddCommGroup G] [NontriviallyNormedField 𝕜] [CompleteSpace 𝕜]
+    [NormedSpace 𝕜 E] [NormedSpace 𝕜 F] [NormedSpace 𝕜 G] [FiniteDimensional 𝕜 E]
+    [FiniteDimensional 𝕜 F] (f : E →ₗ[𝕜] F →ₗ[𝕜] G)
+
+/-- Given a biliniear map whose codomains are finite dimensional, outputs the continuous
+version. -/
+def mkContinuous₂_of_finiteDimensional : E →L[𝕜] F →L[𝕜] G :=
+  letI g x : F →L[𝕜] G := (f x).toContinuousLinearMap
+  letI h : E →ₗ[𝕜] F →L[𝕜] G :=
+    { toFun := g
+      map_add' x y := by ext z; simp [g]
+      map_smul' m x := by ext y; simp [g] }
+  h.toContinuousLinearMap
+
+@[simp]
+lemma mkContinuous₂_of_finiteDimensional_apply (x : E) (y : F) :
+    f.mkContinuous₂_of_finiteDimensional x y = f x y := rfl
+
+end LinearMap
+
+end mkContinuous₂
+
+section InnerProductSpace
+
+open scoped InnerProductSpace
+
+lemma OrthonormalBasis.inner_eq {𝕜 E ι : Type*} [NormedAddCommGroup E] [RCLike 𝕜]
+    [InnerProductSpace 𝕜 E] [Fintype ι] [DecidableEq ι] (b : OrthonormalBasis ι 𝕜 E)  {i j : ι} :
+    ⟪b i, b j⟫_𝕜 = if i = j then 1 else 0 := by
+  by_cases h : i = j
+  · simp only [h, ↓reduceIte]
+    apply RCLike.ext
+    · simp [inner_self_eq_norm_sq]
+    · simp
+  · simp [h]
+
+theorem OrthonormalBasis.sum_sq_inner_right {ι E : Type*} [NormedAddCommGroup E]
+    [InnerProductSpace ℝ E] [Fintype ι] (b : OrthonormalBasis ι ℝ E) (x : E) :
+    ∑ i : ι, ⟪b i, x⟫_ℝ ^ 2 = ‖x‖ ^ 2 := by
+  rw [← b.sum_sq_norm_inner]
+  simp
+
+theorem OrthonormalBasis.sum_sq_inner_left {ι E : Type*} [NormedAddCommGroup E]
+    [InnerProductSpace ℝ E] [Fintype ι] (b : OrthonormalBasis ι ℝ E) (x : E) :
+    ∑ i : ι, ⟪x, b i⟫_ℝ ^ 2 = ‖x‖ ^ 2 := by
+  simp_rw [← b.sum_sq_inner_right, real_inner_comm]
+
+end InnerProductSpace

--- a/BrownianMotion/Auxiliary/LinearAlgebra.lean
+++ b/BrownianMotion/Auxiliary/LinearAlgebra.lean
@@ -11,7 +11,7 @@ variable {E F G 𝕜 : Type*} [NormedAddCommGroup E]
 
 /-- Given a biliniear map whose codomains are finite dimensional, outputs the continuous
 version. -/
-def mkContinuous₂_of_finiteDimensional : E →L[𝕜] F →L[𝕜] G :=
+def mkContinuous₂OfFiniteDimensional : E →L[𝕜] F →L[𝕜] G :=
   letI g x : F →L[𝕜] G := (f x).toContinuousLinearMap
   letI h : E →ₗ[𝕜] F →L[𝕜] G :=
     { toFun := g
@@ -20,8 +20,8 @@ def mkContinuous₂_of_finiteDimensional : E →L[𝕜] F →L[𝕜] G :=
   h.toContinuousLinearMap
 
 @[simp]
-lemma mkContinuous₂_of_finiteDimensional_apply (x : E) (y : F) :
-    f.mkContinuous₂_of_finiteDimensional x y = f x y := rfl
+lemma mkContinuous₂OfFiniteDimensional_apply (x : E) (y : F) :
+    f.mkContinuous₂OfFiniteDimensional x y = f x y := rfl
 
 end LinearMap
 

--- a/BrownianMotion/Auxiliary/LinearAlgebra.lean
+++ b/BrownianMotion/Auxiliary/LinearAlgebra.lean
@@ -32,7 +32,7 @@ section InnerProductSpace
 open scoped InnerProductSpace
 
 lemma OrthonormalBasis.inner_eq {𝕜 E ι : Type*} [NormedAddCommGroup E] [RCLike 𝕜]
-    [InnerProductSpace 𝕜 E] [Fintype ι] [DecidableEq ι] (b : OrthonormalBasis ι 𝕜 E)  {i j : ι} :
+    [InnerProductSpace 𝕜 E] [Fintype ι] [DecidableEq ι] (b : OrthonormalBasis ι 𝕜 E) {i j : ι} :
     ⟪b i, b j⟫_𝕜 = if i = j then 1 else 0 := by
   by_cases h : i = j
   · simp only [h, ↓reduceIte]


### PR DESCRIPTION
This PR does 4 things:

- Tidy the `ContinuousBilinForm` file.
- Add `ContinuousBilinForm.ofMatrix`, the continuous bilinear form induced by a matrix. This could be useful to relate the covariance matrix and the covariance bilinear form.
- Add `ContinuousBilinForm.inner`, a `ContinuousBilinForm` of the inner product on a real Banach space. This is the covariance bilinear form of the standard Gaussian in #68.
- Create a new auxiliary file for linear algebra.