### PR TITLE
CI: bump docgen

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -7,17 +7,17 @@ on:
   pull_request:
     branches:
       - master
-  workflow_dispatch:        # Allow manual triggering of the workflow from the GitHub Actions interface
+  workflow_dispatch: # Allow manual triggering of the workflow from the GitHub Actions interface
 
 # Cancel previous runs if a new commit is pushed to the same PR or branch
 concurrency:
-  group: ${{ github.ref }}  # Group runs by the ref (branch or PR)
-  cancel-in-progress: true  # Cancel any ongoing runs in the same group
+  group: ${{ github.ref }} # Group runs by the ref (branch or PR)
+  cancel-in-progress: true # Cancel any ongoing runs in the same group
 
 # Sets permissions of the GITHUB_TOKEN to allow deployment to GitHub Pages
 permissions:
-  contents: read  # Read access to repository contents
-  pages: write    # Write access to GitHub Pages
+  contents: read # Read access to repository contents
+  pages: write # Write access to GitHub Pages
   id-token: write # Write access to ID tokens
 
 jobs:
@@ -58,7 +58,7 @@ jobs:
           ./build_manual.sh
 
       - name: Compile blueprint and documentation
-        uses: leanprover-community/docgen-action@dac784713171529c96f6d0470f7af30249a02a5d # 2026-02-09
+        uses: leanprover-community/docgen-action@7b5b9a1822650bd45aaeb4182d94bceba2030f89 # 2026-04-14
         with:
           blueprint: true
           homepage: home_page


### PR DESCRIPTION
Bump docgen to latest version so that CI runs successfully again

@RemyDegenne let me know if this is not the way to do it. But the bump worked on my fork so I thought it might help to PR. 