### PR TITLE
Prove `isGaussian_gaussianProjectiveFamily`

### DIFF
--- a/BrownianMotion/Gaussian/Fernique.lean
+++ b/BrownianMotion/Gaussian/Fernique.lean
@@ -51,6 +51,6 @@ lemma IsGaussian.integrable_id (μ : Measure E) [IsGaussian μ] :
 
 -- Mathlib PR #24430
 lemma IsGaussian.integral_dual (L : Dual ℝ E) : μ[L] = L (∫ x, x ∂μ) :=
-  L.integral_comp_comm ((IsGaussian.memLp_id μ 1 (by simp)).integrable le_rfl)
+  L.integral_comp_comm (IsGaussian.integrable_id μ)
 
 end ProbabilityTheory

--- a/BrownianMotion/Gaussian/ProjectiveLimit.lean
+++ b/BrownianMotion/Gaussian/ProjectiveLimit.lean
@@ -3,6 +3,7 @@ Copyright (c) 2025 Rémy Degenne. All rights reserved.
 Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 -/
+import BrownianMotion.Auxiliary.MeasureTheory
 import BrownianMotion.Gaussian.MultivariateGaussian
 import BrownianMotion.Init
 
@@ -74,15 +75,15 @@ instance isGaussian_gaussianProjectiveFamily (I : Finset ℝ≥0) :
     congr
 
 lemma integral_id_gaussianProjectiveFamily (I : Finset ℝ≥0) :
-    ∫ x : I → ℝ, x ∂(gaussianProjectiveFamily I) = 0 := by
+    ∫ x, x ∂(gaussianProjectiveFamily I) = 0 := by
   calc ∫ x : I → ℝ, x ∂(gaussianProjectiveFamily I)
   _ = ∫ x : EuclideanSpace ℝ (Fin I.card), finToSubtype I x
       ∂(gaussianProjectiveFamilyAux (fun i ↦ I.equivFin.symm i)) := by
     unfold gaussianProjectiveFamily
     rw [integral_map (by fun_prop) (by fun_prop)]
   _ = finToSubtype I (∫ x : EuclideanSpace ℝ (Fin I.card), x
-      ∂(gaussianProjectiveFamilyAux (fun i ↦ I.equivFin.symm i))) := by
-    sorry
+      ∂(gaussianProjectiveFamilyAux (fun i ↦ I.equivFin.symm i))) :=
+    (finToSubtype I).toContinuousLinearMap.integral_comp_id_comm (IsGaussian.integrable_id _)
   _ = 0 := by simp [integral_id_gaussianProjectiveFamilyAux]; rfl
 
 lemma isProjectiveMeasureFamily_gaussianProjectiveFamily :

--- a/BrownianMotion/Gaussian/ProjectiveLimit.lean
+++ b/BrownianMotion/Gaussian/ProjectiveLimit.lean
@@ -76,13 +76,11 @@ instance isGaussian_gaussianProjectiveFamily (I : Finset ℝ≥0) :
 
 lemma integral_id_gaussianProjectiveFamily (I : Finset ℝ≥0) :
     ∫ x, x ∂(gaussianProjectiveFamily I) = 0 := by
-  calc ∫ x : I → ℝ, x ∂(gaussianProjectiveFamily I)
-  _ = ∫ x : EuclideanSpace ℝ (Fin I.card), finToSubtype I x
-      ∂(gaussianProjectiveFamilyAux (fun i ↦ I.equivFin.symm i)) := by
+  calc ∫ x, x ∂(gaussianProjectiveFamily I)
+  _ = ∫ x, finToSubtype I x ∂(gaussianProjectiveFamilyAux (fun i ↦ I.equivFin.symm i)) := by
     unfold gaussianProjectiveFamily
     rw [integral_map (by fun_prop) (by fun_prop)]
-  _ = finToSubtype I (∫ x : EuclideanSpace ℝ (Fin I.card), x
-      ∂(gaussianProjectiveFamilyAux (fun i ↦ I.equivFin.symm i))) :=
+  _ = finToSubtype I (∫ x, x ∂(gaussianProjectiveFamilyAux (fun i ↦ I.equivFin.symm i))) :=
     (finToSubtype I).toContinuousLinearMap.integral_comp_id_comm (IsGaussian.integrable_id _)
   _ = 0 := by simp [integral_id_gaussianProjectiveFamilyAux]; rfl
 

