### PR TITLE
chore: simplify the proof of isBounded_image_of_isCadlag_of_isCompact

### DIFF
--- a/BrownianMotion/StochasticIntegral/Cadlag.lean
+++ b/BrownianMotion/StochasticIntegral/Cadlag.lean
@@ -53,7 +53,7 @@ lemma isLocallyBounded_of_isCadlag {E : Type*} [LinearOrder ι] [PseudoMetricSpa
   obtain ⟨V, ⟨⟨B, ⟨hq, ⟨R, hR⟩⟩⟩, hV⟩⟩ := Metric.exists_isBounded_image_of_tendsto (hf.1 x).tendsto
   refine ⟨A ∩ B, inter_mem hp hq, ?_⟩
   apply IsBounded.subset ((hU.union hV).union (isBounded_singleton : Bornology.IsBounded ({f x})))
-  rintro x ⟨y, ⟨hyL, hyR⟩ , rfl⟩
+  rintro _ ⟨y, ⟨hyL, hyR⟩ , rfl⟩
   rcases lt_trichotomy y x with (hlt | heq | hgt)
   · have : y ∈ U := hW.2 ▸ ⟨hyL, hW.1 hlt⟩
     grind


### PR DESCRIPTION
This PR simplifies the proof of `isBounded_image_of_isCadlag_of_isCompact` by proving the following two lemmas:
 - a locally bounded function maps a compact set to a bounded set ([#35013](https://github.com/leanprover-community/mathlib4/pull/35013))
 - a càdlàg function is locally bounded