### PR TITLE
A modification of a Gaussian process is a Gaussian process

### DIFF
--- a/BrownianMotion/Gaussian/BrownianMotion.lean
+++ b/BrownianMotion/Gaussian/BrownianMotion.lean
@@ -70,8 +70,7 @@ lemma continuous_brownian (ω : ℝ≥0 → ℝ) :
   sorry
 
 lemma isGaussianProcess_brownian : IsGaussianProcess brownian gaussianLimit :=
-  isGaussianProcess_preBrownian.modification aemeasurable_brownian
-    (fun t ↦ (brownian_eq_preBrownian t).symm)
+  isGaussianProcess_preBrownian.modification fun t ↦ (brownian_eq_preBrownian t).symm
 
 section Measure
 

--- a/BrownianMotion/Gaussian/BrownianMotion.lean
+++ b/BrownianMotion/Gaussian/BrownianMotion.lean
@@ -70,7 +70,8 @@ lemma continuous_brownian (ω : ℝ≥0 → ℝ) :
   sorry
 
 lemma isGaussianProcess_brownian : IsGaussianProcess brownian gaussianLimit :=
-  isGaussianProcess_preBrownian.modification (fun t ↦ (brownian_eq_preBrownian t).symm)
+  isGaussianProcess_preBrownian.modification aemeasurable_brownian
+    (fun t ↦ (brownian_eq_preBrownian t).symm)
 
 section Measure
 

--- a/BrownianMotion/Gaussian/Gaussian.lean
+++ b/BrownianMotion/Gaussian/Gaussian.lean
@@ -12,6 +12,16 @@ namespace ProbabilityTheory
 
 section InnerProductSpace
 
+protected lemma IsGaussian.ne_zero {E : Type*} [TopologicalSpace E] [AddCommMonoid E] [Module ℝ E]
+    {mE : MeasurableSpace E} (μ : Measure E) [hμ : IsGaussian μ] : μ ≠ 0 := by
+  by_contra h
+  let L : E →L[ℝ] ℝ := Classical.ofNonempty
+  have := hμ.map_eq_gaussianReal L
+  rw [h, Measure.map_zero] at this
+  have : IsProbabilityMeasure (0 : Measure ℝ) := this ▸ inferInstance
+  have := this.ne_zero
+  contradiction
+
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
   [CompleteSpace E] [MeasurableSpace E] [BorelSpace E] {μ : Measure E}
 

--- a/BrownianMotion/Gaussian/Gaussian.lean
+++ b/BrownianMotion/Gaussian/Gaussian.lean
@@ -10,17 +10,15 @@ open scoped Matrix NNReal Real InnerProductSpace ProbabilityTheory
 
 namespace ProbabilityTheory
 
-section InnerProductSpace
+/-- A Gaussian measure is a probability measure. -/
+instance IsGaussian.isProbabilityMeasure {E : Type*} [TopologicalSpace E] [AddCommMonoid E]
+    [Module ℝ E] {mE : MeasurableSpace E} (μ : Measure E) [IsGaussian μ] :
+    IsProbabilityMeasure μ where
+  measure_univ := by
+    have : μ.map (0 : E →L[ℝ] ℝ) Set.univ = 1 := by simp [IsGaussian.map_eq_gaussianReal]
+    simpa [Measure.map_apply (by fun_prop : Measurable (0 : E →L[ℝ] ℝ)) .univ] using this
 
-protected lemma IsGaussian.ne_zero {E : Type*} [TopologicalSpace E] [AddCommMonoid E] [Module ℝ E]
-    {mE : MeasurableSpace E} (μ : Measure E) [hμ : IsGaussian μ] : μ ≠ 0 := by
-  by_contra h
-  let L : E →L[ℝ] ℝ := Classical.ofNonempty
-  have := hμ.map_eq_gaussianReal L
-  rw [h, Measure.map_zero] at this
-  have : IsProbabilityMeasure (0 : Measure ℝ) := this ▸ inferInstance
-  have := this.ne_zero
-  contradiction
+section InnerProductSpace
 
 variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E]
   [CompleteSpace E] [MeasurableSpace E] [BorelSpace E] {μ : Measure E}

