### PR TITLE
feat: generalize StieltjesFunction.measurable_measure

### DIFF
--- a/BrownianMotion.lean
+++ b/BrownianMotion.lean
@@ -1,4 +1,4 @@
-module
+module  -- shake: keep-all
 
 public import BrownianMotion.Auxiliary.Adapted
 public import BrownianMotion.Auxiliary.Algebra
@@ -56,6 +56,7 @@ public import BrownianMotion.StochasticIntegral.LocalMonad
 public import BrownianMotion.StochasticIntegral.LocalizingSequence
 public import BrownianMotion.StochasticIntegral.Locally
 public import BrownianMotion.StochasticIntegral.MathlibImports
+public import BrownianMotion.StochasticIntegral.MonotoneProcess
 public import BrownianMotion.StochasticIntegral.OptionalSampling
 public import BrownianMotion.StochasticIntegral.Predictable
 public import BrownianMotion.StochasticIntegral.QuadraticVariation

--- a/BrownianMotion.lean
+++ b/BrownianMotion.lean
@@ -56,7 +56,6 @@ public import BrownianMotion.StochasticIntegral.LocalMonad
 public import BrownianMotion.StochasticIntegral.LocalizingSequence
 public import BrownianMotion.StochasticIntegral.Locally
 public import BrownianMotion.StochasticIntegral.MathlibImports
-public import BrownianMotion.StochasticIntegral.MonotoneProcess
 public import BrownianMotion.StochasticIntegral.OptionalSampling
 public import BrownianMotion.StochasticIntegral.Predictable
 public import BrownianMotion.StochasticIntegral.QuadraticVariation

--- a/BrownianMotion.lean
+++ b/BrownianMotion.lean
@@ -56,6 +56,7 @@ public import BrownianMotion.StochasticIntegral.LocalMonad
 public import BrownianMotion.StochasticIntegral.LocalizingSequence
 public import BrownianMotion.StochasticIntegral.Locally
 public import BrownianMotion.StochasticIntegral.MathlibImports
+public import BrownianMotion.StochasticIntegral.MonotoneProcess
 public import BrownianMotion.StochasticIntegral.OptionalSampling
 public import BrownianMotion.StochasticIntegral.Predictable
 public import BrownianMotion.StochasticIntegral.QuadraticVariation

--- a/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
+++ b/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
@@ -9,6 +9,7 @@ public import BrownianMotion.Auxiliary.Filtration
 public import BrownianMotion.StochasticIntegral.Cadlag
 public import Mathlib.MeasureTheory.Measure.GiryMonad
 public import Mathlib.MeasureTheory.Measure.Stieltjes
+public import Mathlib.MeasureTheory.Constructions.Polish.StronglyMeasurable
 public import Mathlib.MeasureTheory.VectorMeasure.BoundedVariation
 public import Mathlib.MeasureTheory.VectorMeasure.Variation.Defs
 public import Mathlib.Probability.Kernel.Defs
@@ -232,79 +233,95 @@ end MeasureTheory.VectorMeasure
 
 variable [NormedAddCommGroup E] [CompleteSpace E] [BorelSpace E]
 
-lemma BoundedVariationOn.measurable_vectorMeasure [SecondCountableTopology E]
-    (hY : ∀ i, Measurable (Y i)) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
+lemma BoundedVariationOn.measurable_vectorMeasure_of_stronglyMeasurable
+    (hY : ∀ i, StronglyMeasurable (Y i)) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
     Measurable fun ω => (hvar ω).vectorMeasure := by
   refine VectorMeasure.measurable_of_measurable_coe fun s hs => ?_
