### PR TITLE
Add two "basic" graph nodes

### DIFF
--- a/blueprint/src/chapters/debut.tex
+++ b/blueprint/src/chapters/debut.tex
@@ -9,6 +9,7 @@ If $X : T \to \Omega \to E$ is a progressively measurable process with respect t
 \end{theorem}
 
 \begin{proof}
+  \uses{lem:rightContinuous_basic}
 
 \end{proof}
 

--- a/blueprint/src/chapters/filtration_martingale.tex
+++ b/blueprint/src/chapters/filtration_martingale.tex
@@ -315,6 +315,7 @@ $$
 Note that $\bigsqcap$ denotes the infimum in the lattice of sigma-algebras on $\Omega$.
 \end{definition}
 
+
 \begin{lemma}\label{lem:filtrationRightCont}
   \uses{def:filtration, def:rightLimitFiltration}
   \leanok
@@ -340,6 +341,7 @@ We endow $T$ with the order topology. Let us first prove that the right continua
 Turn now to the proof that for all $t \in T$, $\mathcal{F}_{t+} \subseteq \mathcal{A}$. Let $t \in T$. If $t$ is isolated on the right, then $\mathcal{F}_{t+} = \mathcal{F}_t \subseteq \mathcal{A}$ by definition of a filtration. Otherwise there exists $u > t$, and $\mathcal{F}_{t+} \subseteq \mathcal{F}_u \subseteq \mathcal{A}$, so we are done.
 \end{proof}
 
+
 \begin{lemma}\label{lem:rightContDef}
   \uses{def:rightLimitFiltration}
   \leanok
@@ -358,6 +360,7 @@ $$
 This follows from Definition~\ref{def:rightLimitFiltration} because the topology on $T$ agrees with the one used to define the right continuation.
 \end{proof}
 
+
 \begin{lemma}\label{lem:rightContIsolated}
   \uses{def:rightLimitFiltration}
   \leanok
@@ -369,6 +372,7 @@ Suppose $T$ is a topological space with the topology being the order topology. A
   \uses{lem:rightContDef}
 This is a direct consequence of Lemma~\ref{lem:rightContDef}.
 \end{proof}
+
 
 \begin{lemma}\label{lem:rightContSuccOrder}
   \uses{def:rightLimitFiltration}
@@ -382,6 +386,7 @@ Assume that $T$ is a linear order with successor. This means that for any $t$, t
 Endow $T$ with the order topology. In a linear order with successor equipped with the order topology, every point is isolated on the right, so we can conclude by Lemma~\ref{lem:rightContIsolated}.
 \end{proof}
 
+
 \begin{lemma}\label{lem:rightContIsMax}
   \uses{def:rightLimitFiltration}
   \leanok
@@ -393,6 +398,7 @@ If $t \in T$ is maximal, $\mathcal{F}_{t+} = \mathcal{F}_t$.
   \uses{lem:rightContIsolated}
 Endow $T$ with the order topology. As $t$ is maximal, it is isolated on the right for this topology, so we can conclude by Lemma~\ref{lem:rightContIsolated}.
 \end{proof}
+
 
 \begin{lemma}\label{lem:rightContExistsGt}
   \uses{def:rightLimitFiltration}
@@ -406,6 +412,7 @@ If $T$ is a linear order and there exists $u > t$ such that $(t, u) = \emptyset$
 Endow $T$ with the order topology. The hypothesis implies that $t$ is isolated on the right in this topology, so we can conclude by Lemma~\ref{lem:rightContIsolated}.
 \end{proof}
 
+
 \begin{lemma}\label{lem:rightContNeBot}
   \uses{def:rightLimitFiltration}
   \leanok
@@ -417,6 +424,7 @@ Suppose $T$ is a topological space with the topology being the order topology. A
   \uses{lem:rightContDef}
 This is a direct consequence of Lemma~\ref{lem:rightContDef}.
 \end{proof}
+
 
 \begin{lemma}\label{lem:rightContNotIsMax}
   \uses{def:rightLimitFiltration}
@@ -430,6 +438,7 @@ Assume that $T$ is a densely ordered linear order, meaning that for all $s < t$,
 Endow $T$ with the order topology. In a densely ordered linear order, a point which is not maximal is not isolated on the right, so we can conclude by Lemma~\ref{lem:rightContNeBot}.
 \end{proof}
 
+
 \begin{lemma}\label{lem:rightContEq}
   \uses{def:rightLimitFiltration}
   \leanok
@@ -442,6 +451,7 @@ If $T$ is a densely ordered linear order with no maximal element, then forall $t
 For all $t$, $t$ is not maximal, so we can conclude by Lemma~\ref{lem:rightContNotIsMax}.
 \end{proof}
 
+
 \begin{lemma}\label{lem:leRightCont}
   \uses{def:rightLimitFiltration}
   \leanok
@@ -453,6 +463,7 @@ The filtration $\mathcal{F}$ is contained in its right continuation.
   \uses{lem:rightContDef}
 Endow $T$ with the order topology, and consider $t \in T$. Using Lemma~\ref{lem:rightContDef}, we split into two cases. If $t$ is isolated on the right, then $\mathcal{F}_{t+} = \mathcal{F}_t \supseteq \mathcal{F}_t$ and we are done. Otherwise, for all $u > t$, $\mathcal{F}_t \subseteq \mathcal{F}_u$, therefore $\mathcal{F}_t \subseteq \bigsqcap_{u > t} \mathcal{F}_u$, and we are done.
 \end{proof}
+
 
 \begin{lemma}\label{lem:rightContSelf}
   \uses{def:rightLimitFiltration}
