### PR TITLE
Gram

### DIFF
--- a/BrownianMotion/Gaussian/ProjectiveLimit.lean
+++ b/BrownianMotion/Gaussian/ProjectiveLimit.lean
@@ -40,13 +40,13 @@ def brownianCovMatrix (I : ι → ℝ≥0) : Matrix ι ι ℝ := Matrix.of fun i
 lemma posSemidef_brownianCovMatrix (I : ι → ℝ≥0) :
     (brownianCovMatrix I).PosSemidef := by
   let v : ι → (Set ℝ) := fun i ↦ Set.Icc 0 (I i)
-  have h : brownianCovMatrix I = fun i j ↦ (volume.real ((Icc 0 (I i).toReal) ∩ (Icc 0 (I j)))) := by
-    simp only [Icc_inter_Icc, max_self, Real.volume_real_Icc, sub_zero, le_inf_iff, NNReal.zero_le_coe,
-      and_self, sup_of_le_left]
+  have h : brownianCovMatrix I =
+    fun i j ↦ (volume.real ((Icc 0 (I i).toReal) ∩ (Icc 0 (I j)))) := by
+    simp only [Icc_inter_Icc, max_self, Real.volume_real_Icc, sub_zero, le_inf_iff,
+      NNReal.zero_le_coe, and_self, sup_of_le_left]
     rfl
   apply h ▸ L2.posSemidef_interMatrix (fun j ↦ measurableSet_Icc)
     (fun j ↦ IsCompact.measure_ne_top isCompact_Icc)
-  sorry -- include once Mathlib PR #25883 is available
 
 noncomputable
 def gaussianProjectiveFamilyAux (I : Fin d → ℝ≥0) :


### PR DESCRIPTION
Since I was asked to remove a file (containing the covariance matrix for BM) from my PR25583 in Mathlib on Gram matrices, I copied the code here. 
The code has still sorries, which can be resolved once PR25583 is available in Mathlib. This PR has already been reviewed. 