### PR TITLE
Add upstreaming dashboard

### DIFF
--- a/.github/workflows/blueprint.yml
+++ b/.github/workflows/blueprint.yml
@@ -57,6 +57,15 @@ jobs:
           cd verso
           ./build_manual.sh
 
+      - name: Generate upstreaming dashboard
+        uses: leanprover-community/upstreaming-dashboard-action@main
+        with:
+          website-directory: ./home_page
+          project-name: BrownianMotion
+          branch-name: master
+          search-root: BrownianMotion.Auxiliary
+          include-drafts: true
+
       - name: Compile blueprint and documentation
         uses: leanprover-community/docgen-action@7b5b9a1822650bd45aaeb4182d94bceba2030f89 # 2026-04-14
         with:

--- a/home_page/index.md
+++ b/home_page/index.md
@@ -13,3 +13,4 @@ Useful links:
 * [Blueprint as pdf]({{ site.url }}/blueprint.pdf)
 * [Dependency graph]({{ site.url }}/blueprint/dep_graph_document.html)
 * [Doc pages for this repository]({{ site.url }}/docs/)
+* [Upstreaming dashboard]({{ site.url }}/upstreaming)

--- a/home_page/upstreaming.md
+++ b/home_page/upstreaming.md
@@ -1,0 +1,5 @@
+---
+usemathjax: false
+---
+
+{% include _upstreaming_dashboard/dashboard.md %}


### PR DESCRIPTION
Adds the upstreaming-dashboard-action step to blueprint.yml and a home_page/upstreaming.md that includes the generated snippet. search-root: BrownianMotion.Auxiliary.

Tested locally: 18 files in Auxiliary/ come out as ready (no sorry, no internal deps), StandardBorel is listed as easy-to-unlock (2 sorries).

The open-Mathlib-PRs column will stay empty until Auxiliary file paths mirror Mathlib paths (the PNT and Carleson convention). Up to you whether to reorganize for that, the file list is useful either way.