### PR TITLE
feat(OptionalSampling): prove `condExp_ae_le_stoppedValue_min_nat`

### DIFF
--- a/BrownianMotion/StochasticIntegral/OptionalSampling.lean
+++ b/BrownianMotion/StochasticIntegral/OptionalSampling.lean
@@ -188,7 +188,13 @@ theorem Supermartingale.condExp_ae_le_stoppedValue_min_nat [PartialOrder E] [Ord
     (hX : Supermartingale X 𝓕 P) {k : ℕ} (hτk : ∀ᵐ ω ∂P, τ ω ≤ k)
     (hσ : IsStoppingTime 𝓕 σ) (hτ : IsStoppingTime 𝓕 τ) :
     P[stoppedValue X τ|hσ.measurableSpace] ≤ᵐ[P] stoppedValue X (τ ⊓ σ) := by
-  sorry
+  have hXneg : Submartingale (-X) 𝓕 P := hX.neg
+  have h1 := hXneg.stoppedValue_min_ae_le_condExp_nat 𝓕 hτk hσ hτ
+  have hsvn : ∀ τ', stoppedValue (-X) τ' = -stoppedValue X τ' := fun τ' => by
+    ext ω; simp [stoppedValue]
+  rw [hsvn, hsvn] at h1
+  exact (h1.trans (condExp_neg (stoppedValue X τ) hσ.measurableSpace).le).mono
+    fun ω hω => neg_le_neg_iff.mp hω
 
 end Nat
 


### PR DESCRIPTION
This PR adds proofs autoformalised by @Aristotle-Harmonic.

Co-authored-by: Aristotle (Harmonic) <aristotle-harmonic@harmonic.fun>