### PR TITLE
feat(StochasticIntegral/UniformIntegrable): prove `norm` and `uniformIntegrable_iff_norm`

### DIFF
--- a/BrownianMotion/StochasticIntegral/UniformIntegrable.lean
+++ b/BrownianMotion/StochasticIntegral/UniformIntegrable.lean
@@ -38,10 +38,15 @@ lemma uniformIntegrable_of_dominated [NormedAddCommGroup E] [NormedAddCommGroup 
 
 lemma UniformIntegrable.norm [NormedAddCommGroup E] {X : ι → Ω → E} {p : ℝ≥0∞}
     (hp : 1 ≤ p) (hY : UniformIntegrable X p μ) :
-    UniformIntegrable (fun t ω ↦ ‖X t ω‖) p μ := sorry
+    UniformIntegrable (fun t ω ↦ ‖X t ω‖) p μ := by
+  refine uniformIntegrable_of_dominated hp hY ?_ (fun i ↦ ⟨i, by simp⟩)
+  exact fun i ↦ (UniformIntegrable.aestronglyMeasurable hY i).norm
 
-lemma uniformIntegrable_iff_norm [NormedAddCommGroup E] {X : ι → Ω → E} {p : ℝ≥0∞} (hp : 1 ≤ p) :
-    UniformIntegrable X p μ ↔ UniformIntegrable (fun t ω ↦ ‖X t ω‖) p μ := sorry
+lemma uniformIntegrable_iff_norm [NormedAddCommGroup E] {X : ι → Ω → E} {p : ℝ≥0∞} (hp : 1 ≤ p)
+    (mX : ∀ i, AEStronglyMeasurable (X i) μ) :
+    UniformIntegrable X p μ ↔ UniformIntegrable (fun t ω ↦ ‖X t ω‖) p μ := by
+  refine ⟨UniformIntegrable.norm hp, fun hNorm ↦ uniformIntegrable_of_dominated hp hNorm mX ?_⟩
+  exact fun i ↦ ⟨i, by simp⟩
 
 lemma uniformIntegrable_of_dominated_singleton [NormedAddCommGroup E] {X : ι → Ω → E} {Y : Ω → ℝ}
     {p : ℝ≥0∞} (hp : 1 ≤ p) (hY : MemLp Y p μ) (mX : ∀ i, AEStronglyMeasurable (X i) μ)

--- a/blueprint/src/chapters/filtration_martingale.tex
+++ b/blueprint/src/chapters/filtration_martingale.tex
@@ -817,6 +817,7 @@ If $(X_t)_{t \in T}$ is a family of uniformly integrable random variables, then 
 \end{lemma}
 
 \begin{proof}
+  \leanok
   \uses{lem:uniformIntegrableDominated}
 Apply Lemma~\ref{lem:uniformIntegrableDominated} with $Y := X$.
 \end{proof}
@@ -828,6 +829,7 @@ Let $(X_t)_{t \in T}$ be a family of uniformly integrable random variables. It i
 \end{lemma}
 
 \begin{proof}
+  \leanok
   \uses{lem:uniformIntegrableNorm, lem:uniformIntegrableDominated}
 The forward direction is Lemma~\ref{lem:uniformIntegrableNorm}. The converse direction follows from Lemma~\ref{lem:uniformIntegrableDominated} with $Y := (\|X_t\|)_{t \in T}$.
 \end{proof}


### PR DESCRIPTION
Added the missing hypothesis `mX` in the context of `uniformIntegrable_iff_norm`. 

Closes #269