### PR TITLE
chore: bump `docgen-action` with partially fixing bug

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -36,7 +36,7 @@ jobs:
           use-github-cache: false
 
       - name: Compile blueprint and documentation
-        uses: leanprover-community/docgen-action@b210116d3e6096c0c7146f7a96a6d56b6884fef5 # 2025-06-12
+        uses: leanprover-community/docgen-action@f78d5a9a1a728288aef64bde6f133d30a8511cb7 # 2025-06-27
         with:
           blueprint: true
           homepage: home_page


### PR DESCRIPTION
This fixes a combination of two bugs:

* If we parse an empty dependency list from the manifest, the cache action has nothing to do and it errors instead of skipping the step.
* We didn't include Lake/Lean/Init/Std in the computed dependencies of the project, since they are not mentioned in the manifest. Their docs are still built, so we should include and cache them.

The full fix (which will allow to save every dependency to cache) is in progress. 