### PR TITLE
Feat: `finite_kolmogorov_chentsov`

### DIFF
--- a/BrownianMotion/Continuity/IsKolmogorovProcess.lean
+++ b/BrownianMotion/Continuity/IsKolmogorovProcess.lean
@@ -109,8 +109,8 @@ lemma IsKolmogorovProcess.edist_eq_zero (hX : IsKolmogorovProcess X P p q M)
   _ ≤ M * edist s t ^ q := hX.kolmogorovCondition s t
   _ = 0 := by simp [h, hq]
 
-lemma IsKolmogorovProcess.M_eq_zero (hX : IsKolmogorovProcess X P p q M)
-    (hp : 0 < p) {s t : T} (h : M = 0) :
+lemma IsKolmogorovProcess.M_eq_zero (hX : IsKolmogorovProcess X P p q 0)
+    (hp : 0 < p) {s t : T} :
     ∀ᵐ ω ∂P, edist (X s ω) (X t ω) = 0 := by
   suffices ∀ᵐ ω ∂P, edist (X s ω) (X t ω) ^ p = 0 by
     filter_upwards [this] with ω hω
@@ -120,8 +120,8 @@ lemma IsKolmogorovProcess.M_eq_zero (hX : IsKolmogorovProcess X P p q M)
     exact Measurable.comp_aemeasurable (by fun_prop) hX.aemeasurable_edist
   refine le_antisymm ?_ zero_le'
   calc ∫⁻ ω, edist (X s ω) (X t ω) ^ p ∂P
