### PR TITLE
feat: weak Markov property of a pre-Brownian motion

### DIFF
--- a/BrownianMotion/Gaussian/BrownianMotion.lean
+++ b/BrownianMotion/Gaussian/BrownianMotion.lean
@@ -422,6 +422,9 @@ lemma IsPreBrownian.smul [IsPreBrownian X P] {c : ℝ≥0} (hc : c ≠ 0) :
     · simp [field]
     · exact mul_le_mul_left' hst c
 
+/-- **Weak Markov property**: If `X` is a pre-Brownian motion, then
+`X (t₀ + t) - X t₀` is a pre-Brownian motion which is independent from `(B t, t ≤ t₀)`.
+This is the proof that it is pre-Brownian, see `IsPreBrownian.indepFun_shift` for independence. -/
 lemma IsPreBrownian.shift [h : IsPreBrownian X P] (t₀ : ℝ≥0) :
     IsPreBrownian (fun t ω ↦ X (t₀ + t) ω - X t₀ ω) P := by
   refine IsGaussianProcess.isPreBrownian_of_covariance inferInstance (fun t ↦ ?_) (fun s t hst ↦ ?_)
@@ -434,6 +437,10 @@ lemma IsPreBrownian.shift [h : IsPreBrownian X P] (t₀ : ℝ≥0) :
     any_goals simp
     all_goals exact HasGaussianLaw.memLp_two
 
+/-- **Weak Markov property**: If `X` is a pre-Brownian motion, then
+`X (t₀ + t) - X t₀` is a pre-Brownian motion which is independent from `(B t, t ≤ t₀)`.
+This is the proof that of independence, see `IsPreBrownian.shift` for the proof
+that it is pre-Brownian. -/
 lemma IsPreBrownian.indepFun_shift [h : IsPreBrownian X P] (hX : ∀ t, Measurable (X t)) (t₀ : ℝ≥0) :
     IndepFun (fun ω t ↦ X (t₀ + t) ω - X t₀ ω) (fun ω (t : Set.Iic t₀) ↦ X t ω) P := by
   apply IsGaussianProcess.indepFun''

--- a/BrownianMotion/Gaussian/GaussianProcess.lean
+++ b/BrownianMotion/Gaussian/GaussianProcess.lean
@@ -4,7 +4,7 @@ Released under Apache 2.0 license as described in the file LICENSE.
 Authors: Rémy Degenne
 -/
 import BrownianMotion.Auxiliary.HasGaussianLaw
-import BrownianMotion.Gaussian.StochasticProcesses
+import Mathlib.Probability.Independence.Process
 import Mathlib.Probability.Process.FiniteDimensionalLaws
 
 /-!


### PR DESCRIPTION
- Prove `IsGaussianProcess.of_isGaussianProcess`: if a stochastic process `Y` is such that for any `s`, `Y s` can be written as a linear combination of finitely many values of a Gaussian process, then `Y` is a Gaussian process.
- Prove the weak Markov property: if `X` is a pre-Brownian motion, then `X (t₀ + t) - X t₀` is a pre-Brownian motion which is independent from `(B t, t ≤ t₀)`.