### PR TITLE
chore(blueprint): fix errors

### DIFF
--- a/blueprint/lean_decls
+++ b/blueprint/lean_decls
@@ -164,6 +164,8 @@ ProbabilityTheory.wienerMeasure
 MeasureTheory.Filtration
 MeasureTheory.Adapted
 MeasureTheory.ProgMeasurable
+Function.RightContinuous
+IsCadlag
 MeasureTheory.Adapted.progMeasurable_of_rightContinuous
 MeasureTheory.Martingale
 MeasureTheory.Submartingale

--- a/blueprint/src/chapters/elementary.tex
+++ b/blueprint/src/chapters/elementary.tex
@@ -217,6 +217,7 @@ Then for every simple process $V$ with values in $E$, simple process $W$ with va
 
 \begin{proof}
   \uses{lem:elemStochIntegral_linear}
+  \leanok
 Unfold definitions, use linearity.
 \end{proof}
 

--- a/blueprint/src/chapters/filtration_martingale.tex
+++ b/blueprint/src/chapters/filtration_martingale.tex
@@ -245,7 +245,7 @@ A stopping time with respect to some filtration $\mathcal{F}$ indexed by $T$ is 
   \mathlibok
   \lean{MeasureTheory.IsStoppingTime.measurableSpace}
   Given a stopping time $\tau$ on a time index $T$, define
-  $\mathcal{F}_\tau = \bigcup_{t \in T} \{A \in \mathcal{F} \mid A \cap \{\tau \le t\} \in \mathcal{F}_t\}.$
+  $\mathcal{F}_\tau = \bigcap_{t \in T} \{A \in \mathcal{F} \mid A \cap \{\tau \le t\} \in \mathcal{F}_t\}.$
 \end{definition}
 
 

--- a/blueprint/src/web.tex
+++ b/blueprint/src/web.tex
@@ -12,6 +12,10 @@
 
 \newcommand{\putbib}{} % we are using bibunits in print.tex, but not here
 
+% \bigsqcap is not correctly rendered (https://github.com/mathjax/MathJax/issues/1588)
+% so we define a fallback.
+\renewcommand{\bigsqcap}{\mathop{\Large\sqcap}}
+
 \input{macros/common}
 \input{macros/web}
 
@@ -29,6 +33,14 @@
 \input{content}
 
 \bibliographystyle{amsalpha}
-\bibliography{bib}
+% HACK: bibunits in print.tex generates bu1.bbl and bu2.bbl, but
+% `leanblueprint pdf` expects a single print.bbl to be copied to web.bbl,
+% which is input by \bibliography.
+% We manually input the bbl files instead of using \bibliography.
+\part*{Bibliography}
+\subsection*{Part 1 Bibliography}
+\input{../print/bu1.bbl}
+\subsection*{Part 2 Bibliography}
+\input{../print/bu2.bbl}
 
 \end{document}


### PR DESCRIPTION
This PR:
* Fixes the red display error for `\bigsqcap` for the HTML blueprint by defining a fallback as `\Large\sqcap` (note this looks a little odd)
* Bibliography and citations now work in HTML blueprint, using a hack around plasTeX `\bibliography`.
  (I think but am not completely sure this interacts well with GitHub CI, the below screenshots are after `leanblueprint pdf; leanblueprint web` on my laptop)
* Fixes some other small typos in the blueprint

Fixed bibliography:
<img width="1050" height="826" alt="image" src="https://github.com/user-attachments/assets/d4b1343a-6766-4126-bdb2-9aac70222354" />
<img width="640" height="137" alt="image" src="https://github.com/user-attachments/assets/8e402530-da72-429b-ad71-08779f9386d5" />


Fixed \bigsqcap:
<img width="821" height="279" alt="image" src="https://github.com/user-attachments/assets/1b0c52b6-9ac1-4e26-a6e1-61b49c9e2734" />