--- a/BrownianMotion/Gaussian/GaussianProcess.lean
+++ b/BrownianMotion/Gaussian/GaussianProcess.lean
@@ -27,31 +27,13 @@ variable [MeasurableSpace E] [TopologicalSpace E] [AddCommMonoid E] [Module ℝ 
 /-- A stochastic process is a Gaussian process if all its finite dimensional distributions are
 Gaussian. -/
 def IsGaussianProcess (X : T → Ω → E) (P : Measure Ω := by volume_tac) : Prop :=
-  ∀ I : Finset T, IsGaussian ((P.map (fun ω t ↦ X t ω)).map I.restrict)
+  ∀ I : Finset T, IsGaussian (P.map (fun ω ↦ I.restrict (X · ω)))
 
-lemma IsGaussianProcess.aemeasurable (hX : IsGaussianProcess X P) :
-    AEMeasurable (fun ω t ↦ X t ω) P := by
-  by_contra h
-  by_cases hT : IsEmpty T
-  · have : (fun ω t ↦ X t ω) = fun ω ↦ hT.elim := by ext ω t; exact hT.elim t
-    rw [this] at h
-    exact h aemeasurable_const
-  let t := Classical.choice (not_isEmpty_iff.1 hT)
-  have := hX {t}
-  rw [Measure.map_of_not_aemeasurable h, Measure.map_zero] at this
-  have := this.isProbabilityMeasure.ne_zero
-  contradiction
-
-lemma IsGaussianProcess.modification (hX : IsGaussianProcess X P)
-    (hY : AEMeasurable (fun ω t ↦ Y t ω) P) (hXY : ∀ t, X t =ᵐ[P] Y t) :
+lemma IsGaussianProcess.modification (hX : IsGaussianProcess X P) (hXY : ∀ t, X t =ᵐ[P] Y t) :
     IsGaussianProcess Y P := by
   intro I
-  convert hX I using 1
-  rw [AEMeasurable.map_map_of_aemeasurable, AEMeasurable.map_map_of_aemeasurable]
-  · exact finite_distributions_eq fun t ↦ (hXY t).symm
-  any_goals fun_prop
-  · exact hX.aemeasurable
-  · exact hY
+  rw [finite_distributions_eq fun t ↦ (hXY t).symm]
+  exact hX I
 
 end Basic
 

--- a/BrownianMotion/Gaussian/GaussianProcess.lean
+++ b/BrownianMotion/Gaussian/GaussianProcess.lean
@@ -4,6 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 -/
 import BrownianMotion.Gaussian.MultivariateGaussian
+import BrownianMotion.Gaussian.StochasticProcesses
 import BrownianMotion.Init
 
 /-!
@@ -19,16 +20,39 @@ namespace ProbabilityTheory
 variable {T Ω E : Type*} {mΩ : MeasurableSpace Ω} {P : Measure Ω}
   {X Y : T → Ω → E}
 
+section Basic
+
+variable [MeasurableSpace E] [TopologicalSpace E] [AddCommMonoid E] [Module ℝ E]
+
 /-- A stochastic process is a Gaussian process if all its finite dimensional distributions are
 Gaussian. -/
-def IsGaussianProcess [MeasurableSpace E] [TopologicalSpace E] [AddCommMonoid E] [Module ℝ E]
-    (X : T → Ω → E) (P : Measure Ω := by volume_tac) : Prop :=
+def IsGaussianProcess (X : T → Ω → E) (P : Measure Ω := by volume_tac) : Prop :=
   ∀ I : Finset T, IsGaussian ((P.map (fun ω t ↦ X t ω)).map I.restrict)
 
-lemma IsGaussianProcess.modification
-    [MeasurableSpace E] [TopologicalSpace E] [AddCommMonoid E] [Module ℝ E]
-    (hX : IsGaussianProcess X P) (hXY : ∀ t, X t =ᵐ[P] Y t) :
+lemma IsGaussianProcess.aemeasurable (hX : IsGaussianProcess X P) :
+    AEMeasurable (fun ω t ↦ X t ω) P := by
+  by_contra h
+  by_cases hT : IsEmpty T
+  · have : (fun ω t ↦ X t ω) = fun ω ↦ hT.elim := by ext ω t; exact hT.elim t
+    rw [this] at h
+    exact h aemeasurable_const
+  let t := Classical.choice (not_isEmpty_iff.1 hT)
+  have := hX {t}
+  rw [Measure.map_of_not_aemeasurable h, Measure.map_zero] at this
+  have := this.ne_zero
+  contradiction
+
+lemma IsGaussianProcess.modification (hX : IsGaussianProcess X P)
+    (hY : AEMeasurable (fun ω t ↦ Y t ω) P) (hXY : ∀ t, X t =ᵐ[P] Y t) :
     IsGaussianProcess Y P := by
-  sorry
+  intro I
+  convert hX I using 1
+  rw [AEMeasurable.map_map_of_aemeasurable, AEMeasurable.map_map_of_aemeasurable]
+  · exact finite_distributions_eq fun t ↦ (hXY t).symm
+  any_goals fun_prop
+  · exact hX.aemeasurable
+  · exact hY
+
+end Basic
 
 end ProbabilityTheory

--- a/BrownianMotion/Gaussian/GaussianProcess.lean
+++ b/BrownianMotion/Gaussian/GaussianProcess.lean
@@ -39,7 +39,7 @@ lemma IsGaussianProcess.aemeasurable (hX : IsGaussianProcess X P) :
   let t := Classical.choice (not_isEmpty_iff.1 hT)
   have := hX {t}
   rw [Measure.map_of_not_aemeasurable h, Measure.map_zero] at this
-  have := this.ne_zero
+  have := this.isProbabilityMeasure.ne_zero
   contradiction
 
 lemma IsGaussianProcess.modification (hX : IsGaussianProcess X P)

--- a/BrownianMotion/Gaussian/StochasticProcesses.lean
+++ b/BrownianMotion/Gaussian/StochasticProcesses.lean
@@ -2,7 +2,7 @@ import Mathlib
 
 open MeasureTheory
 
-variable {T Ω E : Type*} {mΩ : MeasurableSpace Ω} {P : Measure Ω}
+variable {T Ω E ι : Type*} [Finite ι] {mΩ : MeasurableSpace Ω} {P : Measure Ω}
     {X Y : T → Ω → E}
 
 lemma modification_of_indistinduishable (h : ∀ᵐ ω ∂P, ∀ t, X t ω = Y t ω) :
@@ -12,9 +12,9 @@ lemma modification_of_indistinduishable (h : ∀ᵐ ω ∂P, ∀ t, X t ω = Y t
 
 variable [MeasurableSpace E]
 
-lemma finite_distributions_eq {n : ℕ} {t : Fin n → T} (h : ∀ t, X t =ᵐ[P] Y t) :
-    P.map (fun ω m ↦ X (t m) ω) = P.map (fun ω m ↦ Y (t m) ω) := by
-  have h' : ∀ᵐ ω ∂P, ∀ (m : Fin n), X (t m) ω = Y (t m) ω := by
+lemma finite_distributions_eq {t : ι → T} (h : ∀ t, X t =ᵐ[P] Y t) :
+    P.map (fun ω i ↦ X (t i) ω) = P.map (fun ω i ↦ Y (t i) ω) := by
+  have h' : ∀ᵐ ω ∂P, ∀ i, X (t i) ω = Y (t i) ω := by
     rw [MeasureTheory.ae_all_iff]
     exact fun i ↦ h (t i)
   refine Measure.map_congr ?_

--- a/BrownianMotion/Gaussian/StochasticProcesses.lean
+++ b/BrownianMotion/Gaussian/StochasticProcesses.lean
@@ -2,7 +2,7 @@ import Mathlib
 
 open MeasureTheory
 
-variable {T Ω E ι : Type*} [Finite ι] {mΩ : MeasurableSpace Ω} {P : Measure Ω}
+variable {T Ω E : Type*} {mΩ : MeasurableSpace Ω} {P : Measure Ω}
     {X Y : T → Ω → E}
 
 lemma modification_of_indistinduishable (h : ∀ᵐ ω ∂P, ∀ t, X t ω = Y t ω) :
@@ -12,15 +12,13 @@ lemma modification_of_indistinduishable (h : ∀ᵐ ω ∂P, ∀ t, X t ω = Y t
 
 variable [MeasurableSpace E]
 
-lemma finite_distributions_eq {t : ι → T} (h : ∀ t, X t =ᵐ[P] Y t) :
-    P.map (fun ω i ↦ X (t i) ω) = P.map (fun ω i ↦ Y (t i) ω) := by
-  have h' : ∀ᵐ ω ∂P, ∀ i, X (t i) ω = Y (t i) ω := by
+lemma finite_distributions_eq {I : Finset T} (h : ∀ t, X t =ᵐ[P] Y t) :
+    P.map (fun ω ↦ I.restrict (X · ω)) = P.map (fun ω ↦ I.restrict (Y · ω)) := by
+  have h' : ∀ᵐ ω ∂P, ∀ (i : I), X i ω = Y i ω := by
     rw [MeasureTheory.ae_all_iff]
-    exact fun i ↦ h (t i)
+    exact fun i ↦ h i
   refine Measure.map_congr ?_
-  filter_upwards [h']
-  simp_all only [Filter.eventually_all, implies_true, Set.mem_setOf_eq, Set.setOf_true,
-    Filter.univ_mem]
+  filter_upwards [h'] with ω h using funext fun i ↦ h i
 
 theorem aemeasurable_proj {α δ : Type*} {X : δ → Type*} {mX : ∀ a, MeasurableSpace (X a)}
     [MeasurableSpace α] {μ : Measure α} {g : α → Π a, X a} (hg : AEMeasurable g μ) (a : δ) :
@@ -30,55 +28,40 @@ theorem aemeasurable_proj {α δ : Type*} {X : δ → Type*} {mX : ∀ a, Measur
 
 lemma coincide_on_cylinders (hX : AEMeasurable (fun ω t ↦ X t ω) P)
     (hY : AEMeasurable (fun ω t ↦ Y t ω) P)
-    (h : ∀ n (tn : Fin n → T), P.map (fun ω m ↦ X (tn m) ω) = P.map (fun ω m ↦ Y (tn m) ω))
+    (h : ∀ I : Finset T, P.map (fun ω ↦ I.restrict (X · ω)) = P.map (fun ω ↦ I.restrict (Y · ω)))
     (c : Set (T → E)) (hc : c ∈ measurableCylinders fun _ ↦ E) :
     P.map (fun ω t ↦ X t ω) c = P.map (fun ω t ↦ Y t ω) c := by
-  simp only [mem_measurableCylinders] at hc
-  obtain ⟨s, ⟨S, ⟨hS, cyl⟩⟩⟩ := hc
-  let ⟨tn, tn_bij⟩ := Fintype.truncFinBijection s |>.out
-  let ⟨tninv, ⟨_, htninv⟩⟩ := Function.bijective_iff_has_inverse.mp tn_bij
-  let h' := h (Fintype.card { x // x ∈ s }) (fun x ↦ tn x)
-  let c' : Set (Fin (Fintype.card { x // x ∈ s }) → E) :=
-    (fun cmap ↦ fun n ↦ s.restrict cmap (tn n)) '' c
-  rw [Function.RightInverse, Function.LeftInverse] at htninv
-  have hXtn : AEMeasurable (fun ω m ↦ X (↑(tn m)) ω) P :=
-    aemeasurable_pi_lambda (fun ω m ↦ X (↑(tn m)) ω) fun m ↦ (aemeasurable_proj hX) ↑(tn m)
-  have hYtn : AEMeasurable (fun ω m ↦ Y (↑(tn m)) ω) P :=
-    aemeasurable_pi_lambda (fun ω m ↦ Y (↑(tn m)) ω) fun m ↦ (aemeasurable_proj hY) ↑(tn m)
-  have set1 : @MeasurableSet (T → E) MeasurableSpace.pi (s.restrict ⁻¹' S) := by measurability
-  have set2 : MeasurableSet ((fun s_1 ↦ s_1 ∘ tninv) ⁻¹' S) := by measurability
+  rw [mem_measurableCylinders] at hc
+  obtain ⟨s, S, hS, rfl⟩ := hc
+  have hXtn : AEMeasurable (fun ω ↦ s.restrict (X · ω)) P :=
+    aemeasurable_pi_lambda _ fun i ↦ (aemeasurable_proj hX) i
+  have hYtn : AEMeasurable (fun ω ↦ s.restrict (Y · ω)) P :=
+    aemeasurable_pi_lambda _ fun i ↦ (aemeasurable_proj hY) i
+  have set1 : @MeasurableSet (T → E) MeasurableSpace.pi (s.restrict ⁻¹' S) :=
+    Finset.measurable_restrict s hS
   have mappings_eq (XY : T → Ω → E) :
-      (fun ω t ↦ XY t ω) ⁻¹' (s.restrict ⁻¹' S)
-      = (fun ω m ↦ XY (↑(tn m)) ω) ⁻¹' ((fun s_1 ↦ s_1 ∘ tninv) ⁻¹' S) := by
-    simp_rw [Set.preimage]
-    unfold Function.comp
-    simp only [Set.mem_setOf_eq, Set.mem_preimage, htninv]
-    subst cyl
-    simp_all only [Multiset.bijective_iff_map_univ_eq_univ, Fin.univ_val_map, Fintype.card_coe,
-      Finset.univ_eq_attach,Finset.attach_val, Subtype.forall]
+      (fun ω t ↦ XY t ω) ⁻¹' (s.restrict ⁻¹' S) = (fun ω ↦ s.restrict (XY · ω)) ⁻¹' S := by
+    rw [← Set.preimage_comp]
     rfl
   have X_on_cyl : P.map (fun ω t ↦ X t ω) (s.restrict ⁻¹' S)
-      = P.map (fun ω m ↦ X (↑(tn m)) ω) (S.preimage (fun s ↦ s ∘ tninv)) := by
-    rw [Measure.map_apply_of_aemeasurable hX set1, Measure.map_apply_of_aemeasurable hXtn set2,
-        mappings_eq X]
+      = P.map (fun ω ↦ s.restrict (X · ω)) S := by
+    rw [Measure.map_apply_of_aemeasurable hX set1, Measure.map_apply_of_aemeasurable hXtn hS,
+      mappings_eq X]
   have Y_on_cyl : P.map (fun ω t ↦ Y t ω) (s.restrict ⁻¹' S)
-      = P.map (fun ω m ↦ Y (↑(tn m)) ω) (S.preimage (fun s ↦ s ∘ tninv)) := by
-    rw [Measure.map_apply_of_aemeasurable hY set1, Measure.map_apply_of_aemeasurable hYtn set2,
-        mappings_eq Y]
-  rw [cyl, cylinder, X_on_cyl, Y_on_cyl, h]
+      = P.map (fun ω ↦ s.restrict (Y · ω)) S := by
+    rw [Measure.map_apply_of_aemeasurable hY set1, Measure.map_apply_of_aemeasurable hYtn hS,
+      mappings_eq Y]
+  rw [cylinder, X_on_cyl, Y_on_cyl, h]
 
 lemma finite_distributions_eq_iff_same_law (hX : AEMeasurable (fun t ω ↦ X ω t) P)
     (hY : AEMeasurable (fun t ω ↦ Y ω t) P) [IsProbabilityMeasure P] :
-    (∀ n, ∀ tn : Fin n → T, P.map (fun ω m ↦ X (tn m) ω) = P.map (fun ω m ↦ Y (tn m) ω))
+    (∀ I : Finset T, P.map (fun ω ↦ I.restrict (X · ω)) = P.map (fun ω ↦ I.restrict (Y · ω)))
     ↔ (P.map (fun ω t ↦ X t ω) = P.map (fun ω t ↦ Y t ω)) := by
   constructor
   · intro h
     apply Measure.ext
-    let cyls : Set (Set (T → E)) := measurableCylinders (fun t : T ↦ E)
-    have pX : IsProbabilityMeasure (Measure.map (fun ω t ↦ X t ω) P) := by
-      apply isProbabilityMeasure_map hX
-    have pY : IsProbabilityMeasure (Measure.map (fun ω t ↦ Y t ω) P) := by
-      apply isProbabilityMeasure_map hY
+    have pX : IsProbabilityMeasure (Measure.map (fun ω t ↦ X t ω) P) := isProbabilityMeasure_map hX
+    have pY : IsProbabilityMeasure (Measure.map (fun ω t ↦ Y t ω) P) := isProbabilityMeasure_map hY
     apply MeasurableSpace.induction_on_inter
       (C := fun S hS ↦ ((P.map (fun ω t ↦ X t ω)) S = (P.map (fun ω t ↦ Y t ω)) S))
       (h_eq := by rw [generateFrom_measurableCylinders])
@@ -90,14 +73,15 @@ lemma finite_distributions_eq_iff_same_law (hX : AEMeasurable (fun t ω ↦ X ω
     · intro f disj hf map
       repeat rw [measure_iUnion disj hf]
       simp [map]
-  · intro h n tn
-    let proj := fun t : T → E ↦ (fun n0 ↦ t (tn n0))
-    have x : P.map (fun ω m ↦ X (tn m) ω) = Measure.map proj (P.map (fun ω t ↦ X t ω)) := by
-      rw [AEMeasurable.map_map_of_aemeasurable (f := fun ω t ↦ X t ω) (g := proj)]
-      repeat measurability
-    have y : P.map (fun ω m ↦ Y (tn m) ω) = Measure.map proj (P.map (fun ω t ↦ Y t ω)) := by
-      rw [AEMeasurable.map_map_of_aemeasurable]
-      repeat measurability
+  · intro h I
+    have x : P.map (fun ω ↦ I.restrict (X · ω)) = (P.map (fun ω t ↦ X t ω)).map I.restrict := by
+      rw [AEMeasurable.map_map_of_aemeasurable]; rfl
+      · fun_prop
+      · exact hX
+    have y : P.map (fun ω ↦ I.restrict (Y · ω)) = (P.map (fun ω t ↦ Y t ω)).map I.restrict := by
+      rw [AEMeasurable.map_map_of_aemeasurable]; rfl
+      · fun_prop
+      · exact hY
     rw [x, y, h]
 
 open TopologicalSpace in
@@ -107,12 +91,9 @@ lemma indistinduishable_of_modification [TopologicalSpace E] [TopologicalSpace T
     (hX : ∀ᵐ ω ∂P, Continuous fun t ↦ X t ω) (hY : ∀ᵐ ω ∂P, Continuous fun t ↦ Y t ω)
     (h : ∀ t, X t =ᵐ[P] Y t) :
     ∀ᵐ ω ∂P, ∀ t, X t ω = Y t ω := by
-  let ⟨D, ⟨D_countable, D_dense⟩⟩ := ‹SeparableSpace T›
-  have eq : (∀ t ∈ D, X t =ᵐ[P] Y t) → ∀ᵐ ω ∂P, ∀ t ∈ D, X t ω = Y t ω := by
-    intro ht
-    exact (ae_ball_iff D_countable).mpr ht
+  let ⟨D, D_countable, D_dense⟩ := ‹SeparableSpace T›
+  have eq (ht : ∀ t ∈ D, X t =ᵐ[P] Y t) : ∀ᵐ ω ∂P, ∀ t ∈ D, X t ω = Y t ω :=
+    (ae_ball_iff D_countable).mpr ht
   filter_upwards [hX, hY, eq (fun t ht ↦ h t)] with ω hX hY h t
   show (fun t ↦ X t ω) t = (fun t ↦ Y t ω) t
-  rw [Continuous.ext_on D_dense hX hY ?_]
-  rw [Set.EqOn]
-  exact h
+  rw [Continuous.ext_on D_dense hX hY h]


### PR DESCRIPTION
I also generalize the instance saying that a Gaussian measure is a probability measure and prove that a Gaussian process is almost everywhere measurable. I need to add this hypothesis to the theorem. Indeed if `Y` is a modification of `X` and `X` is a Gaussian process, then `Y` might fail to be almost everywhere measurable (only if `T` is not countable), in which case it would not be a Gaussian process (see [Zulip](https://leanprover.zulipchat.com/#narrow/channel/509433-Brownian-motion/topic/Tasks.20and.20claims/near/525387577)).
I also generalize `finite_distributions_eq` to an arbitrary fintype. Should I do the same for other lemmas in the same file, or should keep the current version and duplicate this particular lemma?