### PR TITLE
ENNReal Komlos lemma proof draft

### DIFF
--- a/BrownianMotion/StochasticIntegral/Komlos.lean
+++ b/BrownianMotion/StochasticIntegral/Komlos.lean
@@ -6,6 +6,7 @@ Authors: Rémy Degenne
 import Mathlib.Analysis.InnerProductSpace.Basic
 import Mathlib.Analysis.SpecialFunctions.Log.ENNRealLogExp
 import Mathlib.MeasureTheory.Integral.Bochner.Set
+import Mathlib.MeasureTheory.Measure.WithDensityFinite
 
 /-!
 # Komlos lemmas
@@ -659,7 +660,7 @@ lemma komlos_ennreal' (X : ℕ → Ω → ℝ≥0∞) (hX : ∀ n, Measurable (X
   rwa [← add_assoc]
 
 lemma komlos_ennreal (X : ℕ → Ω → ℝ≥0∞) (hX : ∀ n, Measurable (X n))
-    {P : Measure Ω} [IsFiniteMeasure P] :
+    {P : Measure Ω} [SFinite P] :
     ∃ (Y : ℕ → Ω → ℝ≥0∞) (Y_lim : Ω → ℝ≥0∞),
       (∀ n, Y n ∈ convexHull ℝ≥0∞ (Set.range fun m ↦ X (n + m))) ∧ Measurable Y_lim ∧
       ∀ᵐ ω ∂P, Tendsto (Y · ω) atTop (𝓝 (Y_lim ω)) := by
@@ -671,13 +672,8 @@ lemma komlos_ennreal (X : ℕ → Ω → ℝ≥0∞) (hX : ∀ n, Measurable (X 
     refine hs ?_
     simp only [mem_range]
     exact ⟨0, rfl⟩
-  have : IsProbabilityMeasure ((P univ)⁻¹ • P) := by
-    constructor
-    simp only [Measure.smul_apply, smul_eq_mul]
-    rw [ENNReal.inv_mul_cancel]
-    · simp [hP]
-    · simp
+  have : NeZero P := ⟨hP⟩
   obtain ⟨Y, Ylim, hY_convex, hYlim_meas, hYlim_tendsto⟩ :=
-    komlos_ennreal' X hX (P := (P univ)⁻¹ • P)
+    komlos_ennreal' X hX (P := P.toFinite)
   refine ⟨Y, Ylim, hY_convex, hYlim_meas, ?_⟩
-  rwa [Measure.ae_ennreal_smul_measure_iff (by simp)] at hYlim_tendsto
+  exact absolutelyContinuous_toFinite P hYlim_tendsto


### PR DESCRIPTION
Hi all,

First of all, I apologize for not making an update sooner. My trusted, old laptop gave up on me, and since a lot of my previous work was only in local commits, a lot of code was missing when I finally got a new machine.

This PR is a draft: it contains a working proof of `komlos_ennreal`, but the current state is not up to standard. The file is too long, and the structure deviates quite a bit from the blueprint proof.

Here is a broad overview of the proof strategy implemented:

1.  **Transformation**: We map `ENNReal` values to `[0, 1]` using `expInv` (essentially $x \mapsto e^{-x}$, with $\infty \mapsto 0$). This allows us to work with bounded random variables.
2.  **Strict Convexity & Defect**: We exploit the strict convexity of the exponential inverse. We define a `defect` function that quantifies how much the midpoint inequality is strict. The lemma, `quantitative_convexity`, relates the distance between points to this defect.
3.  **Abstract Komlós**: We apply the `komlos_convex` lemma to the functional $\phi(X) = \mathbb{E}[	ext{expInv}(X)]$. This gives us a sequence of convex combinations $g_n$ where the functional values behave well.
4.  **$L^1$ Convergence**: Using the defect estimates (`prob_large_diff_le_defect`), we show that the transformed sequence $	ext{expInv}(g_n)$ is Cauchy in $L^1$. This is the analytic core, translating the functional convergence from the abstract lemma into convergence in probability/mean.
5.  **Back to `ENNReal`**: From $L^1$ convergence, we extract an almost surely convergent subsequence. We then use `logNeg` (inverse of `expInv`) to transfer this convergence back to the original `ENNReal` random variables.

I would appreciate any feedback on how to better structure this. Is the proof salvageable? If not, I am readily willing to pass the torch to someone more suitable. I have already spent way more time on the proof than I care to think about.

Closes #249