### PR TITLE
`isCoverWithBoundedCoveringNumber_Ico_nnreal`

### DIFF
--- a/BrownianMotion/Continuity/CoveringNumber.lean
+++ b/BrownianMotion/Continuity/CoveringNumber.lean
@@ -476,7 +476,7 @@ lemma Isometry.isCover_image_iff {F : Type*} [PseudoEMetricSpace E] [PseudoEMetr
     refine ⟨f c, Set.mem_image_of_mem _ hc_mem, ?_⟩
     rwa [hf.edist_eq]
 
-lemma Isometry.internalCoveringNumber_image
+lemma Isometry.internalCoveringNumber_image'
     {F : Type*} [PseudoEMetricSpace E] [PseudoEMetricSpace F]
     {f : E → F} (hf : Isometry f) {r : ℝ≥0∞} {A : Set E} (hf_inj : Set.InjOn f A) :
     internalCoveringNumber r (f '' A) = internalCoveringNumber r A := by
@@ -514,6 +514,12 @@ lemma Isometry.internalCoveringNumber_image
     simp only [Finset.coe_image, hf.isCover_image_iff] at hC_cover
     refine (iInf_le _ hC_cover).trans ?_
     rw [Finset.card_image_iff.mpr (hf_inj.mono hC'_subset)]
+
+lemma Isometry.internalCoveringNumber_image
+    {F : Type*} [EMetricSpace E] [PseudoEMetricSpace F]
+    {f : E → F} (hf : Isometry f) {r : ℝ≥0∞} {A : Set E} :
+    internalCoveringNumber r (f '' A) = internalCoveringNumber r A :=
+  hf.internalCoveringNumber_image' hf.injective.injOn
 
 theorem internalCoveringNumber_Icc_zero_one_le_one_div {ε : ℝ≥0∞} (hε : ε ≤ 1) :
     internalCoveringNumber ε (Set.Icc (0 : ℝ) 1) ≤ 1 / ε := by

--- a/BrownianMotion/Continuity/CoveringNumber.lean
+++ b/BrownianMotion/Continuity/CoveringNumber.lean
@@ -495,7 +495,21 @@ lemma Isometry.internalCoveringNumber_image
   · simp only [le_iInf_iff]
     intro C hC_subset hC_cover
     obtain ⟨C', hC'_subset, rfl⟩ : ∃ (C' : Finset E), ↑C' ⊆ A ∧ C = C'.image f := by
-      sorry
+      have (x : C) : ∃ y ∈ A, f y = x := by
+        have hx : (x : F) ∈ f '' A := hC_subset x.2
+        simpa only [Set.mem_image] using hx
+      choose g hg_mem hg using this
+      refine ⟨Finset.univ.image (fun x ↦ g x), ?_, ?_⟩
+      · simp only [Finset.univ_eq_attach, Finset.coe_image, Finset.coe_attach, Set.image_univ]
+        rwa [Set.range_subset_iff]
+      · ext x
+        simp only [Finset.univ_eq_attach, Finset.mem_image, Finset.mem_attach, true_and,
+          Subtype.exists]
+        refine ⟨fun h ↦ ?_, fun h ↦ ?_⟩
+        · exact ⟨g ⟨x, h⟩, ⟨x, h, rfl⟩, hg _⟩
+        · obtain ⟨x, hx, rfl⟩ := h
+          obtain ⟨y, hy, rfl⟩ := hx
+          rwa [hg]
     refine (iInf_le _ C').trans <| (iInf_le _ hC'_subset).trans ?_
     simp only [Finset.coe_image, hf.isCover_image_iff] at hC_cover
     refine (iInf_le _ hC_cover).trans ?_

--- a/BrownianMotion/Continuity/CoveringNumber.lean
+++ b/BrownianMotion/Continuity/CoveringNumber.lean
@@ -757,4 +757,24 @@ lemma internalCoveringNumber_closedBall_one_le (ε : ℝ≥0∞) (x : E) :
       ≤ (2 / ε + 1) ^ (Module.finrank ℝ E) :=
   (internalCoveringNumber_closedBall_le _ _ _).trans_eq (by simp)
 
+lemma internalCoveringNumber_closedBall_le_three_mul [Nontrivial E]
+    {ε : ℝ≥0∞} {x : E} {r : ℝ≥0∞} (hr_zero : r ≠ 0) (hr_top : r ≠ ∞) (hε : ε ≤ r) :
+    internalCoveringNumber ε (EMetric.closedBall x r)
+      ≤ (3 * r / ε) ^ (Module.finrank ℝ E) := by
+  by_cases hε_zero : ε = 0
+  · simp only [hε_zero, internalCoveringNumber_zero]
+    rw [ENNReal.div_zero, ENNReal.top_pow]
+    · exact le_top
+    · exact Module.finrank_ne_zero
+    · simp [hr_zero]
+  refine (internalCoveringNumber_closedBall_le _ _ _).trans ?_
+  let d := Module.finrank ℝ E
+  calc (2 * r / ε + 1) ^ d
+  _ ≤ (2 * r / ε + r / ε) ^ d := by
+    gcongr
+    rwa [ENNReal.le_div_iff_mul_le (.inl hε_zero) (.inr hr_top), one_mul]
+  _ = (3 * r / ε) ^ d := by
+    congr
+    rw [← two_add_one_eq_three, add_mul, one_mul, ENNReal.add_div]
+
 end Volume

--- a/BrownianMotion/Continuity/CoveringNumber.lean
+++ b/BrownianMotion/Continuity/CoveringNumber.lean
@@ -464,11 +464,42 @@ lemma internalCoveringNumber_le_encard [PseudoEMetricSpace E] (r : ℝ≥0∞) {
 
 end comparisons
 
-open scoped Pointwise in
-lemma internalCoveringNumber_smul [NormedAddCommGroup E] [Module ℝ E] {r : ℝ≥0∞} {A : Set E}
-    {c : ℝ≥0} (hc : c ≠ 0) :
-  internalCoveringNumber (c * r) (c • A) = internalCoveringNumber r A := by
-  sorry
+lemma Isometry.isCover_image_iff {F : Type*} [PseudoEMetricSpace E] [PseudoEMetricSpace F]
+    {f : E → F} (hf : Isometry f) {r : ℝ≥0∞} {A : Set E} (C : Set E) :
+    IsCover (f '' C) r (f '' A) ↔ IsCover C r A := by
+  refine ⟨fun h x hx ↦ ?_, fun h x hx ↦ ?_⟩
+  · obtain ⟨c, hc_mem, hc⟩ := h (f x) (Set.mem_image_of_mem _ hx)
+    obtain ⟨c', hc', rfl⟩ := hc_mem
+    refine ⟨c', hc', le_of_eq_of_le (hf.edist_eq _ _).symm hc⟩
+  · obtain ⟨y, hy_mem, rfl⟩ := hx
+    obtain ⟨c, hc_mem, hc⟩ := h y hy_mem
+    refine ⟨f c, Set.mem_image_of_mem _ hc_mem, ?_⟩
+    rwa [hf.edist_eq]
+
+lemma Isometry.internalCoveringNumber_image
+    {F : Type*} [PseudoEMetricSpace E] [PseudoEMetricSpace F]
+    {f : E → F} (hf : Isometry f) {r : ℝ≥0∞} {A : Set E} (hf_inj : Set.InjOn f A) :
+    internalCoveringNumber r (f '' A) = internalCoveringNumber r A := by
+  unfold internalCoveringNumber
+  classical
+  refine le_antisymm ?_ ?_
+  · simp only [le_iInf_iff]
+    intro C hC_subset hC_cover
+    refine (iInf_le _ (C.image f)).trans ?_
+    simp only [Finset.coe_image, Set.image_subset_iff]
+    have : ↑C ⊆ f ⁻¹' (f '' A) := hC_subset.trans (Set.subset_preimage_image f A)
+    refine (iInf_le _ this).trans ?_
+    rw [hf.isCover_image_iff]
+    refine (iInf_le _ hC_cover).trans ?_
+    exact mod_cast Finset.card_image_le
+  · simp only [le_iInf_iff]
+    intro C hC_subset hC_cover
+    obtain ⟨C', hC'_subset, rfl⟩ : ∃ (C' : Finset E), ↑C' ⊆ A ∧ C = C'.image f := by
+      sorry
+    refine (iInf_le _ C').trans <| (iInf_le _ hC'_subset).trans ?_
+    simp only [Finset.coe_image, hf.isCover_image_iff] at hC_cover
+    refine (iInf_le _ hC_cover).trans ?_
+    rw [Finset.card_image_iff.mpr (hf_inj.mono hC'_subset)]
 
 theorem internalCoveringNumber_Icc_zero_one_le_one_div {ε : ℝ≥0∞} (hε : ε ≤ 1) :
     internalCoveringNumber ε (Set.Icc (0 : ℝ) 1) ≤ 1 / ε := by
@@ -550,10 +581,6 @@ theorem internalCoveringNumber_Icc_zero_one_le_one_div {ε : ℝ≥0∞} (hε : 
     exact internalCoveringNumber_le_of_isCover C_sub this
   _ = k := by simp_all
   _ ≤ 1 / ε := k_le
-
-theorem internalCoveringNumber_Ico_zero_one_le_one_div {ε : ℝ≥0∞} (hε : ε ≤ 1) :
-    internalCoveringNumber ε (Set.Ico (0 : ℝ≥0) 1) ≤ 1 / ε := by
-  sorry
 
 section Volume
 

--- a/BrownianMotion/Continuity/HasBoundedInternalCoveringNumber.lean
+++ b/BrownianMotion/Continuity/HasBoundedInternalCoveringNumber.lean
@@ -95,21 +95,23 @@ lemma isCoverWithBoundedCoveringNumber_Ico_nnreal :
   totallyBounded n := totallyBounded_Ico _ _
   hasBoundedCoveringNumber n ε hε_le := by
     simp only [ENNReal.rpow_one]
-    -- todo : extract that have as a lemma
-    have h_diam : EMetric.diam (Set.Ico (0 : ℝ≥0) (n + 1)) = n + 1 := by
-      sorry
-    rw [h_diam] at hε_le
     have h_iso : Isometry ((↑) : ℝ≥0 → ℝ) := fun x y ↦ rfl
     have h_inj : Function.Injective ((↑) : ℝ≥0 → ℝ) := NNReal.coe_injective
     rw [← h_iso.internalCoveringNumber_image h_inj.injOn]
-    have : ((↑) : ℝ≥0 → ℝ) '' (Set.Ico (0 : ℝ≥0) (n + 1)) = Set.Ico (0 : ℝ) (n + 1) := by
+    have h_image : ((↑) : ℝ≥0 → ℝ) '' (Set.Ico (0 : ℝ≥0) (n + 1)) = Set.Ico (0 : ℝ) (n + 1) := by
       ext x
       simp only [Set.mem_image, Set.mem_Ico, zero_le, true_and]
       refine ⟨fun ⟨y, hy, hy_eq⟩ ↦ ?_, fun h ↦ ?_⟩
       · rw [← hy_eq]
         exact ⟨y.2, hy⟩
       · exact ⟨⟨x, h.1⟩, h.2, rfl⟩
-    rw [this]
+    rw [h_image]
+    -- todo : extract that have as a lemma
+    have h_diam : EMetric.diam (Set.Ico (0 : ℝ≥0) (n + 1)) = n + 1 := by
+      rw [← h_iso.ediam_image, h_image]
+      simp only [Real.ediam_Ico, sub_zero]
+      norm_cast
+    rw [h_diam] at hε_le
     have : Set.Ico (0 : ℝ) (n + 1) ⊆ EMetric.closedBall (((n : ℝ) + 1) / 2) ((n + 1) / 2) := by
       intro x hx
       simp only [Set.mem_Ico, EMetric.mem_closedBall, edist_dist, dist] at hx ⊢

--- a/BrownianMotion/Continuity/HasBoundedInternalCoveringNumber.lean
+++ b/BrownianMotion/Continuity/HasBoundedInternalCoveringNumber.lean
@@ -88,34 +88,58 @@ structure IsCoverWithBoundedCoveringNumber (C : ℕ → Set T) (A : Set T) (c : 
 open scoped Pointwise in
 lemma isCoverWithBoundedCoveringNumber_Ico_nnreal :
     IsCoverWithBoundedCoveringNumber (fun n ↦ Set.Ico (0 : ℝ≥0) (n + 1)) Set.univ
-      (fun n ↦ (n + 1)) (fun _ ↦ 1) where
-  c_ne_top := by simp
+      (fun n ↦ 4 * (n + 1)) (fun _ ↦ 1) where
+  c_ne_top n := by finiteness
   d_pos := by simp
   isOpen n := NNReal.isOpen_Ico_zero
   totallyBounded n := totallyBounded_Ico _ _
   hasBoundedCoveringNumber n ε hε_le := by
     simp only [ENNReal.rpow_one]
-    have : Set.Ico (0 : ℝ≥0) (n + 1) = (n + 1 : ℝ≥0) • Set.Ico (0 : ℝ≥0) 1 := by
-      have : (n + 1 : ℝ≥0) • Set.Ico (0 : ℝ≥0) 1
-          = (fun x ↦ (n + 1 : ℝ≥0) * x) '' Set.Ico (0 : ℝ≥0) 1 := by
-        ext; simp [Set.mem_smul_set]
-      rw [this, Set.image_mul_left_Ico]
-      simp only [mul_zero, mul_one]
-      simp
-    rw [this]
-    calc (internalCoveringNumber ε ((n + 1 : ℝ≥0) • Set.Ico (0 : ℝ≥0) 1) : ℝ≥0∞)
-    _ = internalCoveringNumber ((n + 1 : ℝ≥0) * (ε / (n + 1)))
-        ((n + 1 : ℝ≥0) • Set.Ico (0 : ℝ≥0) 1) := by
-      congr
-      norm_cast
-      rw [ENNReal.mul_div_cancel (by simp) (by simp)]
-    _ = internalCoveringNumber (ε / (n + 1)) (Set.Ico (0 : ℝ≥0) 1) := by
+    -- todo : extract that have as a lemma
+    have h_diam : EMetric.diam (Set.Ico (0 : ℝ≥0) (n + 1)) = n + 1 := by
       sorry
-      --refine internalCoveringNumber_smul ?_
-    _ ≤ (n + 1) * ε⁻¹ := by
-      refine (internalCoveringNumber_Ico_zero_one_le_one_div ?_).trans_eq ?_
-      · sorry
-      · rw [← ENNReal.div_mul _ (by simp) (by simp), mul_comm, one_div]
+    rw [h_diam] at hε_le
+    have h_iso : Isometry ((↑) : ℝ≥0 → ℝ) := fun x y ↦ rfl
+    have h_inj : Function.Injective ((↑) : ℝ≥0 → ℝ) := NNReal.coe_injective
+    rw [← h_iso.internalCoveringNumber_image h_inj.injOn]
+    have : ((↑) : ℝ≥0 → ℝ) '' (Set.Ico (0 : ℝ≥0) (n + 1)) = Set.Ico (0 : ℝ) (n + 1) := by
+      ext x
+      simp only [Set.mem_image, Set.mem_Ico, zero_le, true_and]
+      refine ⟨fun ⟨y, hy, hy_eq⟩ ↦ ?_, fun h ↦ ?_⟩
+      · rw [← hy_eq]
+        exact ⟨y.2, hy⟩
+      · exact ⟨⟨x, h.1⟩, h.2, rfl⟩
+    rw [this]
+    have : Set.Ico (0 : ℝ) (n + 1) ⊆ EMetric.closedBall (((n : ℝ) + 1) / 2) ((n + 1) / 2) := by
+      intro x hx
+      simp only [Set.mem_Ico, EMetric.mem_closedBall, edist_dist, dist] at hx ⊢
+      refine ENNReal.ofReal_le_of_le_toReal ?_
+      simp only [ENNReal.toReal_div, ENNReal.toReal_ofNat]
+      norm_cast
+      refine abs_le.mpr ⟨?_, ?_⟩
+      · linarith
+      · simp [hx.2.le]
+    calc (internalCoveringNumber ε (Set.Ico (0 : ℝ) (n + 1)) : ℝ≥0∞)
+    _ ≤ internalCoveringNumber (ε / 2) (EMetric.closedBall (((n : ℝ) + 1) / 2) ((n + 1) / 2)) := by
+      gcongr
+      refine internalCoveringNumber_subset_le ?_ this
+      exact ne_top_of_le_ne_top (by finiteness) hε_le
+    _ ≤ 2 * ((n + 1) / 2) / (ε / 2) + 1 :=
+      (internalCoveringNumber_closedBall_le _ _ _).trans_eq (by simp)
+    _ = 2 * (n + 1) / ε + 1 := by
+      rw [mul_div_assoc, mul_div_assoc]
+      congr 2
+      simp_rw [div_eq_mul_inv]
+      rw [ENNReal.mul_inv (by simp) (by simp), inv_inv, mul_assoc, mul_comm _ (2 : ℝ≥0∞),
+        ← mul_assoc _ (2 : ℝ≥0∞), ENNReal.inv_mul_cancel (by simp) (by simp), one_mul]
+    _ ≤ 2 * (n + 1) / ε + 2 * (n + 1) / ε := by
+      gcongr
+      rw [ENNReal.le_div_iff_mul_le (by simp) (.inr <| by finiteness), one_mul, two_mul]
+      exact hε_le.trans le_self_add
+    _ = 4 * (n + 1) * ε⁻¹ := by
+      rw [← two_mul, ← mul_div_assoc, ← mul_assoc]
+      congr
+      norm_num
   mono n m hnm x hx := by
     simp only [Set.mem_Ico, zero_le, true_and] at hx ⊢
     exact hx.trans_le (mod_cast (by gcongr))

--- a/BrownianMotion/Continuity/HasBoundedInternalCoveringNumber.lean
+++ b/BrownianMotion/Continuity/HasBoundedInternalCoveringNumber.lean
@@ -96,8 +96,7 @@ lemma isCoverWithBoundedCoveringNumber_Ico_nnreal :
   hasBoundedCoveringNumber n ε hε_le := by
     simp only [ENNReal.rpow_one]
     have h_iso : Isometry ((↑) : ℝ≥0 → ℝ) := fun x y ↦ rfl
-    have h_inj : Function.Injective ((↑) : ℝ≥0 → ℝ) := NNReal.coe_injective
-    rw [← h_iso.internalCoveringNumber_image h_inj.injOn]
+    rw [← h_iso.internalCoveringNumber_image]
     have h_image : ((↑) : ℝ≥0 → ℝ) '' (Set.Ico (0 : ℝ≥0) (n + 1)) = Set.Ico (0 : ℝ) (n + 1) := by
       ext x
       simp only [Set.mem_image, Set.mem_Ico, zero_le, true_and]

--- a/BrownianMotion/Continuity/HasBoundedInternalCoveringNumber.lean
+++ b/BrownianMotion/Continuity/HasBoundedInternalCoveringNumber.lean
@@ -88,7 +88,7 @@ structure IsCoverWithBoundedCoveringNumber (C : ℕ → Set T) (A : Set T) (c : 
 open scoped Pointwise in
 lemma isCoverWithBoundedCoveringNumber_Ico_nnreal :
     IsCoverWithBoundedCoveringNumber (fun n ↦ Set.Ico (0 : ℝ≥0) (n + 1)) Set.univ
-      (fun n ↦ 4 * (n + 1)) (fun _ ↦ 1) where
+      (fun n ↦ 3 * (n + 1)) (fun _ ↦ 1) where
   c_ne_top n := by finiteness
   d_pos := by simp
   isOpen n := NNReal.isOpen_Ico_zero
@@ -125,22 +125,19 @@ lemma isCoverWithBoundedCoveringNumber_Ico_nnreal :
       gcongr
       refine internalCoveringNumber_subset_le ?_ this
       exact ne_top_of_le_ne_top (by finiteness) hε_le
-    _ ≤ 2 * ((n + 1) / 2) / (ε / 2) + 1 :=
-      (internalCoveringNumber_closedBall_le _ _ _).trans_eq (by simp)
-    _ = 2 * (n + 1) / ε + 1 := by
-      rw [mul_div_assoc, mul_div_assoc]
-      congr 2
+    _ ≤ 3 * ((n + 1) / 2) / (ε / 2) := by
+      refine (internalCoveringNumber_closedBall_le_three_mul ?_ ?_ ?_).trans_eq (by simp)
+      · simp
+      · finiteness
+      · gcongr
+    _ = 3 * (n + 1) / ε := by
+      conv_lhs => rw [mul_div_assoc]
+      conv_rhs => rw [mul_div_assoc]
+      congr 1
       simp_rw [div_eq_mul_inv]
       rw [ENNReal.mul_inv (by simp) (by simp), inv_inv, mul_assoc, mul_comm _ (2 : ℝ≥0∞),
         ← mul_assoc _ (2 : ℝ≥0∞), ENNReal.inv_mul_cancel (by simp) (by simp), one_mul]
-    _ ≤ 2 * (n + 1) / ε + 2 * (n + 1) / ε := by
-      gcongr
-      rw [ENNReal.le_div_iff_mul_le (by simp) (.inr <| by finiteness), one_mul, two_mul]
-      exact hε_le.trans le_self_add
-    _ = 4 * (n + 1) * ε⁻¹ := by
-      rw [← two_mul, ← mul_div_assoc, ← mul_assoc]
-      congr
-      norm_num
+    _ = 3 * (n + 1) * ε⁻¹ := by rw [div_eq_mul_inv]
   mono n m hnm x hx := by
     simp only [Set.mem_Ico, zero_le, true_and] at hx ⊢
     exact hx.trans_le (mod_cast (by gcongr))

--- a/BrownianMotion/Gaussian/BrownianMotion.lean
+++ b/BrownianMotion/Gaussian/BrownianMotion.lean
@@ -84,7 +84,7 @@ lemma exists_brownian :
           ∃ U ∈ 𝓝 t, ∃ C, HolderOnWith C β (Y · ω) U :=
   exists_modification_holder_iSup isCoverWithBoundedCoveringNumber_Ico_nnreal
     (fun n ↦ (isMeasurableKolmogorovProcess_preBrownian (n + 2)).isKolmogorovProcess)
-    (fun n ↦ by simp) zero_lt_one (fun n ↦ by positivity) (fun n ↦ by simp; norm_cast; omega)
+    (fun n ↦ by finiteness) zero_lt_one (fun n ↦ by positivity) (fun n ↦ by simp; norm_cast; omega)
 
 noncomputable
 def brownian : ℝ≥0 → (ℝ≥0 → ℝ) → ℝ :=


### PR DESCRIPTION
I lost a factor 3 in the covering number of the intervals because I used the volume argument and the bound for the internal covering number of a subset.