-  _ ≤ M * edist s t ^ q := hX.kolmogorovCondition s t
-  _ = 0 := by simp [h]
+  _ ≤ 0 * edist s t ^ q := hX.kolmogorovCondition s t
+  _ = 0 := by simp
 
 lemma IsKolmogorovProcess.lintegral_sup_rpow_edist_eq_zero (hX : IsKolmogorovProcess X P p q M)
     (hp : 0 < p) (hq : 0 < q) {T' : Set T} (hT' : T'.Countable)

--- a/BrownianMotion/Continuity/IsKolmogorovProcess.lean
+++ b/BrownianMotion/Continuity/IsKolmogorovProcess.lean
@@ -95,6 +95,8 @@ lemma IsKolmogorovProcess.aemeasurable_edist (hX : IsKolmogorovProcess X P p q M
 
 end Measurability
 
+-- M eq zero
+
 lemma IsKolmogorovProcess.edist_eq_zero (hX : IsKolmogorovProcess X P p q M)
     (hp : 0 < p) (hq : 0 < q) {s t : T} (h : edist s t = 0) :
     ∀ᵐ ω ∂P, edist (X s ω) (X t ω) = 0 := by

--- a/BrownianMotion/Continuity/IsKolmogorovProcess.lean
+++ b/BrownianMotion/Continuity/IsKolmogorovProcess.lean
@@ -181,7 +181,7 @@ lemma IsKolmogorovProcess.edist_eq_zero (hX : IsKolmogorovProcess X P p q M)
   _ ≤ M * edist s t ^ q := hX.kolmogorovCondition s t
   _ = 0 := by simp [h, hq]
 
-lemma IsKolmogorovProcess.M_eq_zero (hX : IsKolmogorovProcess X P p q 0)
+lemma IsKolmogorovProcess.edist_eq_zero_of_M_eq_zero (hX : IsKolmogorovProcess X P p q 0)
     (hp : 0 < p) {s t : T} :
     ∀ᵐ ω ∂P, edist (X s ω) (X t ω) = 0 := by
   suffices ∀ᵐ ω ∂P, edist (X s ω) (X t ω) ^ p = 0 by

--- a/BrownianMotion/Continuity/IsKolmogorovProcess.lean
+++ b/BrownianMotion/Continuity/IsKolmogorovProcess.lean
@@ -828,7 +828,6 @@ lemma finite_set_bound_of_edist_le (hJ : HasBoundedInternalCoveringNumber J c d)
     rw [mul_add]
     exact le_add_self
 
-
 end Together
 
 end ProbabilityTheory

--- a/BrownianMotion/Continuity/IsKolmogorovProcess.lean
+++ b/BrownianMotion/Continuity/IsKolmogorovProcess.lean
@@ -95,8 +95,6 @@ lemma IsKolmogorovProcess.aemeasurable_edist (hX : IsKolmogorovProcess X P p q M
 
 end Measurability
 
--- M eq zero
-
 lemma IsKolmogorovProcess.edist_eq_zero (hX : IsKolmogorovProcess X P p q M)
     (hp : 0 < p) (hq : 0 < q) {s t : T} (h : edist s t = 0) :
     ∀ᵐ ω ∂P, edist (X s ω) (X t ω) = 0 := by
@@ -110,6 +108,20 @@ lemma IsKolmogorovProcess.edist_eq_zero (hX : IsKolmogorovProcess X P p q M)
   calc ∫⁻ ω, edist (X s ω) (X t ω) ^ p ∂P
   _ ≤ M * edist s t ^ q := hX.kolmogorovCondition s t
   _ = 0 := by simp [h, hq]
+
+lemma IsKolmogorovProcess.M_eq_zero (hX : IsKolmogorovProcess X P p q M)
+    (hp : 0 < p) {s t : T} (h : M = 0) :
+    ∀ᵐ ω ∂P, edist (X s ω) (X t ω) = 0 := by
+  suffices ∀ᵐ ω ∂P, edist (X s ω) (X t ω) ^ p = 0 by
+    filter_upwards [this] with ω hω
+    simpa [hp, not_lt_of_gt hp] using hω
+  refine (lintegral_eq_zero_iff' ?_).mp ?_
+  · change AEMeasurable ((fun x ↦ x ^ p) ∘ (fun ω ↦ edist (X s ω) (X t ω))) P
+    exact Measurable.comp_aemeasurable (by fun_prop) hX.aemeasurable_edist
+  refine le_antisymm ?_ zero_le'
+  calc ∫⁻ ω, edist (X s ω) (X t ω) ^ p ∂P
+  _ ≤ M * edist s t ^ q := hX.kolmogorovCondition s t
+  _ = 0 := by simp [h]
 
 lemma IsKolmogorovProcess.lintegral_sup_rpow_edist_eq_zero (hX : IsKolmogorovProcess X P p q M)
     (hp : 0 < p) (hq : 0 < q) {T' : Set T} (hT' : T'.Countable)
@@ -815,6 +827,7 @@ lemma finite_set_bound_of_edist_le (hJ : HasBoundedInternalCoveringNumber J c d)
       + Cp d p q) := by
     rw [mul_add]
     exact le_add_self
+
 
 end Together
 

--- a/BrownianMotion/Continuity/KolmogorovChentsov.lean
+++ b/BrownianMotion/Continuity/KolmogorovChentsov.lean
@@ -97,13 +97,15 @@ lemma constL_lt_top (hc : c ≠ ∞) (hd_pos : 0 < d) (hp_pos : 0 < p) (hdq_lt :
     constL T c d p q β < ∞ := by
   sorry
 
-theorem finite_kolmogorov_chentsov (h_diam : EMetric.diam (.univ : Set T) < ∞)
+
+theorem finite_kolmogorov_chentsov
     (hT : HasBoundedInternalCoveringNumber (Set.univ : Set T) c d)
     (hX : IsKolmogorovProcess X P p q M)
     (hd_pos : 0 < d) (hp_pos : 0 < p) (hdq_lt : d < q)
     (hβ_pos : 0 < β) (hβ_lt : β < (q - d) / p) (T' : Set T) [hT' : Finite T'] :
     ∫⁻ ω, ⨆ (s : T') (t : T'), edist (X s ω) (X t ω) ^ p / edist s t ^ (β * p) ∂P
       ≤ M * constL T c d p q β := by
+  have h_diam : EMetric.diam .univ < ∞ := hT.diam_lt_top hd_pos
   have hq_pos : 0 < q := lt_trans hd_pos hdq_lt
   simp [constL, ← ENNReal.tsum_mul_left]
   by_cases h_ae : ∀ᵐ (ω : Ω) ∂P, ∀ (s t : T'), edist (X s ω) (X t ω) = 0
@@ -119,7 +121,7 @@ theorem finite_kolmogorov_chentsov (h_diam : EMetric.diam (.univ : Set T) < ∞)
     rw [Filter.eventually_all]; intro s
     rw [Filter.eventually_all]; intro t
     rw_mod_cast [h_ae] at hX
-    exact hX.M_eq_zero hp_pos
+    exact hX.edist_eq_zero_of_M_eq_zero hp_pos
   have h_diam_zero : 0 < EMetric.diam (.univ : Set T) := by
     contrapose! h_ae
     rw [Filter.eventually_all]; intro s

--- a/BrownianMotion/Continuity/KolmogorovChentsov.lean
+++ b/BrownianMotion/Continuity/KolmogorovChentsov.lean
@@ -32,7 +32,7 @@ variable {T Ω E : Type*} [PseudoEMetricSpace T] {mΩ : MeasurableSpace Ω}
 
 lemma lintegral_div_edist_le_sum_integral_edist_le (hT : EMetric.diam (Set.univ : Set T) < ∞)
     (hX : IsKolmogorovProcess X P p q M)
-    (hβ : 0 < β) (hp : 0 < p) (hq : 0 < q) {J : Set T} (hJ : Countable J) :
+    (hβ : 0 < β) (hp : 0 < p) (hq : 0 < q) {J : Set T} [hJ : Countable J] :
     ∫⁻ ω, ⨆ (s : J) (t : J), edist (X s ω) (X t ω) ^ p / edist s t ^ (β * p) ∂P
       ≤ ∑' (k : ℕ), 2 ^ (k * β * p)
           * ∫⁻ ω, ⨆ (s : J)
@@ -101,7 +101,7 @@ theorem finite_kolmogorov_chentsov (h_diam : EMetric.diam (.univ : Set T) < ∞)
     (hT : HasBoundedInternalCoveringNumber (Set.univ : Set T) c d)
     (hX : IsKolmogorovProcess X P p q M)
     (hd_pos : 0 < d) (hp_pos : 0 < p) (hdq_lt : d < q)
-    (hβ_pos : 0 < β) (hβ_lt : β < (q - d) / p) (T' : Finset T) :
+    (hβ_pos : 0 < β) (hβ_lt : β < (q - d) / p) (T' : Set T) [hT' : Finite T'] :
     ∫⁻ ω, ⨆ (s : T') (t : T'), edist (X s ω) (X t ω) ^ p / edist s t ^ (β * p) ∂P
       ≤ M * constL T c d p q β := by
   have hq_pos : 0 < q := lt_trans hd_pos hdq_lt
@@ -130,8 +130,7 @@ theorem finite_kolmogorov_chentsov (h_diam : EMetric.diam (.univ : Set T) < ∞)
   have h_diam_real : 0 < (EMetric.diam (.univ : Set T)).toReal :=
     ENNReal.toReal_pos_iff.mpr ⟨h_diam_zero, h_diam⟩
   apply le_trans
-  · apply lintegral_div_edist_le_sum_integral_edist_le h_diam hX hβ_pos hp_pos hq_pos
-    exact T'.countable_toSet
+    (lintegral_div_edist_le_sum_integral_edist_le h_diam hX hβ_pos hp_pos hq_pos)
   apply ENNReal.tsum_le_tsum
   intro k
   wlog hc : c ≠ ∞
@@ -144,10 +143,10 @@ theorem finite_kolmogorov_chentsov (h_diam : EMetric.diam (.univ : Set T) < ∞)
     · simp [le_of_lt hdq_lt]
   apply le_trans
   · apply mul_le_mul_left'
-    refine finite_set_bound_of_edist_le (c := 2 ^ d * c) ?_ hX ?_ hd_pos hp_pos hdq_lt (by simp) ?_
+    refine finite_set_bound_of_edist_le (c := 2 ^ d * c) ?_ hT' hX ?_ hd_pos hp_pos hdq_lt ?_
     · exact hT.subset (Set.subset_univ _)
     · finiteness
-    · exact ne_top_of_le_ne_top (by finiteness) (EMetric.diam_mono (Set.subset_univ _))
+    · simp
   rw [ENNReal.mul_rpow_of_ne_top (by finiteness) (by finiteness), ← mul_assoc,
     ← mul_assoc _ (2 ^ ((k : ℝ) * _)), ← mul_assoc (M : ℝ≥0∞)]
   refine mul_le_mul' (le_of_eq ?_) ?_

--- a/BrownianMotion/Continuity/KolmogorovChentsov.lean
+++ b/BrownianMotion/Continuity/KolmogorovChentsov.lean
@@ -118,8 +118,8 @@ theorem finite_kolmogorov_chentsov (h_diam : EMetric.diam (.univ : Set T) < ∞)
     contrapose! h_ae
     rw [Filter.eventually_all]; intro s
     rw [Filter.eventually_all]; intro t
-    apply hX.M_eq_zero hp_pos
-    exact_mod_cast h_ae
+    rw_mod_cast [h_ae] at hX
+    exact hX.M_eq_zero hp_pos
   have h_diam_zero : 0 < EMetric.diam (.univ : Set T) := by
     contrapose! h_ae
     rw [Filter.eventually_all]; intro s

--- a/blueprint/src/chapters/kolmogorov_chentsov.tex
+++ b/blueprint/src/chapters/kolmogorov_chentsov.tex
@@ -1641,6 +1641,7 @@ Then
 \end{lemma}
 
 \begin{proof}
+  \leanok
   \uses{cor:finite_set_bound_of_dist_le, lem:integral_div_dist_le_sum_integral_dist_le, lem:L_lt_top, lem:hasBoundedInternalCoveringNumber_subset}
 
 Since $J \subseteq T$, $J$ has bounded internal covering number with constant $2^d c_1$ and exponent $d$ (Lemma~\ref{lem:hasBoundedInternalCoveringNumber_subset}).


### PR DESCRIPTION
Some notes:

- I slightly "improved" `constL` since it made the proof easier anyway but if you prefer the whole number I can change it back. 

- I added `IsKolmogorovProcess.M_eq_zero` whose proof is near identical to `IsKolmogorovProcess.edist_eq_zero`.  There could be a refactor so that both are deduced from an intermediate lemma but I am not sure such a lemma is worth stating (it would likely have an unnatural statement). Alternatively the proof of `IsKolmogorovProcess.M_eq_zero` could just be inlined into the main theorem if we don't think it will be reused. 

- Is there a reason to switch to `Finite T'` over `Finset T`? (To be honest I am not sure of the difference but `Finite T'` was more annoying to work with, though I can change it back if necessary). On this note it appears the (proved) prerequisite theorem `finite_set_bound_of_edist_le` is missing any assumption that the set is finite. Its possible you found a way to remove this assumption (haven't looked to closely at the proofs) but I suspect this might be a mistake that will come up in the the remaining prerequisite sorrys? If its not a mistake `finite_kolmogorov_chentsov` can be skipped (and this proof will work for the countable one).  