--- a/BrownianMotion/Gaussian/ProjectiveLimit.lean
+++ b/BrownianMotion/Gaussian/ProjectiveLimit.lean
@@ -11,7 +11,7 @@ import BrownianMotion.Init
 
 -/
 
-open MeasureTheory
+open MeasureTheory NormedSpace
 open scoped ENNReal NNReal
 
 namespace ProbabilityTheory
@@ -39,10 +39,32 @@ def gaussianProjectiveFamily (I : Finset ℝ≥0) : Measure ((i : I) → ℝ) :=
   (gaussianProjectiveFamilyAux (fun i ↦ (I.equivFin).symm i)).map
     ((MeasurableEquiv.refl ℝ).arrowCongr' I.equivFin.symm)
 
+noncomputable
+def dualEuclideanSpaceFromDualSubtype (I : Finset ℝ≥0) (L : ({ x // x ∈ I } → ℝ) →L[ℝ] ℝ) :
+    Dual ℝ (EuclideanSpace ℝ (Fin I.card)) :=
+  LinearMap.toContinuousLinearMap
+    { toFun := L ∘ ((MeasurableEquiv.refl ℝ).arrowCongr' I.equivFin.symm)
+      map_add' x y := by
+        have : (x + y) ∘ I.equivFin = x ∘ I.equivFin + y ∘ I.equivFin := by ext; simp
+        simp [MeasurableEquiv.arrowCongr', Equiv.arrowCongr', Equiv.arrowCongr,
+          MeasurableEquiv.refl, this]
+      map_smul' c x := by
+        have : (c • x) ∘ I.equivFin = c • (x ∘ I.equivFin) := by ext; simp
+        simp [MeasurableEquiv.arrowCongr', Equiv.arrowCongr', Equiv.arrowCongr,
+          MeasurableEquiv.refl, this] }
+
+lemma coe_dualEuclideanSpaceFromDualSubtype (I : Finset ℝ≥0) (L : ({ x // x ∈ I } → ℝ) →L[ℝ] ℝ) :
+    (dualEuclideanSpaceFromDualSubtype I L : EuclideanSpace ℝ (Fin I.card) → ℝ)
+     = L ∘ ((MeasurableEquiv.refl ℝ).arrowCongr' I.equivFin.symm) := rfl
+
 instance isGaussian_gaussianProjectiveFamily (I : Finset ℝ≥0) :
-    IsGaussian (gaussianProjectiveFamily I) := by
-  unfold gaussianProjectiveFamily
-  sorry
+    IsGaussian (gaussianProjectiveFamily I) where
+  map_eq_gaussianReal L := by
+    unfold gaussianProjectiveFamily
+    rw [Measure.map_map (by fun_prop) (by fun_prop), variance_map (by fun_prop) (by fun_prop),
+      integral_map (by fun_prop) (by fun_prop), ← coe_dualEuclideanSpaceFromDualSubtype,
+      IsGaussian.map_eq_gaussianReal (dualEuclideanSpaceFromDualSubtype I L)]
+    congr
 
 lemma isProjectiveMeasureFamily_gaussianProjectiveFamily :
     IsProjectiveMeasureFamily (α := fun _ ↦ ℝ) gaussianProjectiveFamily := by

--- a/BrownianMotion/Gaussian/ProjectiveLimit.lean
+++ b/BrownianMotion/Gaussian/ProjectiveLimit.lean
@@ -34,8 +34,13 @@ instance isGaussian_gaussianProjectiveFamilyAux (I : Fin d → ℝ≥0) :
   unfold gaussianProjectiveFamilyAux
   infer_instance
 
+lemma integral_id_gaussianProjectiveFamilyAux (I : Fin d → ℝ≥0) :
+    ∫ x, x ∂(gaussianProjectiveFamilyAux I) = 0 := by
+  sorry
+
 noncomputable
-def finToSubtype (I : Finset ℝ≥0) : (Fin I.card → ℝ) ≃L[ℝ] (I → ℝ) :=
+def finToSubtype (I : Finset ℝ≥0) : EuclideanSpace ℝ (Fin I.card) ≃L[ℝ] (I → ℝ) :=
+  (EuclideanSpace.equiv (Fin I.card) ℝ).trans
   { toEquiv := Equiv.arrowCongr' I.equivFin.symm (Equiv.refl ℝ)
     map_add' x y := by
       have : (x + y) ∘ I.equivFin = x ∘ I.equivFin + y ∘ I.equivFin := by ext; simp
@@ -44,6 +49,7 @@ def finToSubtype (I : Finset ℝ≥0) : (Fin I.card → ℝ) ≃L[ℝ] (I → �
       have : (c • x) ∘ I.equivFin = c • (x ∘ I.equivFin) := by ext; simp
       simp [Equiv.arrowCongr', Equiv.arrowCongr, this] }
 
+@[simp]
 lemma finToSubtype_apply (I : Finset ℝ≥0) (x : Fin I.card → ℝ) :
     finToSubtype I x = fun i ↦ x (I.equivFin i) := rfl
 
@@ -53,19 +59,31 @@ lemma finToSubtype_apply' (I : Finset ℝ≥0) (x : Fin I.card → ℝ) (i : I) 
 
 noncomputable
 def gaussianProjectiveFamily (I : Finset ℝ≥0) : Measure (I → ℝ) :=
-  (gaussianProjectiveFamilyAux (fun i ↦ (I.equivFin).symm i)).map (finToSubtype I)
+  (gaussianProjectiveFamilyAux (fun i ↦ I.equivFin.symm i)).map (finToSubtype I)
 
 instance isGaussian_gaussianProjectiveFamily (I : Finset ℝ≥0) :
     IsGaussian (gaussianProjectiveFamily I) where
   map_eq_gaussianReal L := by
     unfold gaussianProjectiveFamily
-    have : IsGaussian (gaussianProjectiveFamilyAux (fun i ↦ (I.equivFin).symm i)) := inferInstance
+    have : IsGaussian (gaussianProjectiveFamilyAux (fun i ↦ I.equivFin.symm i)) := inferInstance
     have : (L.comp (finToSubtype I).toContinuousLinearMap : (Fin I.card → ℝ) → ℝ)
       = L ∘ (finToSubtype I) := by ext; simp
     rw [Measure.map_map (by fun_prop) (by fun_prop), variance_map (by fun_prop) (by fun_prop),
       integral_map (by fun_prop) (by fun_prop), ← this,
       IsGaussian.map_eq_gaussianReal (L.comp (finToSubtype I).toContinuousLinearMap)]
     congr
+
+lemma integral_id_gaussianProjectiveFamily (I : Finset ℝ≥0) :
+    ∫ x : I → ℝ, x ∂(gaussianProjectiveFamily I) = 0 := by
+  calc ∫ x : I → ℝ, x ∂(gaussianProjectiveFamily I)
+  _ = ∫ x : EuclideanSpace ℝ (Fin I.card), finToSubtype I x
+      ∂(gaussianProjectiveFamilyAux (fun i ↦ I.equivFin.symm i)) := by
+    unfold gaussianProjectiveFamily
+    rw [integral_map (by fun_prop) (by fun_prop)]
+  _ = finToSubtype I (∫ x : EuclideanSpace ℝ (Fin I.card), x
+      ∂(gaussianProjectiveFamilyAux (fun i ↦ I.equivFin.symm i))) := by
+    sorry
+  _ = 0 := by simp [integral_id_gaussianProjectiveFamilyAux]; rfl
 
 lemma isProjectiveMeasureFamily_gaussianProjectiveFamily :
     IsProjectiveMeasureFamily (α := fun _ ↦ ℝ) gaussianProjectiveFamily := by

--- a/BrownianMotion/Gaussian/ProjectiveLimit.lean
+++ b/BrownianMotion/Gaussian/ProjectiveLimit.lean
@@ -52,7 +52,7 @@ lemma finToSubtype_apply' (I : Finset ℝ≥0) (x : Fin I.card → ℝ) (i : I) 
     finToSubtype I x i = x (I.equivFin i) := rfl
 
 noncomputable
-def gaussianProjectiveFamily (I : Finset ℝ≥0) : Measure ((i : I) → ℝ) :=
+def gaussianProjectiveFamily (I : Finset ℝ≥0) : Measure (I → ℝ) :=
   (gaussianProjectiveFamilyAux (fun i ↦ (I.equivFin).symm i)).map (finToSubtype I)
 
 instance isGaussian_gaussianProjectiveFamily (I : Finset ℝ≥0) :

--- a/BrownianMotion/Gaussian/ProjectiveLimit.lean
+++ b/BrownianMotion/Gaussian/ProjectiveLimit.lean
@@ -77,9 +77,8 @@ instance isGaussian_gaussianProjectiveFamily (I : Finset ℝ≥0) :
 lemma integral_id_gaussianProjectiveFamily (I : Finset ℝ≥0) :
     ∫ x, x ∂(gaussianProjectiveFamily I) = 0 := by
   calc ∫ x, x ∂(gaussianProjectiveFamily I)
-  _ = ∫ x, finToSubtype I x ∂(gaussianProjectiveFamilyAux (fun i ↦ I.equivFin.symm i)) := by
-    unfold gaussianProjectiveFamily
-    rw [integral_map (by fun_prop) (by fun_prop)]
+  _ = ∫ x, finToSubtype I x ∂(gaussianProjectiveFamilyAux (fun i ↦ I.equivFin.symm i)) :=
+    integral_map (by fun_prop) (by fun_prop)
   _ = finToSubtype I (∫ x, x ∂(gaussianProjectiveFamilyAux (fun i ↦ I.equivFin.symm i))) :=
     (finToSubtype I).toContinuousLinearMap.integral_comp_id_comm (IsGaussian.integrable_id _)
   _ = 0 := by simp [integral_id_gaussianProjectiveFamilyAux]; rfl

--- a/BrownianMotion/Gaussian/ProjectiveLimit.lean
+++ b/BrownianMotion/Gaussian/ProjectiveLimit.lean
@@ -35,7 +35,7 @@ instance isGaussian_gaussianProjectiveFamilyAux (I : Fin d → ℝ≥0) :
   infer_instance
 
 noncomputable
-def finToSubtype (I : Finset ℝ≥0) : (Fin I.card → ℝ) ≃L[ℝ] ({ x // x ∈ I } → ℝ) :=
+def finToSubtype (I : Finset ℝ≥0) : (Fin I.card → ℝ) ≃L[ℝ] (I → ℝ) :=
   { toEquiv := Equiv.arrowCongr' I.equivFin.symm (Equiv.refl ℝ)
     map_add' x y := by
       have : (x + y) ∘ I.equivFin = x ∘ I.equivFin + y ∘ I.equivFin := by ext; simp

--- a/BrownianMotion/Gaussian/ProjectiveLimit.lean
+++ b/BrownianMotion/Gaussian/ProjectiveLimit.lean
@@ -44,6 +44,13 @@ def finToSubtype (I : Finset ℝ≥0) : (Fin I.card → ℝ) ≃L[ℝ] ({ x // x
       have : (c • x) ∘ I.equivFin = c • (x ∘ I.equivFin) := by ext; simp
       simp [Equiv.arrowCongr', Equiv.arrowCongr, this] }
 
+lemma finToSubtype_apply (I : Finset ℝ≥0) (x : Fin I.card → ℝ) :
+    finToSubtype I x = fun i ↦ x (I.equivFin i) := rfl
+
+@[simp]
+lemma finToSubtype_apply' (I : Finset ℝ≥0) (x : Fin I.card → ℝ) (i : I) :
+    finToSubtype I x i = x (I.equivFin i) := rfl
+
 noncomputable
 def gaussianProjectiveFamily (I : Finset ℝ≥0) : Measure ((i : I) → ℝ) :=
   (gaussianProjectiveFamilyAux (fun i ↦ (I.equivFin).symm i)).map (finToSubtype I)


### PR DESCRIPTION
Also:
- change the definition of `gaussianProjectiveFamily` to use a map by a continuous linear equivalence instead of merely a measurable equivalence, since that interacts better with Gaussians.
- prove `integral_id_gaussianProjectiveFamily` to test the new definition.