-  induction s, hs using MeasurableSpace.induction_on_inter
-      (‹BorelSpace ι›.measurable_eq.trans (borel_eq_generateFrom_Ioc ι))
-      (isPiSystem_Ioc id id) with
-  | empty => simp
-  | basic s hs =>
-      obtain ⟨a, b, hlt, rfl⟩ := hs
-      have hright (x : ι) : Measurable fun ω => (Y · ω).rightLim x := by
-        by_cases hx : IsTop x
-        · simpa [rightLim_eq_of_isTop hx] using hY x
-        · obtain ⟨y, hxy⟩ : ∃ y, x < y := by simpa [IsTop, not_forall, not_le] using hx
-          obtain ⟨u, hu_anti, hu_mem, hu_lim⟩ :
-              ∃ u : ℕ → ι, StrictAnti u ∧ (∀ n, u n ∈ Ioo x y) ∧ Tendsto u atTop (𝓝 x) :=
-            exists_seq_strictAnti_tendsto' hxy
-          refine measurable_of_tendsto_metrizable (fun n => hY (u n)) ?_
-          rw [tendsto_pi_nhds]
-          intro ω
-          have hω : Tendsto (Y · ω) (𝓝[>] x) (𝓝 ((Y · ω).rightLim x)) :=
-            (hvar ω).tendsto_rightLim x
-          have hu' : Tendsto u atTop (𝓝[>] x) :=
-            tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _ hu_lim
-              (Eventually.of_forall fun n => (hu_mem n).1)
-          simpa [Function.comp] using hω.comp hu'
-      simpa [fun ω => (hvar ω).vectorMeasure_Ioc hlt.le] using (hright b).sub (hright a)
-  | compl s hs ihs =>
-      have huniv : Measurable fun ω => (hvar ω).vectorMeasure univ := by
-        by_cases hΩ : IsEmpty Ω
-        · letI : IsEmpty Ω := hΩ
-          have hzero : (fun ω => (hvar ω).vectorMeasure univ) = fun _ : Ω => (0 : E) := by
-            funext ω
-            exact False.elim (isEmptyElim ω)
-          rw [hzero]
-          exact measurable_const
-        · letI : Nonempty Ω := not_isEmpty_iff.mp hΩ
-          by_cases hι : Nonempty ι
-          · letI := hι
-            letI : Nonempty E := ⟨Y (Classical.choice hι) (Classical.choice ‹Nonempty Ω›)⟩
+  have hsm : StronglyMeasurable fun ω => (hvar ω).vectorMeasure s := by
+    induction s, hs using MeasurableSpace.induction_on_inter
+        (‹BorelSpace ι›.measurable_eq.trans (borel_eq_generateFrom_Ioc ι))
+        (isPiSystem_Ioc id id) with
+    | empty =>
+        simpa using (stronglyMeasurable_const : StronglyMeasurable fun _ : Ω => (0 : E))
+    | basic s hs =>
+        obtain ⟨a, b, hlt, rfl⟩ := hs
+        have hright (x : ι) : StronglyMeasurable fun ω => (Y · ω).rightLim x := by
+          by_cases hx : IsTop x
+          · simpa [rightLim_eq_of_isTop hx] using hY x
+          · obtain ⟨y, hxy⟩ : ∃ y, x < y := by simp_all [IsTop]
+            obtain ⟨u, _, hu_mem, hu_lim⟩ :
+                ∃ u : ℕ → ι, StrictAnti u ∧ (∀ n, u n ∈ Ioo x y) ∧ Tendsto u atTop (𝓝 x) :=
+              exists_seq_strictAnti_tendsto' hxy
+            have hlim : StronglyMeasurable fun ω => limUnder atTop (fun n => Y (u n) ω) := by
+              simpa using
+                (StronglyMeasurable.limUnder (l := atTop) fun n => hY (u n))
+            have heq :
+                (fun ω => limUnder atTop (fun n => Y (u n) ω)) = fun ω => (Y · ω).rightLim x := by
+              funext ω
+              have hω : Tendsto (Y · ω) (𝓝[>] x) (𝓝 ((Y · ω).rightLim x)) :=
+                (hvar ω).tendsto_rightLim x
+              have hu' : Tendsto u atTop (𝓝[>] x) :=
+                tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _ hu_lim
+                  (Eventually.of_forall fun n => (hu_mem n).1)
+              simpa [Function.comp] using (hω.comp hu').limUnder_eq
+            simpa [heq] using hlim
+        simpa [fun ω => (hvar ω).vectorMeasure_Ioc hlt.le] using
+          (continuous_sub.comp_stronglyMeasurable ((hright b).prodMk (hright a)))
+    | compl s hs ihs =>
+        have huniv : StronglyMeasurable fun ω => (hvar ω).vectorMeasure univ := by
+          by_cases hι : IsEmpty ι
+          · letI : IsEmpty ι := hι
+            simpa [eq_empty_of_isEmpty] using
+              (stronglyMeasurable_const : StronglyMeasurable fun _ : Ω => (0 : E))
+          · letI : Nonempty ι := not_isEmpty_iff.mp hι
             obtain ⟨u, hu⟩ := exists_seq_monotone_tendsto_atTop_atTop ι
             obtain ⟨v, hv⟩ := exists_seq_antitone_tendsto_atTop_atBot ι
-            have htop : Measurable fun ω => limUnder atTop (Y · ω) := by
-              refine measurable_of_tendsto_metrizable (fun n => hY (u n)) ?_
-              rw [tendsto_pi_nhds]
-              intro ω
-              simpa [Function.comp] using (hvar ω).tendsto_atTop_limUnder.comp hu.2
-            have hbot : Measurable fun ω => limUnder atBot (Y · ω) := by
-              refine measurable_of_tendsto_metrizable (fun n => hY (v n)) ?_
-              rw [tendsto_pi_nhds]
-              intro ω
-              simpa [Function.comp] using (hvar ω).tendsto_atBot_limUnder.comp hv.2
-            simpa [(hvar _).vectorMeasure_univ] using htop.sub hbot
-          · letI : IsEmpty ι := not_nonempty_iff.mp hι
-            simp [eq_empty_of_isEmpty]
-      simpa [fun ω => (hvar ω).vectorMeasure.of_compl hs] using huniv.sub ihs
-  | iUnion f hfd hfm ihf =>
-      exact measurable_of_tendsto_metrizable (fun n => Finset.measurable_sum _ fun i hi => ihf i)
-        (tendsto_pi_nhds.2 fun ω => ((hvar ω).vectorMeasure.m_iUnion' hfm hfd).tendsto_sum_nat)
+            have htop : StronglyMeasurable fun ω => limUnder atTop (Y · ω) := by
+              have hlim : StronglyMeasurable fun ω => limUnder atTop (fun n => Y (u n) ω) := by
+                simpa using (StronglyMeasurable.limUnder (l := atTop) fun n => hY (u n))
+              have heq :
+                  (fun ω => limUnder atTop (fun n => Y (u n) ω)) =
+                    fun ω => limUnder atTop (Y · ω) := by
+                funext ω
+                simpa [Function.comp] using ((hvar ω).tendsto_atTop_limUnder.comp hu.2).limUnder_eq
+              simpa [heq] using hlim
+            have hbot : StronglyMeasurable fun ω => limUnder atBot (Y · ω) := by
+              have hlim : StronglyMeasurable fun ω => limUnder atTop (fun n => Y (v n) ω) := by
+                simpa using (StronglyMeasurable.limUnder (l := atTop) fun n => hY (v n))
+              have heq :
+                  (fun ω => limUnder atTop (fun n => Y (v n) ω)) =
+                    fun ω => limUnder atBot (Y · ω) := by
+                funext ω
+                simpa [Function.comp] using ((hvar ω).tendsto_atBot_limUnder.comp hv.2).limUnder_eq
+              simpa [heq] using hlim
+            simpa [(hvar _).vectorMeasure_univ] using
+              (continuous_sub.comp_stronglyMeasurable (htop.prodMk hbot))
+        simpa [fun ω => (hvar ω).vectorMeasure.of_compl hs] using
+          (continuous_sub.comp_stronglyMeasurable (huniv.prodMk ihs))
+    | iUnion f hfd hfm ihf =>
+        refine stronglyMeasurable_of_tendsto atTop
+          (fun n => (Finset.range n).stronglyMeasurable_sum fun i hi => ihf i) ?_
+        rw [tendsto_pi_nhds]
+        intro ω
+        simpa using ((hvar ω).vectorMeasure.m_iUnion' hfm hfd).tendsto_sum_nat
+  exact (stronglyMeasurable_iff_measurable_separable.1 hsm).1
+
+lemma BoundedVariationOn.measurable_vectorMeasure_of_measurable [SecondCountableTopology E]
+    (hY : ∀ i, Measurable (Y i)) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
+    Measurable fun ω => (hvar ω).vectorMeasure := by
+  exact BoundedVariationOn.measurable_vectorMeasure_of_stronglyMeasurable
+    (fun i ↦ (hY i).stronglyMeasurable) hvar
 
 variable {ℱ : Filtration ι mΩ}
 
 lemma BoundedVariationOn.measurable_vectorMeasure_of_adapted [SecondCountableTopology E]
     (ha : Adapted ℱ Y) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
-    Measurable fun ω => (hvar ω).vectorMeasure := by
-  exact BoundedVariationOn.measurable_vectorMeasure (fun i ↦ ha.measurable (i := i)) hvar
+    Measurable fun ω => (hvar ω).vectorMeasure :=
+  BoundedVariationOn.measurable_vectorMeasure_of_measurable
+    (fun i ↦ ha.measurable (i := i)) hvar
 
-lemma BoundedVariationOn.measurable_vectorMeasure_of_stronglyAdapted [SecondCountableTopology E]
+lemma BoundedVariationOn.measurable_vectorMeasure_of_stronglyAdapted
     (ha : StronglyAdapted ℱ Y) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
     Measurable fun ω => (hvar ω).vectorMeasure := by
-  apply BoundedVariationOn.measurable_vectorMeasure
-  intro i
-  have hYi : StronglyMeasurable (Y i) := ha.stronglyMeasurable (i := i)
-  have hsep : TopologicalSpace.IsSeparable (range (Y i)) := hYi.isSeparable_range
-  exact (stronglyMeasurable_iff_measurable_separable.2
-    ⟨(stronglyMeasurable_iff_measurable_separable.1 hYi).1, hsep⟩).measurable
+  exact BoundedVariationOn.measurable_vectorMeasure_of_stronglyMeasurable
+    (fun i ↦ ha.stronglyMeasurable (i := i)) hvar

--- a/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
+++ b/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
@@ -201,18 +201,110 @@ noncomputable def StieltjesFunction.kernel_of_rightCont_adapted_mono {ℱ : Filt
     apply measurable_measure
     simp_all [rightCont_mono, fun i => ha.measurable (i := i)]
 
-variable {E : Type*} [NormedAddCommGroup E] [CompleteSpace E] {Y : ι → Ω → E}
+variable {E : Type*} {Y : ι → Ω → E} [MeasurableSpace E]
 
-/-- If `Y : ι → Ω → E` has paths of bounded variation, then `Y` defines a kernel that maps each
-`ω` to the variation of `Y · ω`. -/
-noncomputable def StieltjesFunction.kernel_of_boundedVariation
-    (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) : Kernel Ω ι where
-  toFun ω := (hvar ω).vectorMeasure.variation
-  measurable' := by sorry
+namespace MeasureTheory.VectorMeasure
 
-theorem StieltjesFunction.kernel_of_boundedVariation_eq_kernel_of_rightCont_adapted_mono
-    {ℱ : Filtration ι mΩ} (ha : Adapted ℱ X) (hcont : ∀ ω, RightContinuous (X · ω))
-    (hmono : ∀ ω, Monotone (X · ω)) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
-    StieltjesFunction.kernel_of_boundedVariation hvar =
-      StieltjesFunction.kernel_of_rightCont_adapted_mono ha hcont hmono := by
-  sorry
+variable [AddCommMonoid E] [TopologicalSpace E] [BorelSpace E]
+
+/-- Measurability structure on `VectorMeasure`. -/
+instance instMeasurableSpace :
+    MeasurableSpace (VectorMeasure ι E) :=
+  ⨆ (s : Set ι) (_ : MeasurableSet s), (borel E).comap fun μ => μ s
+
+variable {ι : Type*} [MeasurableSpace ι]
+
+theorem measurable_coe {s : Set ι} (hs : MeasurableSet s) :
+    Measurable fun μ : VectorMeasure ι E => μ s := by
+  borelize E
+  apply Measurable.of_comap_le <| _
+  apply le_biSup _ hs
+
+theorem measurable_of_measurable_coe {f : Ω → VectorMeasure ι E}
+    (h : ∀ (s : Set ι), MeasurableSet s → Measurable fun ω => f ω s) :
+    Measurable f := by
+  refine Measurable.of_le_map <| iSup₂_le fun s hs => MeasurableSpace.comap_le_iff_le_map.2 ?_
+  rw [MeasurableSpace.map_comp]
+  borelize E
+  exact h s hs
+
+end MeasureTheory.VectorMeasure
+
+variable [NormedAddCommGroup E] [CompleteSpace E] [BorelSpace E]
+
+lemma BoundedVariationOn.measurable_vectorMeasure [SecondCountableTopology E]
+    (hY : ∀ i, Measurable (Y i)) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
+    Measurable fun ω => (hvar ω).vectorMeasure := by
+  refine VectorMeasure.measurable_of_measurable_coe fun s hs => ?_
+  induction s, hs using MeasurableSpace.induction_on_inter
+      (‹BorelSpace ι›.measurable_eq.trans (borel_eq_generateFrom_Ioc ι))
+      (isPiSystem_Ioc id id) with
+  | empty => simp
+  | basic s hs =>
+      obtain ⟨a, b, hlt, rfl⟩ := hs
+      have hright (x : ι) : Measurable fun ω => (Y · ω).rightLim x := by
+        by_cases hx : IsTop x
+        · simpa [rightLim_eq_of_isTop hx] using hY x
+        · obtain ⟨y, hxy⟩ : ∃ y, x < y := by simpa [IsTop, not_forall, not_le] using hx
+          obtain ⟨u, hu_anti, hu_mem, hu_lim⟩ :
+              ∃ u : ℕ → ι, StrictAnti u ∧ (∀ n, u n ∈ Ioo x y) ∧ Tendsto u atTop (𝓝 x) :=
+            exists_seq_strictAnti_tendsto' hxy
+          refine measurable_of_tendsto_metrizable (fun n => hY (u n)) ?_
+          rw [tendsto_pi_nhds]
+          intro ω
+          have hω : Tendsto (Y · ω) (𝓝[>] x) (𝓝 ((Y · ω).rightLim x)) :=
+            (hvar ω).tendsto_rightLim x
+          have hu' : Tendsto u atTop (𝓝[>] x) :=
+            tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _ hu_lim
+              (Eventually.of_forall fun n => (hu_mem n).1)
+          simpa [Function.comp] using hω.comp hu'
+      simpa [fun ω => (hvar ω).vectorMeasure_Ioc hlt.le] using (hright b).sub (hright a)
+  | compl s hs ihs =>
+      have huniv : Measurable fun ω => (hvar ω).vectorMeasure univ := by
+        by_cases hΩ : IsEmpty Ω
+        · letI : IsEmpty Ω := hΩ
+          have hzero : (fun ω => (hvar ω).vectorMeasure univ) = fun _ : Ω => (0 : E) := by
+            funext ω
+            exact False.elim (isEmptyElim ω)
+          rw [hzero]
+          exact measurable_const
+        · letI : Nonempty Ω := not_isEmpty_iff.mp hΩ
+          by_cases hι : Nonempty ι
+          · letI := hι
+            letI : Nonempty E := ⟨Y (Classical.choice hι) (Classical.choice ‹Nonempty Ω›)⟩
+            obtain ⟨u, hu⟩ := exists_seq_monotone_tendsto_atTop_atTop ι
+            obtain ⟨v, hv⟩ := exists_seq_antitone_tendsto_atTop_atBot ι
+            have htop : Measurable fun ω => limUnder atTop (Y · ω) := by
+              refine measurable_of_tendsto_metrizable (fun n => hY (u n)) ?_
+              rw [tendsto_pi_nhds]
+              intro ω
+              simpa [Function.comp] using (hvar ω).tendsto_atTop_limUnder.comp hu.2
+            have hbot : Measurable fun ω => limUnder atBot (Y · ω) := by
+              refine measurable_of_tendsto_metrizable (fun n => hY (v n)) ?_
+              rw [tendsto_pi_nhds]
+              intro ω
+              simpa [Function.comp] using (hvar ω).tendsto_atBot_limUnder.comp hv.2
+            simpa [(hvar _).vectorMeasure_univ] using htop.sub hbot
+          · letI : IsEmpty ι := not_nonempty_iff.mp hι
+            simp [eq_empty_of_isEmpty]
+      simpa [fun ω => (hvar ω).vectorMeasure.of_compl hs] using huniv.sub ihs
+  | iUnion f hfd hfm ihf =>
+      exact measurable_of_tendsto_metrizable (fun n => Finset.measurable_sum _ fun i hi => ihf i)
+        (tendsto_pi_nhds.2 fun ω => ((hvar ω).vectorMeasure.m_iUnion' hfm hfd).tendsto_sum_nat)
+
+variable {ℱ : Filtration ι mΩ}
+
+lemma BoundedVariationOn.measurable_vectorMeasure_of_adapted [SecondCountableTopology E]
+    (ha : Adapted ℱ Y) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
+    Measurable fun ω => (hvar ω).vectorMeasure := by
+  exact BoundedVariationOn.measurable_vectorMeasure (fun i ↦ ha.measurable (i := i)) hvar
+
+lemma BoundedVariationOn.measurable_vectorMeasure_of_stronglyAdapted [SecondCountableTopology E]
+    (ha : StronglyAdapted ℱ Y) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
+    Measurable fun ω => (hvar ω).vectorMeasure := by
+  apply BoundedVariationOn.measurable_vectorMeasure
+  intro i
+  have hYi : StronglyMeasurable (Y i) := ha.stronglyMeasurable (i := i)
+  have hsep : TopologicalSpace.IsSeparable (range (Y i)) := hYi.isSeparable_range
+  exact (stronglyMeasurable_iff_measurable_separable.2
+    ⟨(stronglyMeasurable_iff_measurable_separable.1 hYi).1, hsep⟩).measurable

--- a/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
+++ b/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
@@ -10,6 +10,7 @@ public import BrownianMotion.StochasticIntegral.Cadlag
 public import Mathlib.MeasureTheory.Measure.GiryMonad
 public import Mathlib.MeasureTheory.Measure.Stieltjes
 public import Mathlib.MeasureTheory.VectorMeasure.BoundedVariation
+public import Mathlib.MeasureTheory.VectorMeasure.Variation.Defs
 public import Mathlib.Probability.Kernel.Defs
 
 /-! # The Keneral Associated with a Process
@@ -18,7 +19,7 @@ public import Mathlib.Probability.Kernel.Defs
 
 @[expose] public section
 
-open MeasureTheory Filter Function Set Topology
+open MeasureTheory Filter Function Set Topology ProbabilityTheory
 open scoped ENNReal
 
 variable {ι Ω : Type*} [TopologicalSpace ι] [LinearOrder ι]
@@ -194,7 +195,7 @@ noncomputable def StieltjesFunction.kernel {f : Ω → StieltjesFunction ι}
 kernel that maps each `ω` to `(X · ω).measure`. -/
 noncomputable def StieltjesFunction.kernel_of_rightCont_adapted_mono {ℱ : Filtration ι mΩ}
     (ha : Adapted ℱ X) (hcont : ∀ ω, RightContinuous (X · ω)) (hmono : ∀ ω, Monotone (X · ω)) :
-    ProbabilityTheory.Kernel Ω ι where
+    Kernel Ω ι where
   toFun ω := (rightCont_mono hcont hmono ω).measure
   measurable' := by
     apply measurable_measure
@@ -202,9 +203,16 @@ noncomputable def StieltjesFunction.kernel_of_rightCont_adapted_mono {ℱ : Filt
 
 variable {E : Type*} [NormedAddCommGroup E] [CompleteSpace E] {Y : ι → Ω → E}
 
-/-- If `Y : ι → Ω → E` has paths of bounded variation, then for each `ω : Ω`, we get a
-`StieltjesFunction` on `ι` by taking the variation of the right-limit path from a fixed base point
-`i₀`. -/
-noncomputable def StieltjesFunction.rightCont_boundedVariation
-    (i₀ : ι) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) : Ω → StieltjesFunction ι :=
-  fun ω => (hvar ω).stieltjesFunctionRightLim i₀
+/-- If `Y : ι → Ω → E` has paths of bounded variation, then `Y` defines a kernel that maps each
+`ω` to the variation of `Y · ω`. -/
+noncomputable def StieltjesFunction.kernel_of_boundedVariation
+    (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) : Kernel Ω ι where
+  toFun ω := (hvar ω).vectorMeasure.variation
+  measurable' := by sorry
+
+theorem StieltjesFunction.kernel_of_boundedVariation_eq_kernel_of_rightCont_adapted_mono
+    {ℱ : Filtration ι mΩ} (ha : Adapted ℱ X) (hcont : ∀ ω, RightContinuous (X · ω))
+    (hmono : ∀ ω, Monotone (X · ω)) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
+    StieltjesFunction.kernel_of_boundedVariation hvar =
+      StieltjesFunction.kernel_of_rightCont_adapted_mono ha hcont hmono := by
+  sorry

--- a/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
+++ b/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
@@ -133,7 +133,7 @@ lemma StieltjesFunction.measure_restrict_eq_comap (f : StieltjesFunction ι) (a 
       simp [this, measure_empty]
   · exact (Subtype.borelSpace (Ioc a b)).measurable_eq ▸ borel_eq_generateFrom_Ioc ↑(Ioc a b)
 
-theorem StieltjesFunction.measurable_measure {f : Ω → StieltjesFunction ι}
+theorem StieltjesFunction.measurable_measure' {f : Ω → StieltjesFunction ι}
     (hf : ∀ i, Measurable (f · i)) :
     Measurable fun ω => (f ω).measure := by
   by_cases! Nonempty ι
@@ -190,7 +190,7 @@ a kernel. -/
 noncomputable def StieltjesFunction.kernel {f : Ω → StieltjesFunction ι}
     (hf : ∀ i, Measurable (f · i)) : ProbabilityTheory.Kernel Ω ι where
   toFun ω := (f ω).measure
-  measurable' := measurable_measure hf
+  measurable' := measurable_measure' hf
 
 /-- If `X : ι → Ω → ℝ` is a right continuous, adapted, and monotone process, then `X` defines a
 kernel that maps each `ω` to `(X · ω).measure`. -/
@@ -199,7 +199,7 @@ noncomputable def StieltjesFunction.kernelOfRightContAdaptedMono
     Kernel Ω ι where
   toFun ω := (rightContMono hcont hmono ω).measure
   measurable' := by
-    apply measurable_measure
+    apply measurable_measure'
     simp_all [rightContMono, fun i => ha.measurable (i := i)]
 
 end StieltjesKernel

--- a/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
+++ b/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
@@ -1,0 +1,171 @@
+/-
+Copyright (c) 2026 Yongxi Lin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yongxi Lin
+-/
+module
+
+public import Mathlib.MeasureTheory.Measure.GiryMonad
+public import Mathlib.MeasureTheory.Measure.Stieltjes
+
+/-! # The Keneral Associated with a Process
+
+-/
+
+@[expose] public section
+
+open MeasureTheory Filter Set Topology
+open scoped ENNReal
+
+variable {ι Ω : Type*} [TopologicalSpace ι] [LinearOrder ι]
+
+def StieltjesFunction.restrict (f : StieltjesFunction ι) (s : Set ι) : StieltjesFunction s where
+  toFun x := f x
+  mono' x y hxy := f.mono hxy
+  right_continuous' x :=
+    (f.right_continuous x).comp continuousAt_subtype_val.continuousWithinAt fun i => by simp
+
+lemma StieltjesFunction.restrict_Ioc_BddAbove (f : StieltjesFunction ι) {a b : ι} :
+    BddAbove (range (f.restrict (Ioc a b))) :=
+  ⟨f b, fun y ⟨c, hc⟩ => hc ▸ by simp [restrict, f.mono c.2.2]⟩
+
+lemma StieltjesFunction.restrict_Ioc_BddBelow (f : StieltjesFunction ι) {a b : ι} :
+    BddBelow (range (f.restrict (Ioc a b))) :=
+  ⟨f a, fun y ⟨c, hc⟩ => hc ▸ by simp [restrict, f.mono c.2.1.le]⟩
+
+lemma StieltjesFunction.restrict_Ioc_iSup (f : StieltjesFunction ι) {a b : ι} (hab : a < b) :
+    f b = ⨆ i, (f.restrict (Ioc a b)) i := by
+  have := nonempty_Ioc_subtype hab
+  refine le_antisymm ?_ (ciSup_le fun i => by simp [restrict, f.mono i.2.2])
+  have : f b = (f.restrict (Ioc a b)) (⟨b, ⟨hab, refl b⟩⟩ : Ioc a b) := by simp [restrict]
+  grw [this, le_ciSup f.restrict_Ioc_BddAbove]
+
+variable [OrderTopology ι] [DenselyOrdered ι]
+
+lemma StieltjesFunction.restrict_Ioc_iInf (f : StieltjesFunction ι) {a b : ι} (hab : a < b) :
+    f a = ⨅ i, (f.restrict (Ioc a b)) i := by
+  have := nonempty_Ioc_subtype hab
+  have : Tendsto (f.restrict (Ioc a b)) atBot (𝓝 (f a)) := by
+    have : Tendsto (Subtype.val : (Ioc a b) → ι) atBot (𝓝[≥] a) := by
+      refine tendsto_nhdsWithin_iff.2 ⟨?_, .of_forall (by grind)⟩
+      apply tendsto_atBot_isGLB (Subtype.mono_coe _)
+      simp [Subtype.range_coe_subtype, -mem_Ioc, isGLB_Ioc hab]
+    simpa [restrict] using (f.right_continuous a).tendsto.comp this
+  exact tendsto_nhds_unique this (tendsto_atBot_ciInf (f.restrict (Ioc a b)).mono
+    f.restrict_Ioc_BddBelow)
+
+variable [MeasurableSpace ι] [BorelSpace ι] [CompactIccSpace ι]
+  [SecondCountableTopology ι] {mΩ : MeasurableSpace Ω} {P : Measure Ω}
+
+private lemma StieltjesFunction.measurable_finite_measure {f : Ω → StieltjesFunction ι}
+    [∀ ω, IsFiniteMeasure (f ω).measure] (hmbot : Measurable (fun ω => ⨅ i, f ω i))
+    (hmtop : Measurable (fun ω => ⨆ i, f ω i)) (hf : ∀ i, Measurable fun ω ↦ f ω i) :
+    Measurable fun ω => (f ω).measure := by
+  by_cases! Nonempty ι
+  · apply Measurable.measure_of_isPiSystem ?_ (isPiSystem_Ioc id id)
+    · rintro t ⟨i, j, hl, rfl⟩
+      simp only [id_eq, StieltjesFunction.measure_Ioc]
+      fun_prop
+    · have hbot (ω : Ω) : Tendsto (f ω) atBot (𝓝 (⨅ i, (f ω) i)) := by
+        apply tendsto_atBot_ciInf (f ω).mono
+        by_contra!
+        have := measure_univ_of_tendsto_atBot_atBot (f ω) <|
+          tendsto_atBot_atBot_of_monotone' (f ω).mono this
+        aesop
+      have htop (ω : Ω) : Tendsto (f ω) atTop (𝓝 (⨆ i, (f ω) i)) := by
+        apply tendsto_atTop_ciSup (f ω).mono
+        by_contra!
+        have := measure_univ_of_tendsto_atTop_atTop (f ω) <|
+          tendsto_atTop_atTop_of_monotone' (f ω).mono this
+        aesop
+      simp_all [fun ω => measure_univ (f ω) (hbot ω) (htop ω)]
+      measurability
+    · borelize ι
+      exact borel_eq_generateFrom_Ioc ι
+  · simp [Measure.eq_zero_of_isEmpty]
+
+instance {X : Type*} [TopologicalSpace X] [Preorder X] [CompactIccSpace X] {a b : X} :
+    CompactIccSpace (Ioc a b) where
+  isCompact_Icc := by
+    intro c d
+    exact IsEmbedding.subtypeVal.isCompact_iff.2 (by simp [isCompact_Icc])
+
+lemma StieltjesFunction.restrict_measure_Ioc (f : StieltjesFunction ι) {a b : ι} (hab : a < b) :
+    (f.restrict (Ioc a b)).measure univ = ENNReal.ofReal (f b - f a) := by
+  have := nonempty_Ioc_subtype hab
+  have hbot : Tendsto (f.restrict (Ioc a b)) atBot (𝓝 (f a)) := by
+    have : Tendsto (Subtype.val : (Ioc a b) → ι) atBot (𝓝[≥] a) := by
+      refine tendsto_nhdsWithin_iff.2 ⟨?_, .of_forall (by grind)⟩
+      apply tendsto_atBot_isGLB (Subtype.mono_coe _)
+      simp [Subtype.range_coe_subtype, -mem_Ioc, isGLB_Ioc hab]
+    simpa [restrict] using (f.right_continuous a).tendsto.comp this
+  have htop : Tendsto (f.restrict (Ioc a b)) atTop (𝓝 (f b)) := by
+    rw [f.restrict_Ioc_iSup hab]
+    convert tendsto_atTop_ciSup (f.restrict (Ioc a b)).mono f.restrict_Ioc_BddAbove
+  simp [-mem_Ioc, ← measure_univ (f.restrict (Ioc a b)) hbot htop]
+
+instance StieltjesFunction.isFiniteMeasure_restrict_Ioc {f : StieltjesFunction ι} {a b : ι} :
+    IsFiniteMeasure (f.restrict (Ioc a b)).measure where
+  measure_univ_lt_top := by
+    by_cases! hab : a < b
+    · simp [f.restrict_measure_Ioc hab]
+    · have : (univ : Set (Ioc a b)) = ∅ := by grind
+      simp [this, measure_empty]
+
+lemma StieltjesFunction.restrict_eq_measure (f : StieltjesFunction ι) (a b : ι) :
+    (f.restrict (Ioc a b)).measure = f.measure.comap Subtype.val := by
+  apply ext_of_generate_finite _ _ (isPiSystem_Ioc id id)
+  · rintro t ⟨i, j, hl, rfl⟩
+    simp [id_eq, measure_Ioc, (MeasurableEmbedding.subtype_coe measurableSet_Ioc).comap_apply,
+      restrict]
+  · by_cases! hab : a < b
+    · simp [-mem_Ioc, f.restrict_measure_Ioc hab,
+        (MeasurableEmbedding.subtype_coe measurableSet_Ioc).comap_apply]
+    · have : (univ : Set (Ioc a b)) = ∅ := by grind
+      simp [this, measure_empty]
+  · exact (Subtype.borelSpace (Ioc a b)).measurable_eq ▸ borel_eq_generateFrom_Ioc ↑(Ioc a b)
+
+theorem StieltjesFunction.measurable_measure {f : Ω → StieltjesFunction ι}
+    (hf : ∀ i, Measurable fun ω ↦ f ω i) :
+    Measurable fun ω => (f ω).measure := by
+  by_cases! Nonempty ι
+  · refine Measure.measurable_measure.2 fun s hs => ?_
+    obtain ⟨u, hu⟩ := exists_seq_monotone_tendsto_atTop_atTop ι
+    obtain ⟨v, hv⟩ := exists_seq_antitone_tendsto_atTop_atBot ι
+    have hc : univ = botSet ∪ ⋃ n, Ioc (v n) (u n) := by
+      ext x
+      by_cases! hx : IsBot x
+      <;> simp_all only [IsBot, mem_univ, botSet, mem_union, mem_setOf_eq,
+        implies_true, mem_iUnion, mem_Ioc, and_true, true_or, tendsto_atTop_atTop,
+        tendsto_atTop_atBot, not_forall, not_le, true_iff]
+      apply Or.inr
+      obtain ⟨i, hi⟩ := hu.2 x
+      obtain ⟨z, hz⟩ := hx
+      obtain ⟨j, hj⟩ := hv.2 z
+      refine ⟨max i j, ?_, ?_⟩
+      · exact (hj (max i j) (le_max_right i j)).trans_lt hz
+      · exact hi (max i j) (le_max_left i j)
+    have hm : Monotone fun n => s ∩ Ioc (v n) (u n) := by
+      intro i j hij x hx
+      simp_all only [Monotone, Antitone, mem_inter_iff, true_and]
+      exact ⟨(hv.1 hij).trans_lt hx.2.1, hx.2.2.trans (hu.1 hij)⟩
+    have heq (n : ℕ) (ω : Ω) : (f ω).measure (s ∩ Ioc (v n) (u n)) =
+      ((f ω).restrict (Ioc (v n) (u n))).measure (Subtype.val ⁻¹' s) := by
+      simp [restrict_eq_measure, inter_comm,
+        (MeasurableEmbedding.subtype_coe measurableSet_Ioc).comap_apply]
+    rw [← inter_univ s, hc, inter_union_distrib_left, inter_iUnion]
+    have hd : Disjoint (s ∩ botSet) (⋃ n, s ∩ Ioc (v n) (u n)) := by
+      refine disjoint_left.2 fun a ⟨_, ha⟩ ⟨_, ⟨⟨i, rfl⟩, ⟨_, hm⟩⟩⟩ => ?_
+      grind [hm.1, ha (v i)]
+    have hz (ω : Ω) : (f ω).measure (s ∩ botSet) = 0 :=
+      measure_mono_null inter_subset_right (measure_botSet (f ω))
+    simp only [measure_union' hd (hs.inter measurableSet_botSet), hz, hm.measure_iUnion, heq,
+      zero_add]
+    refine Measurable.iSup fun n => (Measure.measurable_measure.1 ?_) _ (by measurability)
+    refine measurable_finite_measure ?_ ?_ fun i => (by measurability)
+    <;> by_cases! hvu : v n < u n
+    · simp [fun ω => ((f ω).restrict_Ioc_iInf hvu).symm, hf (v n)]
+    · simp_all
+    · simp [fun ω => ((f ω).restrict_Ioc_iSup hvu).symm, hf (u n)]
+    · simp_all
+  · simp [Measure.eq_zero_of_isEmpty]

--- a/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
+++ b/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
@@ -316,7 +316,7 @@ lemma measurable_vectorMeasure_of_stronglyMeasurable
 
 lemma measurable_vectorMeasure_of_measurable [SecondCountableTopology E]
     (hY : ∀ i, Measurable (Y i)) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
-    Measurable fun ω => (hvar ω).vectorMeasure :
+    Measurable fun ω => (hvar ω).vectorMeasure :=
   measurable_vectorMeasure_of_stronglyMeasurable (fun i ↦ (hY i).stronglyMeasurable) hvar
 
 lemma measurable_vectorMeasure_of_adapted [SecondCountableTopology E]

--- a/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
+++ b/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
@@ -5,8 +5,11 @@ Authors: Yongxi Lin
 -/
 module
 
+public import BrownianMotion.Auxiliary.Filtration
+public import BrownianMotion.StochasticIntegral.Cadlag
 public import Mathlib.MeasureTheory.Measure.GiryMonad
 public import Mathlib.MeasureTheory.Measure.Stieltjes
+public import Mathlib.Probability.Kernel.Defs
 
 /-! # The Keneral Associated with a Process
 
@@ -14,7 +17,7 @@ public import Mathlib.MeasureTheory.Measure.Stieltjes
 
 @[expose] public section
 
-open MeasureTheory Filter Set Topology
+open MeasureTheory Filter Function Set Topology
 open scoped ENNReal
 
 variable {ι Ω : Type*} [TopologicalSpace ι] [LinearOrder ι]
@@ -59,7 +62,7 @@ variable [MeasurableSpace ι] [BorelSpace ι] [CompactIccSpace ι]
 
 private lemma StieltjesFunction.measurable_finite_measure {f : Ω → StieltjesFunction ι}
     [∀ ω, IsFiniteMeasure (f ω).measure] (hmbot : Measurable (fun ω => ⨅ i, f ω i))
-    (hmtop : Measurable (fun ω => ⨆ i, f ω i)) (hf : ∀ i, Measurable fun ω ↦ f ω i) :
+    (hmtop : Measurable (fun ω => ⨆ i, f ω i)) (hf : ∀ i, Measurable (f · i)) :
     Measurable fun ω => (f ω).measure := by
   by_cases! Nonempty ι
   · apply Measurable.measure_of_isPiSystem ?_ (isPiSystem_Ioc id id)
@@ -126,7 +129,7 @@ lemma StieltjesFunction.restrict_eq_measure (f : StieltjesFunction ι) (a b : ι
   · exact (Subtype.borelSpace (Ioc a b)).measurable_eq ▸ borel_eq_generateFrom_Ioc ↑(Ioc a b)
 
 theorem StieltjesFunction.measurable_measure {f : Ω → StieltjesFunction ι}
-    (hf : ∀ i, Measurable fun ω ↦ f ω i) :
+    (hf : ∀ i, Measurable (f · i)) :
     Measurable fun ω => (f ω).measure := by
   by_cases! Nonempty ι
   · refine Measure.measurable_measure.2 fun s hs => ?_
@@ -169,3 +172,38 @@ theorem StieltjesFunction.measurable_measure {f : Ω → StieltjesFunction ι}
     · simp [fun ω => ((f ω).restrict_Ioc_iSup hvu).symm, hf (u n)]
     · simp_all
   · simp [Measure.eq_zero_of_isEmpty]
+
+variable {X : ι → Ω → ℝ}
+
+/-- If `X : ι → Ω → ℝ` is a right continuous and monotone process, then for each `ω : Ω`, `X · ω` is
+a `StieltjesFunction` defined on `ι`. -/
+def StieltjesFunction.rightCont_mono (hcont : ∀ ω, RightContinuous (X · ω))
+    (hmono : ∀ ω, Monotone (X · ω)) : Ω → StieltjesFunction ι :=
+  fun ω => StieltjesFunction.mk (X · ω) (hmono ω)
+    (fun i => continuousWithinAt_Ioi_iff_Ici.1 (hcont ω i))
+
+/-- If `f : Ω → StieltjesFunction ι` satisfies for each `i`, `f · i` is measurable, then `f` defines
+a kernel. -/
+noncomputable def StieltjesFunction.kernel {f : Ω → StieltjesFunction ι}
+    (hf : ∀ i, Measurable (f · i)) : ProbabilityTheory.Kernel Ω ι where
+  toFun ω := (f ω).measure
+  measurable' := measurable_measure hf
+
+/-- If `X : ι → Ω → ℝ` is a right continuous, adapted, and monotone process, then `X` defines a
+kernel that maps each `ω` to `(X · ω).measure`. -/
+noncomputable def StieltjesFunction.kernel_of_rightCont_adapted_mono {ℱ : Filtration ι mΩ}
+    (ha : Adapted ℱ X) (hcont : ∀ ω, RightContinuous (X · ω)) (hmono : ∀ ω, Monotone (X · ω)) :
+    ProbabilityTheory.Kernel Ω ι where
+  toFun ω := (rightCont_mono hcont hmono ω).measure
+  measurable' := by
+    apply measurable_measure
+    simp_all [rightCont_mono, fun i => ha.measurable (i := i)]
+
+variable {E : Type*} {Y : ι → Ω → E}
+
+/-- If `Y : ι → Ω → E` is a right continuous and of bounded variation, then for each `ω : Ω`,
+`Y · ω` is a `StieltjesFunction` defined on `ι`. -/
+def StieltjesFunction.rightCont_boundedVariation (hcont : ∀ ω, RightContinuous (X · ω))
+    (hmono : ∀ ω, Monotone (X · ω)) : Ω → StieltjesFunction ι :=
+  fun ω => StieltjesFunction.mk (X · ω) (hmono ω)
+    (fun i => continuousWithinAt_Ioi_iff_Ici.1 (hcont ω i))

--- a/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
+++ b/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
@@ -23,7 +23,11 @@ public import Mathlib.Probability.Kernel.Defs
 open MeasureTheory Filter Function Set Topology ProbabilityTheory
 open scoped ENNReal
 
-variable {ι Ω : Type*} [TopologicalSpace ι] [LinearOrder ι]
+variable {ι Ω E : Type*} [TopologicalSpace ι] [LinearOrder ι] {a b : ι}
+variable {mΩ : MeasurableSpace Ω} {ℱ : Filtration ι mΩ}
+variable {X : ι → Ω → ℝ} {Y : ι → Ω → E}
+
+section StieltjesKernel
 
 def StieltjesFunction.restrict (f : StieltjesFunction ι) (s : Set ι) : StieltjesFunction s where
   toFun x := f x
@@ -31,15 +35,15 @@ def StieltjesFunction.restrict (f : StieltjesFunction ι) (s : Set ι) : Stieltj
   right_continuous' x :=
     (f.right_continuous x).comp continuousAt_subtype_val.continuousWithinAt fun i => by simp
 
-lemma StieltjesFunction.restrict_Ioc_BddAbove (f : StieltjesFunction ι) {a b : ι} :
+lemma StieltjesFunction.restrict_Ioc_BddAbove (f : StieltjesFunction ι) :
     BddAbove (range (f.restrict (Ioc a b))) :=
   ⟨f b, fun y ⟨c, hc⟩ => hc ▸ by simp [restrict, f.mono c.2.2]⟩
 
-lemma StieltjesFunction.restrict_Ioc_BddBelow (f : StieltjesFunction ι) {a b : ι} :
+lemma StieltjesFunction.restrict_Ioc_BddBelow (f : StieltjesFunction ι) :
     BddBelow (range (f.restrict (Ioc a b))) :=
   ⟨f a, fun y ⟨c, hc⟩ => hc ▸ by simp [restrict, f.mono c.2.1.le]⟩
 
-lemma StieltjesFunction.restrict_Ioc_iSup (f : StieltjesFunction ι) {a b : ι} (hab : a < b) :
+lemma StieltjesFunction.restrict_Ioc_iSup (f : StieltjesFunction ι) (hab : a < b) :
     f b = ⨆ i, (f.restrict (Ioc a b)) i := by
   have := nonempty_Ioc_subtype hab
   refine le_antisymm ?_ (ciSup_le fun i => by simp [restrict, f.mono i.2.2])
@@ -48,7 +52,7 @@ lemma StieltjesFunction.restrict_Ioc_iSup (f : StieltjesFunction ι) {a b : ι} 
 
 variable [OrderTopology ι] [DenselyOrdered ι]
 
-lemma StieltjesFunction.restrict_Ioc_iInf (f : StieltjesFunction ι) {a b : ι} (hab : a < b) :
+lemma StieltjesFunction.restrict_Ioc_iInf (f : StieltjesFunction ι) (hab : a < b) :
     f a = ⨅ i, (f.restrict (Ioc a b)) i := by
   have := nonempty_Ioc_subtype hab
   have : Tendsto (f.restrict (Ioc a b)) atBot (𝓝 (f a)) := by
@@ -60,8 +64,7 @@ lemma StieltjesFunction.restrict_Ioc_iInf (f : StieltjesFunction ι) {a b : ι} 
   exact tendsto_nhds_unique this (tendsto_atBot_ciInf (f.restrict (Ioc a b)).mono
     f.restrict_Ioc_BddBelow)
 
-variable [MeasurableSpace ι] [BorelSpace ι] [CompactIccSpace ι]
-  [SecondCountableTopology ι] {mΩ : MeasurableSpace Ω} {P : Measure Ω}
+variable [MeasurableSpace ι] [BorelSpace ι] [CompactIccSpace ι] [SecondCountableTopology ι]
 
 private lemma StieltjesFunction.measurable_finite_measure {f : Ω → StieltjesFunction ι}
     [∀ ω, IsFiniteMeasure (f ω).measure] (hmbot : Measurable (fun ω => ⨅ i, f ω i))
@@ -96,7 +99,7 @@ instance {X : Type*} [TopologicalSpace X] [Preorder X] [CompactIccSpace X] {a b 
     intro c d
     exact IsEmbedding.subtypeVal.isCompact_iff.2 (by simp [isCompact_Icc])
 
-lemma StieltjesFunction.restrict_measure_Ioc (f : StieltjesFunction ι) {a b : ι} (hab : a < b) :
+lemma StieltjesFunction.restrict_measure_Ioc (f : StieltjesFunction ι) (hab : a < b) :
     (f.restrict (Ioc a b)).measure univ = ENNReal.ofReal (f b - f a) := by
   have := nonempty_Ioc_subtype hab
   have hbot : Tendsto (f.restrict (Ioc a b)) atBot (𝓝 (f a)) := by
@@ -110,7 +113,7 @@ lemma StieltjesFunction.restrict_measure_Ioc (f : StieltjesFunction ι) {a b : �
     convert tendsto_atTop_ciSup (f.restrict (Ioc a b)).mono f.restrict_Ioc_BddAbove
   simp [-mem_Ioc, ← measure_univ (f.restrict (Ioc a b)) hbot htop]
 
-instance StieltjesFunction.isFiniteMeasure_restrict_Ioc {f : StieltjesFunction ι} {a b : ι} :
+instance StieltjesFunction.isFiniteMeasure_restrict_Ioc {f : StieltjesFunction ι} :
     IsFiniteMeasure (f.restrict (Ioc a b)).measure where
   measure_univ_lt_top := by
     by_cases! hab : a < b
@@ -122,8 +125,7 @@ lemma StieltjesFunction.restrict_eq_measure (f : StieltjesFunction ι) (a b : ι
     (f.restrict (Ioc a b)).measure = f.measure.comap Subtype.val := by
   apply ext_of_generate_finite _ _ (isPiSystem_Ioc id id)
   · rintro t ⟨i, j, hl, rfl⟩
-    simp [id_eq, measure_Ioc, (MeasurableEmbedding.subtype_coe measurableSet_Ioc).comap_apply,
-      restrict]
+    simp [measure_Ioc, (MeasurableEmbedding.subtype_coe measurableSet_Ioc).comap_apply, restrict]
   · by_cases! hab : a < b
     · simp [-mem_Ioc, f.restrict_measure_Ioc hab,
         (MeasurableEmbedding.subtype_coe measurableSet_Ioc).comap_apply]
@@ -176,8 +178,6 @@ theorem StieltjesFunction.measurable_measure {f : Ω → StieltjesFunction ι}
     · simp_all
   · simp [Measure.eq_zero_of_isEmpty]
 
-variable {X : ι → Ω → ℝ}
-
 /-- If `X : ι → Ω → ℝ` is a right continuous and monotone process, then for each `ω : Ω`, `X · ω` is
 a `StieltjesFunction` defined on `ι`. -/
 def StieltjesFunction.rightCont_mono (hcont : ∀ ω, RightContinuous (X · ω))
@@ -194,7 +194,7 @@ noncomputable def StieltjesFunction.kernel {f : Ω → StieltjesFunction ι}
 
 /-- If `X : ι → Ω → ℝ` is a right continuous, adapted, and monotone process, then `X` defines a
 kernel that maps each `ω` to `(X · ω).measure`. -/
-noncomputable def StieltjesFunction.kernel_of_rightCont_adapted_mono {ℱ : Filtration ι mΩ}
+noncomputable def StieltjesFunction.kernel_of_rightCont_adapted_mono
     (ha : Adapted ℱ X) (hcont : ∀ ω, RightContinuous (X · ω)) (hmono : ∀ ω, Monotone (X · ω)) :
     Kernel Ω ι where
   toFun ω := (rightCont_mono hcont hmono ω).measure
@@ -202,18 +202,17 @@ noncomputable def StieltjesFunction.kernel_of_rightCont_adapted_mono {ℱ : Filt
     apply measurable_measure
     simp_all [rightCont_mono, fun i => ha.measurable (i := i)]
 
-variable {E : Type*} {Y : ι → Ω → E} [MeasurableSpace E]
+end StieltjesKernel
 
 namespace MeasureTheory.VectorMeasure
 
-variable [AddCommMonoid E] [TopologicalSpace E] [BorelSpace E]
+variable {ι : Type*} [MeasurableSpace ι]
+variable [AddCommMonoid E] [TopologicalSpace E] [MeasurableSpace E] [BorelSpace E]
 
 /-- Measurability structure on `VectorMeasure`. -/
 instance instMeasurableSpace :
     MeasurableSpace (VectorMeasure ι E) :=
   ⨆ (s : Set ι) (_ : MeasurableSet s), (borel E).comap fun μ => μ s
-
-variable {ι : Type*} [MeasurableSpace ι]
 
 theorem measurable_coe {s : Set ι} (hs : MeasurableSet s) :
     Measurable fun μ : VectorMeasure ι E => μ s := by
@@ -231,9 +230,68 @@ theorem measurable_of_measurable_coe {f : Ω → VectorMeasure ι E}
 
 end MeasureTheory.VectorMeasure
 
-variable [NormedAddCommGroup E] [CompleteSpace E] [BorelSpace E]
+section StronglyMeasurableLim
 
-lemma BoundedVariationOn.measurable_vectorMeasure_of_stronglyMeasurable
+variable [OrderTopology ι] [SecondCountableTopology ι]
+variable [NormedAddCommGroup E] [CompleteSpace E]
+
+lemma stronglyMeasurable_limUnder_atTop [Nonempty ι]
+    (hY : ∀ i, StronglyMeasurable (Y i)) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
+    StronglyMeasurable fun ω => limUnder atTop (Y · ω) := by
+  obtain ⟨u, hu⟩ := atTop.exists_seq_tendsto (α := ι)
+  convert (StronglyMeasurable.limUnder (l := atTop) fun n => hY (u n)) using 1
+  ext ω
+  exact ((hvar ω).tendsto_atTop_limUnder.comp hu).limUnder_eq.symm
+
+lemma stronglyMeasurable_limUnder_atBot [Nonempty ι]
+    (hY : ∀ i, StronglyMeasurable (Y i)) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
+    StronglyMeasurable fun ω => limUnder atBot (Y · ω) := by
+  obtain ⟨u, hu⟩ := atBot.exists_seq_tendsto (α := ι)
+  convert (StronglyMeasurable.limUnder (l := atTop) fun n => hY (u n)) using 1
+  ext ω
+  exact ((hvar ω).tendsto_atBot_limUnder.comp hu).limUnder_eq.symm
+
+variable [DenselyOrdered ι]
+
+lemma stronglyMeasurable_rightLim
+    (hY : ∀ i, StronglyMeasurable (Y i)) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ)
+    (x : ι) : StronglyMeasurable fun ω => (Y · ω).rightLim x := by
+  by_cases hx : IsTop x
+  · simpa [rightLim_eq_of_isTop hx] using hY x
+  have := nhdsGT_neBot_of_exists_gt (by simp_all [IsTop] : ∃ y, x < y)
+  obtain ⟨u, hu⟩ := (𝓝[>] x).exists_seq_tendsto
+  convert (StronglyMeasurable.limUnder (l := atTop) fun n => hY (u n)) using 1
+  ext ω
+  exact (((hvar ω).tendsto_rightLim x).comp hu).limUnder_eq.symm
+
+variable [MeasurableSpace ι] [BorelSpace ι] [CompactIccSpace ι]
+
+lemma stronglyMeasurable_vectorMeasure_Ioc
+    (hY : ∀ i, StronglyMeasurable (Y i)) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ)
+    {a b : ι} (hab : a ≤ b) :
+    StronglyMeasurable fun ω => (hvar ω).vectorMeasure (Ioc a b) := by
+  simpa [fun ω => (hvar ω).vectorMeasure_Ioc hab] using
+    (continuous_sub.comp_stronglyMeasurable
+      ((stronglyMeasurable_rightLim hY hvar b).prodMk (stronglyMeasurable_rightLim hY hvar a)))
+
+lemma stronglyMeasurable_vectorMeasure_univ
+    (hY : ∀ i, StronglyMeasurable (Y i)) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
+    StronglyMeasurable fun ω => (hvar ω).vectorMeasure univ := by
+  by_cases! hι : IsEmpty ι
+  · simpa [eq_empty_of_isEmpty] using stronglyMeasurable_const
+  · simpa [(hvar _).vectorMeasure_univ] using
+      (continuous_sub.comp_stronglyMeasurable ((stronglyMeasurable_limUnder_atTop hY hvar).prodMk
+        (stronglyMeasurable_limUnder_atBot hY hvar)))
+
+end StronglyMeasurableLim
+
+namespace BoundedVariationOn
+
+variable [OrderTopology ι] [DenselyOrdered ι] [MeasurableSpace ι] [BorelSpace ι]
+   [CompactIccSpace ι] [SecondCountableTopology ι]
+variable [NormedAddCommGroup E] [CompleteSpace E] [MeasurableSpace E] [BorelSpace E]
+
+lemma measurable_vectorMeasure_of_stronglyMeasurable
     (hY : ∀ i, StronglyMeasurable (Y i)) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
     Measurable fun ω => (hvar ω).vectorMeasure := by
   refine VectorMeasure.measurable_of_measurable_coe fun s hs => ?_
@@ -241,87 +299,34 @@ lemma BoundedVariationOn.measurable_vectorMeasure_of_stronglyMeasurable
     induction s, hs using MeasurableSpace.induction_on_inter
         (‹BorelSpace ι›.measurable_eq.trans (borel_eq_generateFrom_Ioc ι))
         (isPiSystem_Ioc id id) with
-    | empty =>
-        simpa using (stronglyMeasurable_const : StronglyMeasurable fun _ : Ω => (0 : E))
+    | empty => simpa using stronglyMeasurable_const
     | basic s hs =>
         obtain ⟨a, b, hlt, rfl⟩ := hs
-        have hright (x : ι) : StronglyMeasurable fun ω => (Y · ω).rightLim x := by
-          by_cases hx : IsTop x
-          · simpa [rightLim_eq_of_isTop hx] using hY x
-          · obtain ⟨y, hxy⟩ : ∃ y, x < y := by simp_all [IsTop]
-            obtain ⟨u, _, hu_mem, hu_lim⟩ :
-                ∃ u : ℕ → ι, StrictAnti u ∧ (∀ n, u n ∈ Ioo x y) ∧ Tendsto u atTop (𝓝 x) :=
-              exists_seq_strictAnti_tendsto' hxy
-            have hlim : StronglyMeasurable fun ω => limUnder atTop (fun n => Y (u n) ω) := by
-              simpa using
-                (StronglyMeasurable.limUnder (l := atTop) fun n => hY (u n))
-            have heq :
-                (fun ω => limUnder atTop (fun n => Y (u n) ω)) = fun ω => (Y · ω).rightLim x := by
-              funext ω
-              have hω : Tendsto (Y · ω) (𝓝[>] x) (𝓝 ((Y · ω).rightLim x)) :=
-                (hvar ω).tendsto_rightLim x
-              have hu' : Tendsto u atTop (𝓝[>] x) :=
-                tendsto_nhdsWithin_of_tendsto_nhds_of_eventually_within _ hu_lim
-                  (Eventually.of_forall fun n => (hu_mem n).1)
-              simpa [Function.comp] using (hω.comp hu').limUnder_eq
-            simpa [heq] using hlim
-        simpa [fun ω => (hvar ω).vectorMeasure_Ioc hlt.le] using
-          (continuous_sub.comp_stronglyMeasurable ((hright b).prodMk (hright a)))
+        simpa using stronglyMeasurable_vectorMeasure_Ioc hY hvar hlt.le
     | compl s hs ihs =>
-        have huniv : StronglyMeasurable fun ω => (hvar ω).vectorMeasure univ := by
-          by_cases hι : IsEmpty ι
-          · letI : IsEmpty ι := hι
-            simpa [eq_empty_of_isEmpty] using
-              (stronglyMeasurable_const : StronglyMeasurable fun _ : Ω => (0 : E))
-          · letI : Nonempty ι := not_isEmpty_iff.mp hι
-            obtain ⟨u, hu⟩ := exists_seq_monotone_tendsto_atTop_atTop ι
-            obtain ⟨v, hv⟩ := exists_seq_antitone_tendsto_atTop_atBot ι
-            have htop : StronglyMeasurable fun ω => limUnder atTop (Y · ω) := by
-              have hlim : StronglyMeasurable fun ω => limUnder atTop (fun n => Y (u n) ω) := by
-                simpa using (StronglyMeasurable.limUnder (l := atTop) fun n => hY (u n))
-              have heq :
-                  (fun ω => limUnder atTop (fun n => Y (u n) ω)) =
-                    fun ω => limUnder atTop (Y · ω) := by
-                funext ω
-                simpa [Function.comp] using ((hvar ω).tendsto_atTop_limUnder.comp hu.2).limUnder_eq
-              simpa [heq] using hlim
-            have hbot : StronglyMeasurable fun ω => limUnder atBot (Y · ω) := by
-              have hlim : StronglyMeasurable fun ω => limUnder atTop (fun n => Y (v n) ω) := by
-                simpa using (StronglyMeasurable.limUnder (l := atTop) fun n => hY (v n))
-              have heq :
-                  (fun ω => limUnder atTop (fun n => Y (v n) ω)) =
-                    fun ω => limUnder atBot (Y · ω) := by
-                funext ω
-                simpa [Function.comp] using ((hvar ω).tendsto_atBot_limUnder.comp hv.2).limUnder_eq
-              simpa [heq] using hlim
-            simpa [(hvar _).vectorMeasure_univ] using
-              (continuous_sub.comp_stronglyMeasurable (htop.prodMk hbot))
         simpa [fun ω => (hvar ω).vectorMeasure.of_compl hs] using
-          (continuous_sub.comp_stronglyMeasurable (huniv.prodMk ihs))
+          continuous_sub.comp_stronglyMeasurable
+            ((stronglyMeasurable_vectorMeasure_univ hY hvar).prodMk ihs)
     | iUnion f hfd hfm ihf =>
         refine stronglyMeasurable_of_tendsto atTop
           (fun n => (Finset.range n).stronglyMeasurable_sum fun i hi => ihf i) ?_
-        rw [tendsto_pi_nhds]
-        intro ω
-        simpa using ((hvar ω).vectorMeasure.m_iUnion' hfm hfd).tendsto_sum_nat
-  exact (stronglyMeasurable_iff_measurable_separable.1 hsm).1
+        simpa [tendsto_pi_nhds] using fun ω =>
+          ((hvar ω).vectorMeasure.m_iUnion' hfm hfd).tendsto_sum_nat
+  exact hsm.measurable
 
-lemma BoundedVariationOn.measurable_vectorMeasure_of_measurable [SecondCountableTopology E]
+lemma measurable_vectorMeasure_of_measurable [SecondCountableTopology E]
     (hY : ∀ i, Measurable (Y i)) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
-    Measurable fun ω => (hvar ω).vectorMeasure := by
-  exact BoundedVariationOn.measurable_vectorMeasure_of_stronglyMeasurable
-    (fun i ↦ (hY i).stronglyMeasurable) hvar
+    Measurable fun ω => (hvar ω).vectorMeasure :=
+  measurable_vectorMeasure_of_stronglyMeasurable (fun i ↦ (hY i).stronglyMeasurable) hvar
 
-variable {ℱ : Filtration ι mΩ}
-
-lemma BoundedVariationOn.measurable_vectorMeasure_of_adapted [SecondCountableTopology E]
+lemma measurable_vectorMeasure_of_adapted [SecondCountableTopology E]
     (ha : Adapted ℱ Y) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
     Measurable fun ω => (hvar ω).vectorMeasure :=
-  BoundedVariationOn.measurable_vectorMeasure_of_measurable
-    (fun i ↦ ha.measurable (i := i)) hvar
+  measurable_vectorMeasure_of_measurable (fun _ ↦ ha.measurable) hvar
 
-lemma BoundedVariationOn.measurable_vectorMeasure_of_stronglyAdapted
+lemma measurable_vectorMeasure_of_stronglyAdapted
     (ha : StronglyAdapted ℱ Y) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
-    Measurable fun ω => (hvar ω).vectorMeasure := by
-  exact BoundedVariationOn.measurable_vectorMeasure_of_stronglyMeasurable
-    (fun i ↦ ha.stronglyMeasurable (i := i)) hvar
+    Measurable fun ω => (hvar ω).vectorMeasure :=
+  measurable_vectorMeasure_of_stronglyMeasurable (fun _ ↦ ha.stronglyMeasurable) hvar
+
+end BoundedVariationOn

--- a/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
+++ b/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
@@ -316,7 +316,7 @@ lemma measurable_vectorMeasure_of_stronglyMeasurable
 
 lemma measurable_vectorMeasure_of_measurable [SecondCountableTopology E]
     (hY : ∀ i, Measurable (Y i)) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) :
-    Measurable fun ω => (hvar ω).vectorMeasure :=
+    Measurable fun ω => (hvar ω).vectorMeasure :
   measurable_vectorMeasure_of_stronglyMeasurable (fun i ↦ (hY i).stronglyMeasurable) hvar
 
 lemma measurable_vectorMeasure_of_adapted [SecondCountableTopology E]

--- a/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
+++ b/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
@@ -35,25 +35,25 @@ def StieltjesFunction.restrict (f : StieltjesFunction ι) (s : Set ι) : Stieltj
   right_continuous' x :=
     (f.right_continuous x).comp continuousAt_subtype_val.continuousWithinAt fun i => by simp
 
-lemma StieltjesFunction.restrict_Ioc_BddAbove (f : StieltjesFunction ι) :
+lemma StieltjesFunction.bddAbove_restrict_Ioc (f : StieltjesFunction ι) :
     BddAbove (range (f.restrict (Ioc a b))) :=
   ⟨f b, fun y ⟨c, hc⟩ => hc ▸ by simp [restrict, f.mono c.2.2]⟩
 
-lemma StieltjesFunction.restrict_Ioc_BddBelow (f : StieltjesFunction ι) :
+lemma StieltjesFunction.bddBelow_restrict_Ioc (f : StieltjesFunction ι) :
     BddBelow (range (f.restrict (Ioc a b))) :=
   ⟨f a, fun y ⟨c, hc⟩ => hc ▸ by simp [restrict, f.mono c.2.1.le]⟩
 
-lemma StieltjesFunction.restrict_Ioc_iSup (f : StieltjesFunction ι) (hab : a < b) :
-    f b = ⨆ i, (f.restrict (Ioc a b)) i := by
+lemma StieltjesFunction.iSup_restrict_Ioc (f : StieltjesFunction ι) (hab : a < b) :
+    ⨆ i, (f.restrict (Ioc a b)) i = f b := by
   have := nonempty_Ioc_subtype hab
-  refine le_antisymm ?_ (ciSup_le fun i => by simp [restrict, f.mono i.2.2])
+  refine le_antisymm (ciSup_le fun i => by simp [restrict, f.mono i.2.2]) ?_
   have : f b = (f.restrict (Ioc a b)) (⟨b, ⟨hab, refl b⟩⟩ : Ioc a b) := by simp [restrict]
-  grw [this, le_ciSup f.restrict_Ioc_BddAbove]
+  grw [this, le_ciSup f.bddAbove_restrict_Ioc]
 
 variable [OrderTopology ι] [DenselyOrdered ι]
 
-lemma StieltjesFunction.restrict_Ioc_iInf (f : StieltjesFunction ι) (hab : a < b) :
-    f a = ⨅ i, (f.restrict (Ioc a b)) i := by
+lemma StieltjesFunction.iInf_restrict_Ioc (f : StieltjesFunction ι) (hab : a < b) :
+    ⨅ i, (f.restrict (Ioc a b)) i = f a := by
   have := nonempty_Ioc_subtype hab
   have : Tendsto (f.restrict (Ioc a b)) atBot (𝓝 (f a)) := by
     have : Tendsto (Subtype.val : (Ioc a b) → ι) atBot (𝓝[≥] a) := by
@@ -61,12 +61,12 @@ lemma StieltjesFunction.restrict_Ioc_iInf (f : StieltjesFunction ι) (hab : a < 
       apply tendsto_atBot_isGLB (Subtype.mono_coe _)
       simp [Subtype.range_coe_subtype, -mem_Ioc, isGLB_Ioc hab]
     simpa [restrict] using (f.right_continuous a).tendsto.comp this
-  exact tendsto_nhds_unique this (tendsto_atBot_ciInf (f.restrict (Ioc a b)).mono
-    f.restrict_Ioc_BddBelow)
+  exact (tendsto_nhds_unique this (tendsto_atBot_ciInf (f.restrict (Ioc a b)).mono
+    f.bddBelow_restrict_Ioc)).symm
 
 variable [MeasurableSpace ι] [BorelSpace ι] [CompactIccSpace ι] [SecondCountableTopology ι]
 
-private lemma StieltjesFunction.measurable_finite_measure {f : Ω → StieltjesFunction ι}
+private lemma StieltjesFunction.measurable_measure_of_isFiniteMeasure {f : Ω → StieltjesFunction ι}
     [∀ ω, IsFiniteMeasure (f ω).measure] (hmbot : Measurable (fun ω => ⨅ i, f ω i))
     (hmtop : Measurable (fun ω => ⨆ i, f ω i)) (hf : ∀ i, Measurable (f · i)) :
     Measurable fun ω => (f ω).measure := by
@@ -99,7 +99,7 @@ instance {X : Type*} [TopologicalSpace X] [Preorder X] [CompactIccSpace X] {a b 
     intro c d
     exact IsEmbedding.subtypeVal.isCompact_iff.2 (by simp [isCompact_Icc])
 
-lemma StieltjesFunction.restrict_measure_Ioc (f : StieltjesFunction ι) (hab : a < b) :
+lemma StieltjesFunction.measure_restrict_Ioc (f : StieltjesFunction ι) (hab : a < b) :
     (f.restrict (Ioc a b)).measure univ = ENNReal.ofReal (f b - f a) := by
   have := nonempty_Ioc_subtype hab
   have hbot : Tendsto (f.restrict (Ioc a b)) atBot (𝓝 (f a)) := by
@@ -109,25 +109,25 @@ lemma StieltjesFunction.restrict_measure_Ioc (f : StieltjesFunction ι) (hab : a
       simp [Subtype.range_coe_subtype, -mem_Ioc, isGLB_Ioc hab]
     simpa [restrict] using (f.right_continuous a).tendsto.comp this
   have htop : Tendsto (f.restrict (Ioc a b)) atTop (𝓝 (f b)) := by
-    rw [f.restrict_Ioc_iSup hab]
-    convert tendsto_atTop_ciSup (f.restrict (Ioc a b)).mono f.restrict_Ioc_BddAbove
+    rw [← f.iSup_restrict_Ioc hab]
+    convert tendsto_atTop_ciSup (f.restrict (Ioc a b)).mono f.bddAbove_restrict_Ioc
   simp [-mem_Ioc, ← measure_univ (f.restrict (Ioc a b)) hbot htop]
 
 instance StieltjesFunction.isFiniteMeasure_restrict_Ioc {f : StieltjesFunction ι} :
     IsFiniteMeasure (f.restrict (Ioc a b)).measure where
   measure_univ_lt_top := by
     by_cases! hab : a < b
-    · simp [f.restrict_measure_Ioc hab]
+    · simp [f.measure_restrict_Ioc hab]
     · have : (univ : Set (Ioc a b)) = ∅ := by grind
       simp [this, measure_empty]
 
-lemma StieltjesFunction.restrict_eq_measure (f : StieltjesFunction ι) (a b : ι) :
+lemma StieltjesFunction.measure_restrict_eq_comap (f : StieltjesFunction ι) (a b : ι) :
     (f.restrict (Ioc a b)).measure = f.measure.comap Subtype.val := by
   apply ext_of_generate_finite _ _ (isPiSystem_Ioc id id)
   · rintro t ⟨i, j, hl, rfl⟩
     simp [measure_Ioc, (MeasurableEmbedding.subtype_coe measurableSet_Ioc).comap_apply, restrict]
   · by_cases! hab : a < b
-    · simp [-mem_Ioc, f.restrict_measure_Ioc hab,
+    · simp [-mem_Ioc, f.measure_restrict_Ioc hab,
         (MeasurableEmbedding.subtype_coe measurableSet_Ioc).comap_apply]
     · have : (univ : Set (Ioc a b)) = ∅ := by grind
       simp [this, measure_empty]
@@ -159,7 +159,7 @@ theorem StieltjesFunction.measurable_measure {f : Ω → StieltjesFunction ι}
       exact ⟨(hv.1 hij).trans_lt hx.2.1, hx.2.2.trans (hu.1 hij)⟩
     have heq (n : ℕ) (ω : Ω) : (f ω).measure (s ∩ Ioc (v n) (u n)) =
       ((f ω).restrict (Ioc (v n) (u n))).measure (Subtype.val ⁻¹' s) := by
-      simp [restrict_eq_measure, inter_comm,
+      simp [measure_restrict_eq_comap, inter_comm,
         (MeasurableEmbedding.subtype_coe measurableSet_Ioc).comap_apply]
     rw [← inter_univ s, hc, inter_union_distrib_left, inter_iUnion]
     have hd : Disjoint (s ∩ botSet) (⋃ n, s ∩ Ioc (v n) (u n)) := by
@@ -170,17 +170,17 @@ theorem StieltjesFunction.measurable_measure {f : Ω → StieltjesFunction ι}
     simp only [measure_union' hd (hs.inter measurableSet_botSet), hz, hm.measure_iUnion, heq,
       zero_add]
     refine Measurable.iSup fun n => (Measure.measurable_measure.1 ?_) _ (by measurability)
-    refine measurable_finite_measure ?_ ?_ fun i => (by measurability)
+    refine measurable_measure_of_isFiniteMeasure ?_ ?_ fun i => (by measurability)
     <;> by_cases! hvu : v n < u n
-    · simp [fun ω => ((f ω).restrict_Ioc_iInf hvu).symm, hf (v n)]
+    · simp [fun ω => (f ω).iInf_restrict_Ioc hvu, hf (v n)]
     · simp_all
-    · simp [fun ω => ((f ω).restrict_Ioc_iSup hvu).symm, hf (u n)]
+    · simp [fun ω => (f ω).iSup_restrict_Ioc hvu, hf (u n)]
     · simp_all
   · simp [Measure.eq_zero_of_isEmpty]
 
 /-- If `X : ι → Ω → ℝ` is a right continuous and monotone process, then for each `ω : Ω`, `X · ω` is
 a `StieltjesFunction` defined on `ι`. -/
-def StieltjesFunction.rightCont_mono (hcont : ∀ ω, RightContinuous (X · ω))
+def StieltjesFunction.rightContMono (hcont : ∀ ω, RightContinuous (X · ω))
     (hmono : ∀ ω, Monotone (X · ω)) : Ω → StieltjesFunction ι :=
   fun ω => StieltjesFunction.mk (X · ω) (hmono ω)
     (fun i => continuousWithinAt_Ioi_iff_Ici.1 (hcont ω i))
@@ -194,13 +194,13 @@ noncomputable def StieltjesFunction.kernel {f : Ω → StieltjesFunction ι}
 
 /-- If `X : ι → Ω → ℝ` is a right continuous, adapted, and monotone process, then `X` defines a
 kernel that maps each `ω` to `(X · ω).measure`. -/
-noncomputable def StieltjesFunction.kernel_of_rightCont_adapted_mono
+noncomputable def StieltjesFunction.kernelOfRightContAdaptedMono
     (ha : Adapted ℱ X) (hcont : ∀ ω, RightContinuous (X · ω)) (hmono : ∀ ω, Monotone (X · ω)) :
     Kernel Ω ι where
-  toFun ω := (rightCont_mono hcont hmono ω).measure
+  toFun ω := (rightContMono hcont hmono ω).measure
   measurable' := by
     apply measurable_measure
-    simp_all [rightCont_mono, fun i => ha.measurable (i := i)]
+    simp_all [rightContMono, fun i => ha.measurable (i := i)]
 
 end StieltjesKernel
 
@@ -210,8 +210,7 @@ variable {ι : Type*} [MeasurableSpace ι]
 variable [AddCommMonoid E] [TopologicalSpace E] [MeasurableSpace E] [BorelSpace E]
 
 /-- Measurability structure on `VectorMeasure`. -/
-instance instMeasurableSpace :
-    MeasurableSpace (VectorMeasure ι E) :=
+instance : MeasurableSpace (VectorMeasure ι E) :=
   ⨆ (s : Set ι) (_ : MeasurableSet s), (borel E).comap fun μ => μ s
 
 theorem measurable_coe {s : Set ι} (hs : MeasurableSet s) :

--- a/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
+++ b/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
@@ -9,6 +9,7 @@ public import BrownianMotion.Auxiliary.Filtration
 public import BrownianMotion.StochasticIntegral.Cadlag
 public import Mathlib.MeasureTheory.Measure.GiryMonad
 public import Mathlib.MeasureTheory.Measure.Stieltjes
+public import Mathlib.MeasureTheory.VectorMeasure.BoundedVariation
 public import Mathlib.Probability.Kernel.Defs
 
 /-! # The Keneral Associated with a Process
@@ -199,11 +200,11 @@ noncomputable def StieltjesFunction.kernel_of_rightCont_adapted_mono {ℱ : Filt
     apply measurable_measure
     simp_all [rightCont_mono, fun i => ha.measurable (i := i)]
 
-variable {E : Type*} {Y : ι → Ω → E}
+variable {E : Type*} [NormedAddCommGroup E] [CompleteSpace E] {Y : ι → Ω → E}
 
-/-- If `Y : ι → Ω → E` is a right continuous and of bounded variation, then for each `ω : Ω`,
-`Y · ω` is a `StieltjesFunction` defined on `ι`. -/
-def StieltjesFunction.rightCont_boundedVariation (hcont : ∀ ω, RightContinuous (X · ω))
-    (hmono : ∀ ω, Monotone (X · ω)) : Ω → StieltjesFunction ι :=
-  fun ω => StieltjesFunction.mk (X · ω) (hmono ω)
-    (fun i => continuousWithinAt_Ioi_iff_Ici.1 (hcont ω i))
+/-- If `Y : ι → Ω → E` has paths of bounded variation, then for each `ω : Ω`, we get a
+`StieltjesFunction` on `ι` by taking the variation of the right-limit path from a fixed base point
+`i₀`. -/
+noncomputable def StieltjesFunction.rightCont_boundedVariation
+    (i₀ : ι) (hvar : ∀ ω, BoundedVariationOn (Y · ω) univ) : Ω → StieltjesFunction ι :=
+  fun ω => (hvar ω).stieltjesFunctionRightLim i₀

--- a/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
+++ b/BrownianMotion/StochasticIntegral/MonotoneProcess.lean
@@ -29,6 +29,7 @@ variable {X : ι → Ω → ℝ} {Y : ι → Ω → E}
 
 section StieltjesKernel
 
+/-- Restrict domain of a Stieltjes function `f` to a set `s`. -/
 def StieltjesFunction.restrict (f : StieltjesFunction ι) (s : Set ι) : StieltjesFunction s where
   toFun x := f x
   mono' x y hxy := f.mono hxy


### PR DESCRIPTION
A generalization of [StieltjesFunction.measurable_measure](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Probability/Kernel/Disintegration/MeasurableStieltjes.html#StieltjesFunction.measurable_measure) is proved, and I only assume that `∀ i, Measurable fun ω ↦ f ω i`.

Here's an outline of the proof:
1. We first prove that [StieltjesFunction.measurable_measure](https://leanprover-community.github.io/mathlib4_docs/Mathlib/Probability/Kernel/Disintegration/MeasurableStieltjes.html#StieltjesFunction.measurable_measure) is true if `∀ ω, IsFiniteMeasure (f ω).measure`. If `(f ω).measure` is finite, then necessarily `fun ω => (f ω).measure univ = ⨅ i, f ω i - ⨆ i, f ω i` is measurable, so it is natural to assume that the supremum and infimum are measurable functions.
2. As [StieltjesFunction.measure](https://leanprover-community.github.io/mathlib4_docs/Mathlib/MeasureTheory/Measure/Stieltjes.html#StieltjesFunction.measure) is defined for types `ι` such that `[CompactIccSpace ι] [SecondCountableTopology ι]` hold for `ι`. We can write `ι` as an increasing union of `Ioc` intervals (this is not true if the `botSet` is nonempty, but the `botSet` has zero measure). We can then express `(f ω).measure` as the supremum of countably many finite measures. Finally, we can apply `Measurable.iSup` and the result above.

Update on Apr 17:

Add a measurable space structure on `VectorMeasure ι E` and prove lemma [13.7](https://remydegenne.github.io/brownian-motion/blueprint/sect0007.html#lem:BoundedVariationOn.measurable_vectorMeasure). The section of StronglyMeasurableLim are helper lemmas for `BoundedVariationOn.measurable_vectorMeasure_of_stronglyMeasurable`.

This proof is mostly done by codex (of course I golfed and reviewed).

Closes #419