### PR TITLE
Don't generate docs

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -40,3 +40,4 @@ jobs:
         with:
           blueprint: true
           homepage: home_page
+          api_docs: false


### PR DESCRIPTION
Since a recent update, generating the docs takes hours. I'm disabling the doc generation until that's fixed.