@@ -470,12 +481,25 @@ $$\mathcal{F}_{t++} = \bigsqcap_{s > t} \mathcal{F}_{s+} \subseteq \mathcal{F}_{
 thus $\mathcal{F}_{t++} \subseteq \bigsqcap_{s > t} \mathcal{F}_s = \mathcal{F}_{t+}$, which concludes the proof.
 \end{proof}
 
+
+\begin{lemma}[Basic properties of the right continuation]\label{lem:rightLimitFiltration_basic}
+  \uses{lem:filtrationRightCont, lem:rightContDef, lem:rightContIsolated, lem:rightContSuccOrder, lem:rightContIsMax, lem:rightContExistsGt,lem:rightContNeBot, lem:rightContNotIsMax, lem:rightContEq, lem:leRightCont, lem:rightContSelf}
+  \leanok
+Fake lemma for the dependency graph. Import this to depend on Definition~\ref{def:rightLimitFiltration}.
+\end{lemma}
+
+\begin{proof}\leanok
+
+\end{proof}
+
+
 \begin{definition}[Right-continuous filtration]\label{def:rightContinuous}
-  \uses{def:rightLimitFiltration}
+  \uses{def:rightLimitFiltration, lem:rightLimitFiltration_basic}
   \leanok
   \lean{MeasureTheory.Filtration.IsRightContinuous}
 We say that the filtration is \emph{right-continuous} if for all $t \in T$, $\mathcal{F}_{t+} \subseteq \mathcal{F}_t$.
 \end{definition}
+
 
 \begin{lemma}\label{lem:eqRightCont}
   \uses{def:rightLimitFiltration, def:rightContinuous}
@@ -489,6 +513,7 @@ If $\mathcal{F}$ is right-continuous, then for all $t \in T$, $\mathcal{F}_t = \
 This is a direct consequence of Definition~\ref{def:rightContinuous} and Lemma~\ref{lem:leRightCont}.
 \end{proof}
 
+
 \begin{lemma}\label{lem:rightContinuousRightCont}
   \uses{def:rightLimitFiltration, def:rightContinuous}
   \leanok
@@ -500,6 +525,7 @@ The right continuation of $\mathcal{F}$ is right-continuous.
   \uses{lem:rightContSelf}
 This follows immediately from Lemma~\ref{lem:rightContSelf}.
 \end{proof}
+
 
 \begin{lemma}\label{lem:rightContinuousMeasurableSet}
   \uses{def:rightLimitFiltration, def:rightContinuous}
@@ -513,8 +539,20 @@ If $\mathcal{F}$ is right-continuous, then for all $t \in T$, any set $A \subset
 This is a direct consequence of Definition~\ref{def:rightContinuous}.
 \end{proof}
 
+
+\begin{lemma}[Basic properties of right continuous filtrations]\label{lem:rightContinuous_basic}
+  \uses{lem:eqRightCont, lem:rightContinuousRightCont, lem:rightContinuousMeasurableSet}
+  \leanok
+Fake lemma for the dependency graph. Import this to depend on Definition~\ref{def:rightContinuous}.
+\end{lemma}
+
+\begin{proof}\leanok
+
+\end{proof}
+
+
 \begin{definition}[Usual conditions]\label{def:hasUsualConditions}
-  \uses{def:rightContinuous}
+  \uses{def:rightContinuous, lem:rightContinuous_basic}
   \leanok
   \lean{MeasureTheory.Filtration.HasUsualConditions}
 We say that a filtered probability space $(\Omega, \mathcal{F}, P)$ satisfies the usual conditions if the filtration is right-continuous and if $\mathcal{F}_0$ contains all the $P$-null sets.

--- a/blueprint/src/chapters/local_martingales.tex
+++ b/blueprint/src/chapters/local_martingales.tex
@@ -122,7 +122,7 @@ Similarly, by the stability of $Q$, $X^{\sigma_n \wedge \tau_n} \mathbb{I}_{\sig
 \end{proof}
 
 \begin{lemma}\label{lem:isLocalizingSequence_of_isPreLocalizingSequence}
-  \uses{def:localizingSequence, def:rightContinuous}
+  \uses{def:localizingSequence, lem:rightContinuous_basic}
   \leanok
   \lean{ProbabilityTheory.isLocalizingSequence_of_isPreLocalizingSequence}
 If $(\tau_n)_{n \in \mathbb{N}}$ is a pre-localizing sequence, then the sequence defined by $\tau'_n = \inf_{m \ge n} \tau_m$ is a localizing sequence.
@@ -134,7 +134,7 @@ If $(\tau_n)_{n \in \mathbb{N}}$ is a pre-localizing sequence, then the sequence
 
 
 \begin{lemma}\label{lem:locally_of_isPreLocalizingSequence}
-  \uses{def:locally, def:localizingSequence, def:stable, def:rightContinuous, def:preLocalizingSequence}
+  \uses{def:locally, def:localizingSequence, def:stable, lem:rightContinuous_basic, def:preLocalizingSequence}
   \leanok
   \lean{ProbabilityTheory.locally_of_isPreLocalizingSequence}
 Let $P$ be a stable class of processes and let $(\tau_n)_{n \in \mathbb{N}}$ be a pre-localizing sequence such that for all $n \in \mathbb{N}$, $X^{\tau_n}\mathbb{I}_{\tau_n > 0}$ is in $P$.


### PR DESCRIPTION
Some lemmas are about immediate consequences of definitions, and we don't want to have to track their uses in every downstream theorem when connecting the dependency graph. Currently they form a cloud of nodes in the graph that is seemingly not used by anything else (although they are).

The tentative solution is, for a definition `def:definition` with many small such lemmas that are immediate consequences of the def, to create a fake lemma called `lem:definition_basic` which imports all of them. Then whenever we want to use the definition in the blueprint we instead import that lemma.
The main benefit is a more legible, less cluttered dependency graph.