### PR TITLE
Add Doob-Meyer finite-variation uniqueness infrastructure

### DIFF
--- a/BrownianMotion/StochasticIntegral/Cadlag.lean
+++ b/BrownianMotion/StochasticIntegral/Cadlag.lean
@@ -41,6 +41,12 @@ structure IsCadlag [TopologicalSpace E] [Preorder ι] (f : ι → E) : Prop wher
   right_continuous : Function.IsRightContinuous f
   left_limit : ∀ x, ∃ l, Tendsto f (𝓝[<] x) (𝓝 l)
 
+/-- A continuous function is càdlàg. -/
+lemma Continuous.isCadlag [TopologicalSpace E] [PartialOrder ι] {f : ι → E}
+    (hf : Continuous f) : IsCadlag f where
+  right_continuous x := (hf.continuousAt (x := x)).continuousWithinAt
+  left_limit x := ⟨f x, tendsto_nhdsWithin_of_tendsto_nhds (hf.continuousAt (x := x))⟩
+
 section Jump
 
 /-- The set of left jump times of a function. -/
@@ -143,6 +149,15 @@ lemma IsCadlag.const_smul {E : Type*} [SMul ℝ E] [TopologicalSpace E] [Continu
   refine ⟨fun i ↦ ContinuousWithinAt.const_smul (hf.1 i) r, fun i ↦ ?_⟩
   obtain ⟨l, hl⟩ := hf.2 i
   exact ⟨r • l, hl.const_smul r⟩
+
+/-- A continuous map sends càdlàg paths to càdlàg paths. -/
+lemma IsCadlag.continuous_comp {F : Type*} [TopologicalSpace E] [TopologicalSpace F]
+    [PartialOrder ι]
+    {g : E → F} {f : ι → E} (hf : IsCadlag f) (hg : Continuous g) :
+    IsCadlag (g ∘ f) := by
+  refine ⟨Function.IsRightContinuous.continuous_comp hg hf.right_continuous, fun x ↦ ?_⟩
+  obtain ⟨l, hl⟩ := hf.left_limit x
+  exact ⟨g l, (hg.tendsto l).comp hl⟩
 
 /-- A càdlàg function is locally bounded. -/
 lemma isLocallyBounded_of_isCadlag {E : Type*} [LinearOrder ι] [PseudoMetricSpace E]

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -6,11 +6,10 @@ Authors: Rémy Degenne
 module
 
 public import BrownianMotion.StochasticIntegral.ClassD
-public import BrownianMotion.StochasticIntegral.Komlos
-public import BrownianMotion.StochasticIntegral.Predictable
-public import Mathlib.Topology.Order.LiminfLimsup
-
-import Mathlib.Order.CompleteLattice.Group
+public import Mathlib.MeasureTheory.Integral.DominatedConvergence
+public import Mathlib.MeasureTheory.PiSystem
+public import Mathlib.Topology.EMetricSpace.BoundedVariation
+public import Mathlib.Topology.Order.DenselyOrdered
 
 /-! # Doob-Meyer decomposition theorem
 
@@ -18,1231 +17,3733 @@ import Mathlib.Order.CompleteLattice.Group
 
 @[expose] public section
 
-open MeasureTheory Filter Order ProbabilityTheory Convexity
-open scoped NNReal ENNReal Topology
+open MeasureTheory Filter TopologicalSpace
+open scoped ENNReal Uniformity
 
-section DenseMesh
-
-/-- The fixed countable dense set used instead of dyadics, with both endpoints adjoined. -/
-noncomputable def denseSet (ι : Type*) [LE ι] [OrderBot ι] [OrderTop ι]
-    [TopologicalSpace ι] [SecondCountableTopology ι] : Set ι :=
-  (TopologicalSpace.exists_countable_dense ι).choose ∪ ({⊥, ⊤} : Set ι)
-
-lemma denseSet_countable (ι : Type*) [LE ι] [OrderBot ι] [OrderTop ι]
-    [TopologicalSpace ι] [SecondCountableTopology ι] : (denseSet ι).Countable := by
-  have h_dense_countable := (TopologicalSpace.exists_countable_dense ι).choose_spec.1
-  simpa [denseSet] using h_dense_countable.union (by simp : ({⊥, ⊤} : Set ι).Countable)
-
-lemma denseSet_dense (ι : Type*) [LE ι] [OrderBot ι] [OrderTop ι]
-    [TopologicalSpace ι] [SecondCountableTopology ι] : Dense (denseSet ι) :=
-  (TopologicalSpace.exists_countable_dense ι).choose_spec.2.mono (Set.subset_union_left)
-
-/-- A choice of enumeration of the countable dense set used to construct finite meshes. -/
-noncomputable def denseEnum (ι : Type*) [LE ι] [OrderBot ι] [OrderTop ι]
-    [TopologicalSpace ι] [SecondCountableTopology ι] : ℕ → ι :=
-  have : Nonempty (denseSet ι) := ⟨⟨⊥, by simp [denseSet]⟩⟩
-  Subtype.val ∘ (countable_iff_exists_surjective.mp (denseSet_countable ι)).choose
-
-/-- The `n`-th finite mesh: the first `n` points of the dense enumeration, plus endpoints. -/
-noncomputable def mesh (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : Finset ι :=
-  insert ⊥ <| insert ⊤ <| (Finset.range n).image (denseEnum ι)
-
-lemma bot_mem_mesh (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : (⊥ : ι) ∈ mesh ι n := by simp [mesh]
-
-lemma top_mem_mesh (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : (⊤ : ι) ∈ mesh ι n := by simp [mesh]
-
-instance (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : OrderBot (mesh ι n) where
-  bot := ⟨⊥, bot_mem_mesh ι n⟩
-  bot_le _ := bot_le
-
-instance (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : OrderTop (mesh ι n) where
-  top := ⟨⊤, top_mem_mesh ι n⟩
-  le_top _ := le_top
-
-@[simp]
-lemma top_eq_top (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : (⊤ : mesh ι n) = (⊤ : ι) := by rfl
-
-@[simp]
-lemma bot_eq_bot (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : (⊥ : mesh ι n) = (⊥ : ι) := by rfl
-
-noncomputable instance (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : LocallyFiniteOrder (mesh ι n) :=
-  Fintype.toLocallyFiniteOrder
-
-noncomputable instance (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : SuccOrder (mesh ι n) :=
-  LinearLocallyFiniteOrder.succOrder (mesh ι n)
-
-noncomputable instance (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : PredOrder (mesh ι n) :=
-  LinearLocallyFiniteOrder.predOrder (mesh ι n)
-
-noncomputable instance (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : CompleteLinearOrder (mesh ι n) :=
-  Fintype.toCompleteLinearOrder (mesh ι n)
-
-end DenseMesh
-
-section Estimate
-
-/-- The filtration obtained by restricting `𝓕` to a finite dense mesh. -/
-def meshFiltration {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι] [LinearOrder ι]
-    [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (𝓕 : Filtration ι mΩ) (n : ℕ) :
-    Filtration (mesh ι n) mΩ :=
-  𝓕.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
-
-instance sigmaFiniteFiltration_meshFiltration {ι Ω : Type*} [TopologicalSpace ι]
-    [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} {𝓕 : Filtration ι mΩ} [SigmaFiniteFiltration P 𝓕]
-    (n : ℕ) : SigmaFiniteFiltration P (meshFiltration 𝓕 n) := by
-  unfold meshFiltration
-  infer_instance
-
-/-- Predictable part of a discrete process. -/
-noncomputable def predictablePart {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
-    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) :
-    ι → Ω → E :=
-  fun n ↦ ∑ i ∈ Finset.Iio n, P[S (succ i) - S i | 𝓕 i]
-
-/-- The predictable part is additive for integrable processes. -/
-lemma predictablePart_add {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
-    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    [CompleteSpace E] {P : Measure Ω} {S₁ S₂ : ι → Ω → E} (𝓕 : Filtration ι mΩ)
-    (hS₁ : ∀ t, Integrable (S₁ t) P) (hS₂ : ∀ t, Integrable (S₂ t) P) (t : ι) :
-    predictablePart (S₁ + S₂) 𝓕 P t =ᵐ[P] predictablePart S₁ 𝓕 P t + predictablePart S₂ 𝓕 P t := by
-  simp only [_root_.predictablePart, ← Finset.sum_add_distrib]
-  refine eventuallyEq_sum fun i _ => ?_
-  rw [show (S₁ + S₂) (succ i) - (S₁ + S₂) i =
-    (S₁ (succ i) - S₁ i) + (S₂ (succ i) - S₂ i) by simp; abel]
-  exact condExp_add ((hS₁ (succ i)).sub (hS₁ i)) ((hS₂ (succ i)).sub (hS₂ i)) (𝓕 i)
-
-/-- The predictable part of a martingale is zero at every time. -/
-lemma predictablePart_eq_zero_of_martingale {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
-    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    [CompleteSpace E] {P : Measure Ω} {S : ι → Ω → E} {𝓕 : Filtration ι mΩ} (hS : Martingale S 𝓕 P)
-    (t : ι) :
-    predictablePart S 𝓕 P t =ᵐ[P] 0 := by
-  rw [_root_.predictablePart, ← Finset.sum_const_zero]
-  refine eventuallyEq_sum fun i _ => ?_
-  grw [condExp_sub (hS.integrable (succ i)) (hS.integrable i) (𝓕 i),
-    (hS.condExp_ae_eq (le_succ i)).sub (hS.condExp_ae_eq le_rfl), sub_self]
-
-@[simp]
-lemma predictablePart_bot {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrder ι] [OrderBot ι]
-    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    [CompleteSpace E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) :
-    predictablePart S 𝓕 P ⊥ = 0 := by
-  simp [_root_.predictablePart]
-
-/-- The predictable part at a fixed point of a discrete mesh is integrable. -/
-lemma integrable_predictablePart {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
-    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    [CompleteSpace E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω)
-    (t : ι) :
-    Integrable (predictablePart S 𝓕 P t) P := by
-  simp only [_root_.predictablePart]
-  exact integrable_finsetSum' (Finset.Iio t) fun _ _ => integrable_condExp
-
-/-- For a submartingale indexed by a countable type, the predictable part is monotone a.e. -/
-lemma MeasureTheory.Submartingale.monotone_predictablePart_ae {ι Ω E : Type*} [LinearOrder ι]
-    [LocallyFiniteOrderBot ι] [SuccOrder ι] [Countable ι] {mΩ : MeasurableSpace Ω} {P : Measure Ω}
-    [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E] [PartialOrder E]
-    [IsOrderedAddMonoid E] {S : ι → Ω → E} {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P) :
-    ∀ᵐ ω ∂P, Monotone (_root_.predictablePart S 𝓕 P · ω) := by
-  have hnonneg : ∀ᵐ ω ∂P, ∀ i : ι, 0 ≤ P[S (succ i) - S i | 𝓕 i] ω :=
-    ae_all_iff.2 fun i ↦ hs.condExp_sub_nonneg (le_succ i)
-  filter_upwards [hnonneg] with ω hω a b hab
-  simp only [_root_.predictablePart, Finset.sum_apply]
-  exact Finset.sum_le_sum_of_subset_of_nonneg (Finset.Iio_subset_Iio hab) fun i _ _ ↦ hω i
-
-/-- For a submartingale indexed by a countable type, the predictable part is nonnegative a.e. -/
-lemma MeasureTheory.Submartingale.predictablePart_nonneg' {ι Ω E : Type*} [LinearOrder ι]
-    [LocallyFiniteOrder ι] [OrderBot ι] [SuccOrder ι] [Countable ι] {mΩ : MeasurableSpace Ω}
-    {P : Measure Ω} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E] [PartialOrder E]
-    [IsOrderedAddMonoid E] {S : ι → Ω → E} {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P) :
-    ∀ᵐ ω ∂P, ∀ n, 0 ≤ _root_.predictablePart S 𝓕 P n ω := by
-  filter_upwards [hs.monotone_predictablePart_ae] with ω hω n
-  simpa [predictablePart_bot] using hω bot_le
-
-/-- Martingale part of a discrete process. -/
-noncomputable def martingalePart {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
-    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) :
-    ι → Ω → E :=
-  S - predictablePart S 𝓕 P
-
-/-- The martingale part is additive for integrable processes. -/
-lemma martingalePart_add {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
-    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    [CompleteSpace E] {P : Measure Ω} {S₁ S₂ : ι → Ω → E} {𝓕 : Filtration ι mΩ}
-    (hS₁ : ∀ t, Integrable (S₁ t) P) (hS₂ : ∀ t, Integrable (S₂ t) P) (t : ι) :
-    martingalePart (S₁ + S₂) 𝓕 P t =ᵐ[P] martingalePart S₁ 𝓕 P t + martingalePart S₂ 𝓕 P t := by
-  filter_upwards [predictablePart_add 𝓕 hS₁ hS₂ t] with ω hω
-  simp [_root_.martingalePart, hω]
-  abel
-
-/-- The martingale part of a martingale is the martingale itself. -/
-lemma martingalePart_eq_self_of_martingale {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
-    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    [CompleteSpace E] {P : Measure Ω} {S : ι → Ω → E} {𝓕 : Filtration ι mΩ}
-    (hS : Martingale S 𝓕 P) (t : ι) :
-    martingalePart S 𝓕 P t =ᵐ[P] S t := by
-  filter_upwards [predictablePart_eq_zero_of_martingale hS t] with ω hω
-  simp [_root_.martingalePart, hω]
-
-/-- The martingale part of a process is a martingale. -/
-lemma martingale_martingalePart {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
-    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    [CompleteSpace E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) :
-    Martingale (martingalePart S 𝓕 P) 𝓕 P := by
-  sorry
-
-@[simp]
-lemma martingalePart_add_predictablePart {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
-    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    [CompleteSpace E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) :
-    martingalePart S 𝓕 P + predictablePart S 𝓕 P = S := by
-  simp [_root_.martingalePart]
-
-/-- Sequence of terminal values of the predictable part. -/
-noncomputable def predictableSeqTop {ι Ω E : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
-    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E]
-    [NormedSpace ℝ E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω)
-    (n : ℕ) : Ω → E :=
-  predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P ⊤
-
-/-- The terminal values of the predictable parts on each mesh are integrable. -/
-lemma integrable_predictableSeqTop {ι Ω E : Type*} [TopologicalSpace ι]
-    [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
-    (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) :
-    Integrable (predictableSeqTop S 𝓕 P n) P :=
-  integrable_predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P ⊤
-
-/-- The terminal values of the predictable parts of a martingale vanish on every mesh. -/
-lemma predictableSeqTop_eq_zero_of_martingale {ι Ω E : Type*} [TopologicalSpace ι]
-    [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
-    {P : Measure Ω} {S : ι → Ω → E} {𝓕 : Filtration ι mΩ} (hS : Martingale S 𝓕 P)
-    (n : ℕ) :
-    predictableSeqTop S 𝓕 P n =ᵐ[P] 0 := by
-  simp only [predictableSeqTop, meshFiltration]
-  apply predictablePart_eq_zero_of_martingale _ ⊤
-  exact (hS.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n))))
-
-/-- Sequence of terminal values of the martingale part. -/
-noncomputable def martingaleSeqTop {ι Ω E : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
-    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E]
-    [NormedSpace ℝ E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) : Ω → E :=
-  martingalePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P ⊤
-
-/-- The terminal values of the discrete martingale parts are additive. -/
-lemma martingaleSeqTop_add {ι Ω E : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
-    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
-    [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E] {P : Measure Ω}
-    {S₁ S₂ : ι → Ω → E} (𝓕 : Filtration ι mΩ) (hS₁ : ∀ t, Integrable (S₁ t) P)
-    (hS₂ : ∀ t, Integrable (S₂ t) P) (n : ℕ) :
-    martingaleSeqTop (S₁ + S₂) 𝓕 P n =ᵐ[P]
-      martingaleSeqTop S₁ 𝓕 P n + martingaleSeqTop S₂ 𝓕 P n := by
-  simpa [martingaleSeqTop] using martingalePart_add (fun t : mesh ι n ↦ hS₁ t) (fun t ↦ hS₂ t) ⊤
-
-/-- The terminal values of the martingale parts of a martingale are its terminal value on every
-mesh. -/
-lemma martingaleSeqTop_eq_self_of_martingale {ι Ω E : Type*} [TopologicalSpace ι]
-    [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
-    {P : Measure Ω} {S : ι → Ω → E} {𝓕 : Filtration ι mΩ} (hS : Martingale S 𝓕 P)
-    (n : ℕ) :
-    martingaleSeqTop S 𝓕 P n =ᵐ[P] S ⊤ := by
-  simp only [martingaleSeqTop, meshFiltration]
-  apply martingalePart_eq_self_of_martingale _ ⊤
-  exact (hS.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n))))
-
-/-- If `S = 0` a.e., then the martingale part’s terminal value equals the negative of the
-predictable part’s terminal value. -/
-lemma martingaleSeqTop_eq_neg_predictableSeqTop {ι Ω E : Type*} [TopologicalSpace ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    [CompleteSpace E] {S : ι → Ω → E} (𝓕 : Filtration ι mΩ) (hstop : S ⊤ =ᶠ[ae P] 0)
-    (n : ℕ) :
-    martingaleSeqTop S 𝓕 P n =ᶠ[ae P] -predictableSeqTop S 𝓕 P n := by
-  simp only [martingaleSeqTop, _root_.martingalePart, Pi.sub_apply, Function.comp_apply, top_eq_top,
-    predictableSeqTop]
-  grw [neg_eq_zero_sub, hstop]
-
-/-- Apply the optional stopping theorem to get equation 4. Note that `T1 Space` is needed to make
-sure that `mesh ι n` has order topology. -/
-lemma equation4 {ι Ω E : Type*} [TopologicalSpace ι] [T1Space ι] [SecondCountableTopology ι]
-    [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
-    {P : Measure Ω} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E] {S : ι → Ω → E}
-    {𝓕 : Filtration ι mΩ} {n : ℕ} [SigmaFiniteFiltration P 𝓕] (hstop : S ⊤ =ᶠ[ae P] 0)
-    {τ : Ω → WithTop (mesh ι n)} (hτ : ∀ ω, τ ω ≤ WithTop.some (⊤ : mesh ι n))
-    (hτs : IsStoppingTime (meshFiltration 𝓕 n) τ) :
-    stoppedValue (S ∘ Subtype.val) τ =ᵐ[P]
-      -P[(predictableSeqTop S 𝓕 P n) | hτs.measurableSpace] +
-        stoppedValue (predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P) τ := by
-  grw [← condExp_neg, ← martingaleSeqTop_eq_neg_predictableSeqTop 𝓕 hstop]
-  simp only [martingaleSeqTop]
-  grw [← (martingale_martingalePart (S ∘ Subtype.val)
-    (meshFiltration 𝓕 n) P).stoppedValue_ae_eq_condExp_of_le_const hτs hτ,
-    ← stoppedValue.add, _root_.martingalePart_add_predictablePart]
-
-section equation5
-
-/-- The mesh stopping time `τₙ(c)` associated with the predictable part on the `n`-th mesh. -/
-noncomputable def tauMesh {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
-    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ)
-    (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) (c : ℝ) :
-    Ω → WithTop (mesh ι n) :=
-  fun ω ↦ (((hittingBtwn (fun (t : mesh ι n) ω ↦
-    (predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P) (succ t) ω) (Set.Ioi c)
-    ⊥ ⊤ ω) : mesh ι n) : WithTop (mesh ι n))
-
-lemma tauMesh_le_top {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
-    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ)
-    (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) (c : ℝ) (ω : Ω) :
-    tauMesh S 𝓕 P n c ω ≤ (⊤ : mesh ι n) :=
-  WithTop.coe_le_coe.2 (hittingBtwn_le ω)
-
-/-- The stopped valued of the predictable part with respect to `τₙ(c)` is less than or equal to
-`c`. -/
-lemma stoppedValue_predictablePart_tauMesh_le {ι Ω : Type*} [TopologicalSpace ι]
-    [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
-    (S : ι → Ω → ℝ) (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) {c : ℝ} (hc : 0 ≤ c) :
-    stoppedValue (predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P)
-      (tauMesh S 𝓕 P n c) ≤ fun _ ↦ c := by
-  intro ω
-  let A := predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P
-  let τ := hittingBtwn (fun t ω ↦ A (succ t) ω) (Set.Ioi c) ⊥ ⊤ ω
-  change A τ ω ≤ c
-  by_cases hτ_bot : τ = ⊥
-  · simpa [A, hτ_bot] using hc
-  · have hpred_lt : pred τ < τ := (pred_lt_iff_ne_bot).2 hτ_bot
-    have hnot_min : ¬ IsMin τ := by simpa [isMin_iff_eq_bot] using hτ_bot
-    simpa [succ_pred_of_not_isMin hnot_min] using notMem_of_lt_hittingBtwn hpred_lt bot_le
-
-/-- The predictable part is predictable. -/
-lemma isPredictable_predictablePart {ι Ω E : Type*} [LinearOrder ι] [LocallyFiniteOrder ι]
-    [OrderBot ι] [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    [CompleteSpace E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) :
-    IsStronglyPredictable 𝓕 (predictablePart S 𝓕 P) := by
-  sorry
-
-/-- At time `t`, the predictable part is strongly measurable with respect to the previous
-σ-algebra. -/
-lemma stronglyMeasurable_pred_predictablePart {ι Ω E : Type*} [LinearOrder ι]
-    [LocallyFiniteOrderBot ι] [PredOrder ι] [SuccOrder ι] {mΩ : MeasurableSpace Ω}
-    [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ)
-    (P : Measure Ω) (t : ι) :
-    StronglyMeasurable[𝓕 (pred t)] (predictablePart S 𝓕 P t) :=
-  Finset.stronglyMeasurable_sum _ fun _ hi =>
-    stronglyMeasurable_condExp.mono (𝓕.mono (le_pred_of_lt (Finset.mem_Iio.1 hi)))
-
-/-- At time `t`, the predictable part is strongly measurable with respect to the previous
-σ-algebra. -/
-lemma stronglyMeasurable_predictablePart {ι Ω E : Type*} [LinearOrder ι] [LocallyFiniteOrderBot ι]
-    [PredOrder ι] [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E]
-    [NormedSpace ℝ E] [CompleteSpace E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ)
-    (P : Measure Ω) (t : ι) :
-    StronglyMeasurable[𝓕 t] (predictablePart S 𝓕 P t) :=
-  (stronglyMeasurable_pred_predictablePart S 𝓕 P t).mono (𝓕.mono (pred_le _))
-
-/-- The predictable part of a process is strongly adapted. -/
-lemma stronglyAdapted_predictablePart {ι Ω E : Type*} [LinearOrder ι] [LocallyFiniteOrderBot ι]
-    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    [CompleteSpace E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) :
-    StronglyAdapted 𝓕 (predictablePart S 𝓕 P) :=
-  fun _ => Finset.stronglyMeasurable_sum _ fun _ hi =>
-    stronglyMeasurable_condExp.mono (𝓕.mono (Finset.mem_Iio.1 hi).le)
-
-/-- The predictable part of a process is strongly adapted. -/
-lemma stronglyAdapted_predictablePart' {ι Ω E : Type*} [LinearOrder ι] [LocallyFiniteOrderBot ι]
-    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
-    [CompleteSpace E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) :
-    StronglyAdapted 𝓕 (fun t ω ↦ predictablePart S 𝓕 P (succ t) ω) :=
-  fun _ => Finset.stronglyMeasurable_sum _ fun _ hi ↦
-    stronglyMeasurable_condExp.mono (𝓕.mono (le_of_lt_succ (Finset.mem_Iio.1 hi)))
-
-/-- `τₙ(c)` is indeed a stopping time. -/
-lemma isStoppingTime_tauMesh {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
-    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ)
-    (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) (c : ℝ) :
-    IsStoppingTime (meshFiltration 𝓕 n) (tauMesh S 𝓕 P n c) :=
-  (stronglyAdapted_predictablePart'
-    (S ∘ Subtype.val) (meshFiltration 𝓕 n) P).adapted.isStoppingTime_hittingBtwn measurableSet_Ioi
-
-/-- Combine equation 4 and `stoppedValue_predictablePart_tauMesh_le` to get this inequality. -/
-lemma stoppedValue_le_neg_condExp_predictableSeqTop_add_const {ι Ω : Type*} [TopologicalSpace ι]
-    [T1Space ι] [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι]
-    [OrderTop ι] {mΩ : MeasurableSpace Ω} {P : Measure Ω} {S : ι → Ω → ℝ} (hstop : S ⊤ =ᶠ[ae P] 0)
-    (𝓕 : Filtration ι mΩ) (n : ℕ) [SigmaFiniteFiltration P 𝓕] {c : ℝ} (hc : 0 ≤ c) :
-    stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n c) ≤ᵐ[P]
-      -P[predictableSeqTop S 𝓕 P n | (isStoppingTime_tauMesh S 𝓕 P n c).measurableSpace] +
-      (fun _ => c) := by
-  filter_upwards [equation4 hstop (tauMesh_le_top S 𝓕 P n c) (isStoppingTime_tauMesh S 𝓕 P n c)]
-    with ω heqω
-  rw [heqω]
-  exact add_le_add_right (stoppedValue_predictablePart_tauMesh_le S 𝓕 P n hc ω) _
-
-/-- `{τₙ(c) < 1} = {c < Aⁿ₁}`. -/
-lemma MeasureTheory.Submartingale.tauMesh_lt_top_eq_lt_predictableSeqTop {ι Ω : Type*}
-    [TopologicalSpace ι] [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} {S : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ}
-    (hs : Submartingale S 𝓕 P) (n : ℕ) {c : ℝ} (hc : 0 ≤ c) :
-    {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)} =ᵐ[P] {ω | c < predictableSeqTop S 𝓕 P n ω} := by
-  refine eventuallyEq_set.2 ?_
-  have hs_mesh : Submartingale (S ∘ Subtype.val) (meshFiltration 𝓕 n) P :=
-    hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
-  filter_upwards [hs_mesh.monotone_predictablePart_ae] with ω hmono
-  let A : mesh ι n → Ω → ℝ := _root_.predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P
-  by_cases htop_bot : (⊤ : mesh ι n) = ⊥
-  · simp [tauMesh, predictableSeqTop, htop_bot, hc]
-  · refine ⟨fun hω => ?_, fun htop_gt => ?_⟩
-    · simp_all only [tauMesh, WithTop.coe_lt_coe, Std.le_refl, hittingBtwn_lt_iff, Set.Ico_bot,
-        Set.mem_Iio, Set.mem_Ioi, predictableSeqTop]
-      obtain ⟨j, _, hj⟩ := hω
-      exact lt_of_lt_of_le hj (hmono le_top)
-    · have hnot_min : ¬ IsMin (⊤ : mesh ι n) := by simpa [isMin_iff_eq_bot] using htop_bot
-      have hmem : A (succ (pred ⊤)) ω ∈ Set.Ioi c := by
-        simpa [A, succ_pred_of_not_isMin hnot_min, predictableSeqTop] using htop_gt
-      have hhit : hittingBtwn (fun (t : mesh ι n) ω ↦ A (succ t) ω) (Set.Ioi c) ⊥ ⊤ ω < ⊤ := by
-        rw [hittingBtwn_lt_iff ⊤ le_rfl]
-        exact ⟨pred ⊤, ⟨bot_le, (pred_lt_iff_ne_bot).2 htop_bot⟩, hmem⟩
-      simpa [tauMesh, A] using hhit
-
-/-- The constant `c` is integrable on the event where `τₙ(c)` hits before the top element. -/
-lemma MeasureTheory.Submartingale.integrableOn_const_tauMesh_lt_top {ι Ω : Type*}
-    [TopologicalSpace ι] [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} {S : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ}
-    (hs : Submartingale S 𝓕 P) (n : ℕ) {c : ℝ} (hc : 0 ≤ c) :
-    IntegrableOn (fun _ : Ω => c) {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)} P := by
-  by_cases! hc0 : c = 0
-  · simp [hc0]
-  · refine integrableOn_const (LT.lt.ne ?_)
-    rw [measure_congr (hs.tauMesh_lt_top_eq_lt_predictableSeqTop n hc)]
-    exact (integrable_predictableSeqTop S 𝓕 P n).measure_gt_lt_top (lt_of_le_of_ne hc hc0.symm)
-
-/-- Stopping `S` at the bounded mesh time `τₙ(c)` preserves integrability. -/
-lemma MeasureTheory.Submartingale.integrable_stoppedValue_tauMesh {ι Ω : Type*} [TopologicalSpace ι]
-    [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
-    {P : Measure Ω} {S : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P) (n : ℕ)
-    (c : ℝ) :
-    Integrable (stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n c)) P :=
-  integrable_stoppedValue (mesh ι n) (isStoppingTime_tauMesh S 𝓕 P n c)
-    (hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))).integrable
-    (tauMesh_le_top S 𝓕 P n c)
-
-/-- The first estimate before equation 5. -/
-lemma first_estimate {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι] [SecondCountableTopology ι]
-    [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
-    {P : Measure Ω} {S : ι → Ω → ℝ} (hstop : S ⊤ =ᶠ[ae P] 0) (𝓕 : Filtration ι mΩ) (n : ℕ)
-    [SigmaFiniteFiltration P 𝓕] {c : ℝ} (hc : 0 ≤ c) (hs : Submartingale S 𝓕 P) :
-    ∫ ω in {ω | c < predictableSeqTop S 𝓕 P n ω}, predictableSeqTop S 𝓕 P n ω ∂P ≤
-      c * P.real {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)} -
-        ∫ ω in {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)},
-          stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n c) ω ∂P :=
-  calc
-    _ = ∫ ω in {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)},
-          P[predictableSeqTop S 𝓕 P n |
-            (isStoppingTime_tauMesh S 𝓕 P n c).measurableSpace] ω ∂P := by
-      rw [setIntegral_condExp,
-        setIntegral_congr_set (hs.tauMesh_lt_top_eq_lt_predictableSeqTop n hc)]
-      · exact integrable_predictableSeqTop S 𝓕 P n
-      · exact (isStoppingTime_tauMesh S 𝓕 P n c).measurableSet_lt' ⊤
-    _ ≤ ∫ ω in {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)},
-        (c - stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n c) ω) ∂P := by
-      refine setIntegral_mono_ae integrable_condExp.integrableOn
-        ((hs.integrableOn_const_tauMesh_lt_top n hc).sub
-          (hs.integrable_stoppedValue_tauMesh n c).integrableOn) ?_
-      filter_upwards [stoppedValue_le_neg_condExp_predictableSeqTop_add_const hstop 𝓕 n hc]
-        with ω hω
-      simp at hω
-      linarith [hω]
-    _ = _ := by
-      rw [integral_sub (hs.integrableOn_const_tauMesh_lt_top n hc)
-        (hs.integrable_stoppedValue_tauMesh n c).integrableOn, setIntegral_const]
-      ring
-
-/-- If `a ≤ b`, then `{τₙ(b) < 1} ⊆ {τₙ(a) < 1}`. -/
-lemma tauMesh_lt_top_subset_of_lt {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
-    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ)
-    (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) {a b : ℝ} (hab : a ≤ b) :
-    {ω | tauMesh S 𝓕 P n b ω < (⊤ : mesh ι n)} ⊆ {ω | tauMesh S 𝓕 P n a ω < (⊤ : mesh ι n)} := by
-  simp_all only [tauMesh, WithTop.coe_lt_coe, Set.setOf_subset_setOf]
-  exact fun ω hω => (hittingBtwn_anti ((fun t ω ↦ _root_.predictablePart (S ∘ Subtype.val)
-    (meshFiltration 𝓕 n) P (succ t) ω)) ⊥ ⊤ (antitone_Ioi hab) ω).trans_lt hω
-
-/-- Stopping the predictable part at the bounded mesh time `τₙ(c)` preserves integrability. -/
-lemma integrable_stoppedValue_predictablePart_tauMesh {ι Ω : Type*} [TopologicalSpace ι]
-    [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ) (𝓕 : Filtration ι mΩ)
-    (P : Measure Ω) (n : ℕ) (c : ℝ) :
-    Integrable (stoppedValue (predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P)
-      (tauMesh S 𝓕 P n c)) P :=
-  integrable_stoppedValue (mesh ι n) (isStoppingTime_tauMesh S 𝓕 P n c)
-    (integrable_predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P)
-    (tauMesh_le_top S 𝓕 P n c)
-
-/-- The second estimate before equation 5. -/
-lemma second_estimate {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} {S : ι → Ω → ℝ} (hstop : S ⊤ =ᶠ[ae P] 0)
-    (𝓕 : Filtration ι mΩ) (n : ℕ) [SigmaFiniteFiltration P 𝓕] {c : ℝ} (hc : 0 ≤ c)
-    (hs : Submartingale S 𝓕 P) :
-    c / 2 * P.real {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)} ≤
-      - ∫ ω in {ω | tauMesh S 𝓕 P n (c / 2) ω < (⊤ : mesh ι n)},
-        stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n (c / 2)) ω ∂P :=
-  have hpred_int := integrable_predictableSeqTop S 𝓕 P n
-  have hstopped_pred_int := integrable_stoppedValue_predictablePart_tauMesh S 𝓕 P n (c / 2)
-  calc
-    _ = ∫ ω in {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)}, c / 2 ∂P := by simp [mul_comm]
-    _ ≤ ∫ ω in {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)},
-          (predictableSeqTop S 𝓕 P n ω -
-            stoppedValue (predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P)
-              (tauMesh S 𝓕 P n (c / 2)) ω) ∂P := by
-      refine setIntegral_mono_on_ae ?_ ?_ ?_ ?_
-      · exact (hs.integrableOn_const_tauMesh_lt_top n hc).div_const 2
-      · exact (hpred_int.sub hstopped_pred_int).integrableOn
-      · refine (((isStoppingTime_tauMesh S 𝓕 P n c).measurableSet _).1 ?_).1
-        exact (isStoppingTime_tauMesh S 𝓕 P n c).measurableSet_lt' ⊤
-      · filter_upwards [hs.tauMesh_lt_top_eq_lt_predictableSeqTop n hc] with ω hτ hω
-        have : c < predictableSeqTop S 𝓕 P n ω := hτ.mp hω
-        have := stoppedValue_predictablePart_tauMesh_le S 𝓕 P n (by linarith : 0 ≤ c / 2) ω
-        linarith
-    _ ≤ ∫ ω in {ω | tauMesh S 𝓕 P n (c / 2) ω < (⊤ : mesh ι n)},
-          (predictableSeqTop S 𝓕 P n ω -
-            stoppedValue (predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P)
-              (tauMesh S 𝓕 P n (c / 2)) ω) ∂P := by
-      refine setIntegral_mono_set ?_ ?_ ?_
-      · exact (hpred_int.sub hstopped_pred_int).integrableOn
-      · have hs_mesh : Submartingale (S ∘ Subtype.val) (meshFiltration 𝓕 n) P :=
-          hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
-        filter_upwards [ae_restrict_le hs_mesh.monotone_predictablePart_ae] with ω hmono
-        simpa [predictableSeqTop, stoppedValue] using hmono le_top
-      · exact (tauMesh_lt_top_subset_of_lt S 𝓕 P n (by linarith)).eventuallyLE
-    _ = ∫ ω in {ω | tauMesh S 𝓕 P n (c / 2) ω < (⊤ : mesh ι n)}, predictableSeqTop S 𝓕 P n ω ∂P -
-          ∫ ω in {ω | tauMesh S 𝓕 P n (c / 2) ω < (⊤ : mesh ι n)},
-            stoppedValue (predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P)
-              (tauMesh S 𝓕 P n (c / 2)) ω ∂P := by
-      rw [integral_sub]
-      · exact hpred_int.integrableOn
-      · exact hstopped_pred_int.integrableOn
-    _ = ∫ ω in {ω | tauMesh S 𝓕 P n (c / 2) ω < (⊤ : mesh ι n)},
-          P[predictableSeqTop S 𝓕 P n |
-            (isStoppingTime_tauMesh S 𝓕 P n (c / 2)).measurableSpace] ω ∂P -
-              ∫ ω in {ω | tauMesh S 𝓕 P n (c / 2) ω < (⊤ : mesh ι n)},
-                stoppedValue (predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P)
-                  (tauMesh S 𝓕 P n (c / 2)) ω ∂P := by
-      rw [setIntegral_condExp]
-      · exact hpred_int
-      · exact (isStoppingTime_tauMesh S 𝓕 P n (c / 2)).measurableSet_lt' ⊤
-    _ = _ := by
-      rw [← integral_sub integrable_condExp.restrict hstopped_pred_int.integrableOn, ← integral_neg]
-      · refine setIntegral_congr_ae ?_ ?_
-        · refine (((isStoppingTime_tauMesh S 𝓕 P n (c / 2)).measurableSet _).1 ?_).1
-          exact (isStoppingTime_tauMesh S 𝓕 P n (c / 2)).measurableSet_lt' ⊤
-        · filter_upwards [equation4 hstop (tauMesh_le_top S 𝓕 P n (c / 2))
-            (isStoppingTime_tauMesh S 𝓕 P n (c / 2))] with ω hω _
-          simp at hω
-          linarith [hω]
-
-lemma equation5 {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι] [SecondCountableTopology ι]
-    [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
-    {P : Measure Ω} {S : ι → Ω → ℝ} (hstop : S ⊤ =ᶠ[ae P] 0)
-    (𝓕 : Filtration ι mΩ) (n : ℕ) [SigmaFiniteFiltration P 𝓕] {c : ℝ} (hc : 0 ≤ c)
-    (hs : Submartingale S 𝓕 P) :
-    ∫ ω in {ω | c < predictableSeqTop S 𝓕 P n ω}, predictableSeqTop S 𝓕 P n ω ∂P ≤
-      -2 * ∫ ω in {ω | tauMesh S 𝓕 P n (c / 2) ω < (⊤ : mesh ι n)},
-        stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n (c / 2)) ω ∂P -
-          ∫ ω in {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)},
-            stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n c) ω ∂P := by
-  grw [first_estimate hstop 𝓕 n hc hs]
-  linear_combination 2 * (second_estimate hstop 𝓕 n hc hs)
-
-lemma equation5' {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι] [SecondCountableTopology ι]
-    [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
-    {P : Measure Ω} {S : ι → Ω → ℝ} (hstop : S ⊤ =ᶠ[ae P] 0)
-    (𝓕 : Filtration ι mΩ) (n : ℕ) [SigmaFiniteFiltration P 𝓕] {c : ℝ} (hc : 0 ≤ c)
-    (hs : Submartingale S 𝓕 P) :
-    ∫ ω in {ω | c < predictableSeqTop S 𝓕 P n ω}, predictableSeqTop S 𝓕 P n ω ∂P ≤
-      ∫ ω in {ω | tauMesh S 𝓕 P n (c / 2) ω < (⊤ : mesh ι n)}, (-2) *
-        stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n (c / 2)) ω ∂P +
-          ∫ ω in {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)},
-            -stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n c) ω ∂P := by
-  grw [equation5 hstop 𝓕 n hc hs, ← integral_const_mul_of_integrable, sub_eq_add_neg,
-    ← integral_neg]
-  exact (hs.integrable_stoppedValue_tauMesh n (c / 2)).restrict
-
-end equation5
-
-end Estimate
-
-section UniformIntegrability
-
-/-- Lift the mesh stopping time `τₙ(c)` to a stopping time on the original index set. -/
-noncomputable def tauMeshLift {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
-    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ)
-    (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) (c : ℝ) : Ω → WithTop ι :=
-  fun ω => ((tauMesh S 𝓕 P n c ω).untopA : mesh ι n)
-
-@[simp]
-lemma tauMesh_ne_top {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
-    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ)
-    (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) (c : ℝ) (ω : Ω) :
-    tauMesh S 𝓕 P n c ω ≠ ⊤ := by
-  simp [tauMesh]
-
-@[simp]
-lemma tauMeshLift_ne_top {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
-    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ)
-    (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) (c : ℝ) (ω : Ω) :
-    tauMeshLift S 𝓕 P n c ω ≠ ⊤ := by
-  simp [tauMeshLift]
-
-lemma stoppedValue_tauMeshLift {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
-    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ)
-    (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) (c : ℝ) :
-    stoppedValue S (tauMeshLift S 𝓕 P n c) =
-      stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n c) := by
-  ext; simp [stoppedValue, tauMeshLift]
-
-/-- We still get a stopping time after the lifting. -/
-lemma isStoppingTime_tauMeshLift {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
-    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ)
-    (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) (c : ℝ) :
-    IsStoppingTime 𝓕 (tauMeshLift S 𝓕 P n c) := by
-  sorry
-
-/-- Used in estimating the size of the set `{τₙ(b) < 1}`. -/
-lemma integral_predictableSeqTop_eq_neg_integral_bot {ι Ω : Type*} [TopologicalSpace ι]
-    [T1Space ι] [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι]
-    [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} {P : Measure Ω} {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} [SigmaFiniteFiltration P 𝓕] (hstop : S ⊤ =ᵐ[P] 0) (n : ℕ) :
-    ∫ ω, predictableSeqTop S 𝓕 P n ω ∂P = - ∫ ω, S ⊥ ω ∂P := calc
-  _ = - ∫ ω, -predictableSeqTop S 𝓕 P n ω ∂P := by simp [integral_neg]
-  _ = - ∫ ω, martingaleSeqTop S 𝓕 P n ω ∂P := by
-    simp [integral_congr_ae (martingaleSeqTop_eq_neg_predictableSeqTop 𝓕 hstop n)]
-  _ = - ∫ ω, S ⊥ ω ∂P := by
-    rw [martingaleSeqTop, ← setIntegral_univ,
-      ← (martingale_martingalePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P).setIntegral_eq
-      (bot_le (a := ⊤)) MeasurableSet.univ]
-    simp [_root_.martingalePart]
-
-/-- Estimate for the hitting event `{τₙ(c) < 1}`. -/
-lemma measure_tauMesh_lt_top_le {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} {S : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ}
-    [SigmaFiniteFiltration P 𝓕] (hs : Submartingale S 𝓕 P) (hstop : S ⊤ =ᵐ[P] 0) (n : ℕ) {c : ℝ}
-    (hc : 0 < c) :
-    P {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)} ≤
-      ENNReal.ofReal (- ∫ ω, S ⊥ ω ∂P) / ENNReal.ofReal c := calc
-  P {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)} = P {ω | c < predictableSeqTop S 𝓕 P n ω} :=
-    measure_congr (hs.tauMesh_lt_top_eq_lt_predictableSeqTop n hc.le)
-  _ ≤ P {ω | ENNReal.ofReal c ≤ ENNReal.ofReal (predictableSeqTop S 𝓕 P n ω)} :=
-    measure_mono fun ω hω => ENNReal.ofReal_le_ofReal hω.le
-  _ ≤ (∫⁻ ω, ENNReal.ofReal (predictableSeqTop S 𝓕 P n ω) ∂P) / ENNReal.ofReal c :=
-    meas_ge_le_lintegral_div
-      ((integrable_predictableSeqTop S 𝓕 P n).aestronglyMeasurable.aemeasurable.ennreal_ofReal)
-      (ENNReal.ofReal_ne_zero_iff.2 hc) ENNReal.ofReal_ne_top
-  _ = ENNReal.ofReal (∫ ω, predictableSeqTop S 𝓕 P n ω ∂P) / ENNReal.ofReal c := by
-    rw [ofReal_integral_eq_lintegral_ofReal (integrable_predictableSeqTop S 𝓕 P n)]
-    have hs_mesh : Submartingale (S ∘ Subtype.val) (meshFiltration 𝓕 n) P :=
-      hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
-    filter_upwards [hs_mesh.predictablePart_nonneg'] with ω hω using hω ⊤
-  _ = ENNReal.ofReal (- ∫ ω, S ⊥ ω ∂P) / ENNReal.ofReal c := by
-    rw [integral_predictableSeqTop_eq_neg_integral_bot hstop n]
-
-/-- The terminal values of the predictable parts are uniformly integrable. -/
-lemma uniformIntegrable_predictableSeqTop {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P)
-    (hd : UniformIntegrable (fun (τ : {T : Ω → WithTop ι | IsStoppingTime 𝓕 T ∧ ∀ ω, T ω ≠ ⊤}) ↦
-      stoppedValue S τ.1) 1 P) (hstop : S ⊤ =ᵐ[P] 0) (ht : ∀ t, S t ≤ᵐ[P] 0) :
-    UniformIntegrable (predictableSeqTop S 𝓕 P) 1 P := by
-  refine (uniformIntegrable_iff_tendsto_nnReal_iSup_setIntegral_of_nonneg (fun n => ?_)
-    (fun n => ?_) (fun n => ?_)).2 ?_
-  · exact (stronglyAdapted_predictablePart
-      (S ∘ Subtype.val) (meshFiltration 𝓕 n) P).stronglyMeasurable.aestronglyMeasurable
-  · have hs_mesh : Submartingale (S ∘ Subtype.val) (meshFiltration 𝓕 n) P :=
-      hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
-    filter_upwards [hs_mesh.predictablePart_nonneg'] with ω hω using hω ⊤
-  · exact integrable_predictableSeqTop S 𝓕 P n
-  · refine tendsto_of_tendsto_of_tendsto_of_le_of_le' (a := 0) (h := fun c : ℝ≥0 ↦
-      (⨆ k, ENNReal.ofReal (∫ ω in {ω | tauMesh S 𝓕 P k (c / 2) ω < (⊤ : mesh ι k)}, (-2) *
-        stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P k (c / 2)) ω ∂P)) +
-          ⨆ k, ENNReal.ofReal (∫ ω in {ω | tauMesh S 𝓕 P k c ω < (⊤ : mesh ι k)},
-            -stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P k c) ω ∂P)) tendsto_const_nhds ?_ ?_ ?_
-    · rw [← zero_add (0 : ℝ≥0∞)]
-      apply Tendsto.add
-      · -- use `hd` to prove the following two sorries
-        sorry
-      · sorry
-    · filter_upwards with c using by positivity
-    · filter_upwards with c
-      calc
-        ⨆ k, ENNReal.ofReal (∫ ω in {ω | c < predictableSeqTop S 𝓕 P k ω},
-          predictableSeqTop S 𝓕 P k ω ∂P) ≤ ⨆ k, ENNReal.ofReal
-            (∫ ω in {ω | tauMesh S 𝓕 P k (c / 2) ω < (⊤ : mesh ι k)}, (-2) *
-              stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P k (c / 2)) ω ∂P +
-                ∫ ω in {ω | tauMesh S 𝓕 P k c ω < (⊤ : mesh ι k)},
-                  -stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P k c) ω ∂P) := by
-          gcongr with k
-          exact equation5' hstop 𝓕 k c.2 hs
-        _ = ⨆ k, ENNReal.ofReal
-            (∫ ω in {ω | tauMesh S 𝓕 P k (c / 2) ω < (⊤ : mesh ι k)}, (-2) *
-              stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P k (c / 2)) ω ∂P) +
-                ENNReal.ofReal (∫ ω in {ω | tauMesh S 𝓕 P k c ω < (⊤ : mesh ι k)},
-                  -stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P k c) ω ∂P) := by
-          congr with k
-          have hmesh : ∀ᵐ ω ∂P, ∀ t : mesh ι k, S t ω ≤ 0 := ae_all_iff.2 fun t => ht t
-          apply ENNReal.ofReal_add
-          all_goals
-            apply integral_nonneg_of_ae
-            simp only [stoppedValue, Function.comp_apply]
-          · filter_upwards [ae_restrict_of_ae hmesh] with ω hω
-            exact mul_nonneg_of_nonpos_of_nonpos (by simp) (hω ((tauMesh S 𝓕 P k (c / 2) ω).untopA))
-          · filter_upwards [ae_restrict_of_ae hmesh] with ω hω
-            exact neg_nonneg.2 (hω ((tauMesh S 𝓕 P k c ω).untopA))
-        _ ≤ _ := iSup_add_le _ _
-
-/-- As the terminal values of predictable parts are uniformly integrable, the terminal values of the
-martingale parts are uniformly integrable. -/
-lemma uniformIntegrable_martingaleSeqTopAux {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P)
-    (hd : UniformIntegrable (fun (τ : {T : Ω → WithTop ι | IsStoppingTime 𝓕 T ∧ ∀ ω, T ω ≠ ⊤}) ↦
-      stoppedValue S τ.1) 1 P) (hstop : S ⊤ =ᵐ[P] 0) (ht : ∀ t, S t ≤ᵐ[P] 0) :
-    UniformIntegrable (martingaleSeqTop S 𝓕 P) 1 P := by
-  rw [uniformIntegrable_congr_ae (martingaleSeqTop_eq_neg_predictableSeqTop 𝓕 hstop)]
-  exact (uniformIntegrable_predictableSeqTop hs hd hstop ht).neg
-
-/-- Prove uniform integrability without the assumption `S ⊤ =ᵐ[P] 0` and `∀ t, S t ≤ᵐ[P] 0`. -/
-lemma uniformIntegrable_martingaleSeqTop {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ}
-    (hd : UniformIntegrable (fun (τ : {T : Ω → WithTop ι | IsStoppingTime 𝓕 T ∧ ∀ ω, T ω ≠ ⊤}) ↦
-      stoppedValue S τ.1) 1 P) (hs : Submartingale S 𝓕 P) :
-    UniformIntegrable (martingaleSeqTop S 𝓕 P) 1 P := by
-  have h0 : S = S - (fun i => P[S ⊤ | 𝓕 i]) + (fun i => P[S ⊤ | 𝓕 i]) := by simp
-  have h1 (i) : Integrable ((S - fun t => P[S ⊤ | 𝓕 t]) i) P :=
-    (hs.integrable i).sub integrable_condExp
-  rw [h0, uniformIntegrable_congr_ae (martingaleSeqTop_add 𝓕 h1 (fun i => integrable_condExp))]
-  refine UniformIntegrable.add (refl 1) ?_ ?_
-  · refine uniformIntegrable_martingaleSeqTopAux ?_ ?_ ?_ fun i => ?_
-    · exact hs.sub_martingale (martingale_condExp _ _ _)
-    · sorry
-    · simp [condExp_of_stronglyMeasurable _ (hs.stronglyMeasurable ⊤) (hs.integrable ⊤)]
-    · filter_upwards [hs.ae_le_condExp (i := i) le_top] with ω
-      simp
-  · rw [uniformIntegrable_congr_ae
-      (martingaleSeqTop_eq_self_of_martingale (martingale_condExp (S ⊤) 𝓕 P))]
-    exact Integrable.uniformIntegrable_condExp (hs.integrable ⊤) (fun _ => 𝓕.le' ⊤)
-
-end UniformIntegrability
-
--- We define the martingale part in the doob-meyer decomposition.
-section MartingalePartLimDef
-
-/-- Show that the terminals values of some convex combinations of the martingale parts converge. -/
-lemma exists_martingalPart_lim {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) :
-    ∃ M : Ω → ℝ, ∃ a : ℕ → StdSimplex ℝ ℕ,
-      Tendsto (fun n ↦ eLpNorm ((a n).weights.sum (fun m r ↦ r • martingaleSeqTop S 𝓕 P m) - M) 1 P)
-      atTop (𝓝 0) := by
-  sorry
-
-/-- This is the martingalePart in the doob-meyer decomposition of a submartingale. -/
-noncomputable def martingalePartLim {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (i : ι) :=
-  P[(exists_martingalPart_lim hd hs).choose | 𝓕 i]
-
-lemma martingale_martingalePartLim {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) :
-    Martingale (martingalePartLim hd hs) 𝓕 P :=
-  martingale_condExp (exists_martingalPart_lim hd hs).choose 𝓕 P
-
-/-- This is the weight associated with the martingale part. -/
-noncomputable def weight {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) : ℕ → StdSimplex ℝ ℕ :=
-  (exists_martingalPart_lim hd hs).choose_spec.choose
-
-/-- The extension of the discrete martingale part `M^n`. -/
-noncomputable def martingaleSeqStep {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
-    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (P : Measure Ω)
-    (S : ι → Ω → ℝ) (𝓕 : Filtration ι mΩ) (n : ℕ) (i : ι) :=
-  P[martingaleSeqTop S 𝓕 P n | 𝓕 i]
-
-/-- The convexly averaged mesh step-extension `ℳ^n` of the martingale parts. -/
-noncomputable def martingaleConvexStep {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) : ι → Ω → ℝ :=
-  (weight hd hs n).weights.sum fun m r ↦ r • martingaleSeqStep P S 𝓕 m
-
-/-- `L¹` norm convergence of `martingaleConvexStep`, proved by using conditional Jensen. -/
-lemma martingaleConvexStep_eLpNorm_tendsto {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) (t : ι) :
-    Tendsto (fun n ↦ eLpNorm
-      (martingaleConvexStep hd hs n t - martingalePartLim hd hs t) 1 P) atTop (𝓝 0) := by
-  sorry
-
-end MartingalePartLimDef
-
--- We define the predictable part in the doob-meyer decomposition.
-section PredictablePartLimDef
-
-/-- The half-open mesh interval ending at `t`, with left endpoint the predecessor of `t` in the
-finite mesh. -/
-def meshPredIoc {ι : Type*} [LinearOrder ι] [OrderBot ι] [OrderTop ι] [TopologicalSpace ι]
-    [SecondCountableTopology ι] (n : ℕ) (t : mesh ι n) : Set ι :=
-  Set.Ioc ((pred t : mesh ι n) : ι) (t : ι)
-
-/-- The mesh step-extension of the discrete predictable part `A^n`. -/
-noncomputable def predictableSeqStep {ι Ω : Type*} [TopologicalSpace ι]
-    [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
-    (P : Measure Ω) (S : ι → Ω → ℝ) (𝓕 : Filtration ι mΩ) (n : ℕ) :
-    ι → Ω → ℝ :=
-  fun t ↦ ∑ u : mesh ι n, (meshPredIoc n u).indicator
-    (fun _ : ι ↦ predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P u) t
-
-/-- The convexly averaged mesh step-extension `𝒜^n` of the predictable parts. -/
-noncomputable def predictableConvexStep {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) : ι → Ω → ℝ :=
-  (weight hd hs n).weights.sum fun m r ↦ r • predictableSeqStep P S 𝓕 m
-
-/-- The predictable part `A` in the Doob-Meyer decomposition, defined as `S - M`. -/
-noncomputable def predictablePartLim {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) : ι → Ω → ℝ :=
-  S - martingalePartLim hd hs
-
-/-- `L¹` norm convergence of `predictableConvexStep` for `t` in `denseSet ι`. -/
-lemma predictableConvexStep_eLpNorm_tendsto {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) {t : ι}
-    (ht : t ∈ denseSet ι) :
-    Tendsto (fun n ↦ eLpNorm
-      (predictableConvexStep hd hs n t - predictablePartLim hd hs t) 1 P) atTop (𝓝 0) := by
-  sorry
-
-/-- Almost everywhere convergence of `predictableConvexStep`. -/
-lemma predictableConvexStep_ae_tendsto {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) {t : ι}
-    (ht : t ∈ denseSet ι) :
-    ∃ φ : ℕ → ℕ, StrictMono φ ∧
-      ∀ᵐ ω ∂P, Tendsto (fun n ↦ predictableConvexStep hd hs (φ n) t ω)
-        atTop (𝓝 (predictablePartLim hd hs t ω)) := by
-  sorry
-
-end PredictablePartLimDef
-
--- Helper lemmas about limits of monotone functions.
-section MonotoneLim
-
-/-- The limit of a collection of functions that is frequently monotone is monotone. -/
-lemma monotone_of_frequently_monotone_of_tendsto {ι α β : Type*} [Preorder α] [TopologicalSpace β]
-    [Preorder β] [OrderClosedTopology β] {l : Filter ι} {F : ι → α → β} {f : α → β}
-    (hF : ∃ᶠ i in l, Monotone (F i)) (hlim : ∀ x, Tendsto (fun i ↦ F i x) l (𝓝 (f x))) :
-    Monotone f :=
-  isClosed_monotone.mem_of_frequently_of_tendsto hF ((tendsto_pi_nhds).2 hlim)
-
-/-- The limit of a collection of functions that is frequently antitone is antitone. -/
-lemma antitone_of_frequently_antitone_of_tendsto {ι α β : Type*} [Preorder α] [TopologicalSpace β]
-    [Preorder β] [OrderClosedTopology β] {l : Filter ι} {F : ι → α → β} {f : α → β}
-    (hF : ∃ᶠ i in l, Antitone (F i)) (hlim : ∀ x, Tendsto (fun i ↦ F i x) l (𝓝 (f x))) :
-    Antitone f :=
-  monotone_of_frequently_monotone_of_tendsto (β := βᵒᵈ) hF hlim
-
-/-- The limit of a collection of functions that is eventually monotone is monotone. -/
-lemma monotone_of_eventually_monotone_of_tendsto {ι α β : Type*} [Preorder α] [TopologicalSpace β]
-    [Preorder β] [OrderClosedTopology β] {l : Filter ι} [l.NeBot] {F : ι → α → β} {f : α → β}
-    (hF : ∀ᶠ i in l, Monotone (F i)) (hlim : ∀ x, Tendsto (fun i ↦ F i x) l (𝓝 (f x))) :
-    Monotone f :=
-  monotone_of_frequently_monotone_of_tendsto hF.frequently hlim
-
-/-- The limit of a collection of functions that is eventually antitone is antitone. -/
-lemma antitone_of_eventually_antitone_of_tendsto {ι α β : Type*} [Preorder α] [TopologicalSpace β]
-    [Preorder β] [OrderClosedTopology β] {l : Filter ι} [l.NeBot] {F : ι → α → β} {f : α → β}
-    (hF : ∀ᶠ i in l, Antitone (F i)) (hlim : ∀ x, Tendsto (fun i ↦ F i x) l (𝓝 (f x))) :
-    Antitone f :=
-  monotone_of_eventually_monotone_of_tendsto (β := βᵒᵈ) hF hlim
-
-/-- The limit of a collection of monotone functions is monotone. -/
-lemma monotone_of_monotone_of_tendsto {ι α β : Type*} [Preorder α] [TopologicalSpace β]
-    [Preorder β] [OrderClosedTopology β] {l : Filter ι} [l.NeBot] {F : ι → α → β} {f : α → β}
-    (hF : ∀ i, Monotone (F i)) (hlim : ∀ x, Tendsto (fun i ↦ F i x) l (𝓝 (f x))) :
-    Monotone f :=
-  monotone_of_eventually_monotone_of_tendsto (Eventually.of_forall hF) hlim
-
-/-- The limit of a collection of antitone functions is antitone. -/
-lemma antitone_of_antitone_of_tendsto {ι α β : Type*} [Preorder α] [TopologicalSpace β]
-    [Preorder β] [OrderClosedTopology β] {l : Filter ι} [l.NeBot] {F : ι → α → β} {f : α → β}
-    (hF : ∀ i, Antitone (F i)) (hlim : ∀ x, Tendsto (fun i ↦ F i x) l (𝓝 (f x))) :
-    Antitone f :=
-  monotone_of_monotone_of_tendsto (β := βᵒᵈ) hF hlim
-
-/-- This is an auxillary lemma used to prove `Dense.monotone_of_isRightContinuous`. It is saying
-that if `D` is a dense set and `a, b` are two points such that `a < b`, then the comap of
-`𝓝[Set.Ioi a] a` under the inclusion `D → α` is nontrivial. Note that `a < b` is necessary as
-this is clearly not true if `a` is a top element. -/
-lemma Dense.comap_val_nhdsWithin_Ioi_neBot {α : Type*} [TopologicalSpace α] [LinearOrder α]
-    [OrderTopology α] [DenselyOrdered α] {D : Set α} (hD : Dense D) {a b : α} (hab : a < b) :
-    ((𝓝[Set.Ioi a] a).comap ((↑) : D → α)).NeBot := by
-  refine comap_neBot_iff.2 fun t ht => ?_
-  obtain ⟨c, hc⟩ := (mem_nhdsGT_iff_exists_mem_Ioc_Ioo_subset hab).1 ht
-  obtain ⟨d, hd⟩ := hD.inter_open_nonempty (Set.Ioo a c) isOpen_Ioo (Set.nonempty_Ioo.2 hc.1.1)
-  exact ⟨⟨d, hd.2⟩, hc.2 hd.1⟩
-
-/-- This is the dual of `Dense.comap_val_nhdsWithin_Ioi_neBot`. -/
-lemma Dense.comap_val_nhdsWithin_Iio_neBot {α : Type*} [TopologicalSpace α] [LinearOrder α]
-    [OrderTopology α] [DenselyOrdered α] {D : Set α} (hD : Dense D) {a b : α} (hab : b < a) :
-    ((𝓝[Set.Iio a] a).comap ((↑) : D → α)).NeBot := by
-  refine comap_neBot_iff.2 fun t ht => ?_
-  obtain ⟨c, hc⟩ := (mem_nhdsLT_iff_exists_mem_Ico_Ioo_subset hab).1 ht
-  obtain ⟨d, hd⟩ := hD.inter_open_nonempty (Set.Ioo c a) isOpen_Ioo (Set.nonempty_Ioo.2 hc.1.2)
-  exact ⟨⟨d, hd.2⟩, hc.2 hd.1⟩
-
-/-- If `f` is monotone on a dense set `D` and is right continuous, then `f` is monotone. We prove
-under the assumption that `α` has a top element `⊤` and `⊤ ∈ D`, which is a necessary assumption
-because otherwise it is possible that `⊤` is an isolated point. This theorem should be also true
-when `α` satisfies `NoTopOrder α`. -/
-lemma Dense.monotone_of_isRightContinuous {α β : Type*} [LinearOrder α] [OrderTop α]
-    [TopologicalSpace α] [OrderTopology α] [DenselyOrdered α] [TopologicalSpace β]
-    [Preorder β] [t : OrderClosedTopology β] {f : α → β} {D : Set α} (hD : Dense D) (htop : ⊤ ∈ D)
-    (hm : Monotone (f ∘ (↑) : D → β)) (hf : f.IsRightContinuous) :
-    Monotone f := by
-  refine monotone_iff_forall_lt.2 fun a b hab => ?_
-  by_cases! hbtop : b = ⊤
-  · have : (comap ((↑) : D → α) (𝓝[>] a)).NeBot := hD.comap_val_nhdsWithin_Ioi_neBot hab
-    rw [hbtop]
-    refine (isClosed_Iic (a := f ⊤)).mem_of_tendsto (Tendsto.comp (hf a)
-      (tendsto_comap (f := ((↑) : D → α)))) ?_
-    rw [eventually_comap, eventually_nhdsWithin_iff]
-    filter_upwards with z hz d rfl using hm (Subtype.mk_le_mk.2 le_top : d ≤ ⟨⊤, htop⟩)
-  · -- This part should work when `α` satisfies `NoTopOrder α`.
-    let I : D × D → α × α := Prod.map Subtype.val Subtype.val
-    have : ((𝓝[Set.Ioi a ×ˢ Set.Ioi b] ⟨a, b⟩).comap I).NeBot := by
-      simp only [nhdsWithin_prod_eq, comap_prodMap_prod, I]
-      exact (hD.comap_val_nhdsWithin_Ioi_neBot hab).prod
-        (hD.comap_val_nhdsWithin_Ioi_neBot hbtop.lt_top)
-    have : ∀ᶠ (p : D × D) in (𝓝[Set.Ioi a ×ˢ Set.Ioi b] ⟨a, b⟩).comap I, p.1 ≤ p.2 := by
-      rw [eventually_comap, eventually_nhdsWithin_iff]
-      have := isOpen_lt_prod.mem_nhds_iff.2 (by simp [hab] : ⟨a, b⟩ ∈ {p : α × α | p.1 < p.2})
-      filter_upwards [this] with p hlt _ a rfl using hlt.le
-    exact t.isClosed_le'.mem_of_tendsto (Tendsto.comp ((hf a).prodMap (hf b)) tendsto_comap)
-      (this.mono fun d hd => by simpa using hm hd)
-
-/-- A helper lemma. -/
-lemma Filter.IsCoboundedUnder.trans {ι α : Type*} {r : α → α → Prop} {l : Filter ι} [l.NeBot]
-    [IsTrans α r] {u v : ι → α} (hle : ∀ᶠ i in l, r (u i) (v i)) (h : IsCoboundedUnder r l u) :
-    IsCoboundedUnder r l v := by
-  simp only [IsCoboundedUnder, IsCobounded, eventually_map] at *
-  obtain ⟨b, hb⟩ := h
-  refine ⟨b, fun a ha => hb a ?_⟩
-  filter_upwards [ha, hle] with i hi huv using Trans.trans huv hi
-
-/-- Convergence on a dense set of a collection of monotone function controls the `limsup` at a point
-if `f` is right continuous at `a`. We prove this under the assumption that `α` has both a bottom
-element and a top element. The bottom element is needed because otherwise `limsup` evaluated at the
-bottome element may give a junk value to break the inequality. -/
-lemma limsup_le_of_eventually_monotone_of_tendsto_on_dense {ι α β : Type*} [LinearOrder α]
-    [BoundedOrder α] [TopologicalSpace α] [OrderTopology α] [DenselyOrdered α]
-    [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β] {l : Filter ι}
-    [l.NeBot] {D : Set α} {F : ι → α → β} {f : α → β} (hF : ∀ᶠ i in l, Monotone (F i))
-    (hD : Dense D) (htop : ⊤ ∈ D) (hbot : ⊥ ∈ D) {a : α} (hfa : ContinuousWithinAt f (Set.Ioi a) a)
-    (hlim : ∀ t ∈ D, Tendsto (F · t) l (𝓝 (f t))) :
-    limsup (F · a) l ≤ f a := by
-  by_cases! ha : a = ⊤
-  · rw [ha, (hlim ⊤ htop).limsup_eq]
-  · have : (comap ((↑) : D → α) (𝓝[>] a)).NeBot := hD.comap_val_nhdsWithin_Ioi_neBot ha.lt_top
-    refine (isClosed_Ici (a := limsup (F · a) l)).mem_of_tendsto (Tendsto.comp hfa
-      (tendsto_comap (f := ((↑) : D → α)))) ?_
-    rw [eventually_comap, eventually_nhdsWithin_iff]
-    filter_upwards with z hz d rfl
-    simp only [Function.comp_apply, Set.mem_Ici, ← (hlim d d.2).limsup_eq]
-    refine limsup_le_limsup ?_ ?_ (hlim d d.2).isBoundedUnder_le
-    · filter_upwards [hF] with i hi using hi hz.le
-    · refine (hlim ⊥ hbot).isCoboundedUnder_le.trans ?_
-      filter_upwards [hF] with i hi using hi bot_le
-
-/-- This is the dual of `limsup_le_of_eventually_monotone_of_tendsto_on_dense`. -/
-lemma le_liminf_of_eventually_monotone_of_tendsto_on_dense {ι α β : Type*} [LinearOrder α]
-    [BoundedOrder α] [TopologicalSpace α] [OrderTopology α] [DenselyOrdered α]
-    [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β] {l : Filter ι}
-    [l.NeBot] {D : Set α} {F : ι → α → β} {f : α → β} (hF : ∀ᶠ i in l, Monotone (F i))
-    (hD : Dense D) (htop : ⊤ ∈ D) (hbot : ⊥ ∈ D) {a : α} (hfa : ContinuousWithinAt f (Set.Iio a) a)
-    (hlim : ∀ t ∈ D, Tendsto (F · t) l (𝓝 (f t))) :
-    f a ≤ liminf (F · a) l := by
-  by_cases! ha : a = ⊥
-  · rw [ha, (hlim ⊥ hbot).liminf_eq]
-  · have : (comap ((↑) : D → α) (𝓝[<] a)).NeBot := hD.comap_val_nhdsWithin_Iio_neBot ha.bot_lt
-    refine (isClosed_Iic (a := liminf (F · a) l)).mem_of_tendsto (Tendsto.comp hfa
-      (tendsto_comap (f := ((↑) : D → α)))) ?_
-    rw [eventually_comap, eventually_nhdsWithin_iff]
-    filter_upwards with z hz d rfl
-    simp only [Function.comp_apply, Set.mem_Iic, ← (hlim d d.2).liminf_eq]
-    refine liminf_le_liminf ?_ (hlim d d.2).isBoundedUnder_ge ?_
-    · filter_upwards [hF] with i hi using hi hz.le
-    · refine (hlim ⊤ htop).isCoboundedUnder_ge.trans ?_
-      filter_upwards [hF] with i hi using hi le_top
-
-/-- We combine `limsup_le_of_eventually_monotone_of_tendsto_on_dense` and
-`le_liminf_of_eventually_monotone_of_tendsto_on_dense` to prove that `F · a` converges to `f a`
-if `f` is continuous at `a`. -/
-lemma tendsto_of_eventually_monotone_of_tendsto_on_dense {ι α β : Type*} [LinearOrder α]
-    [BoundedOrder α] [TopologicalSpace α] [OrderTopology α] [DenselyOrdered α]
-    [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β] {l : Filter ι}
-    [l.NeBot] {D : Set α} {F : ι → α → β} {f : α → β} (hF : ∀ᶠ i in l, Monotone (F i))
-    (hD : Dense D) (htop : ⊤ ∈ D) (hbot : ⊥ ∈ D) (a : α) (hfa : ContinuousAt f a)
-    (hlim : ∀ t ∈ D, Tendsto (F · t) l (𝓝 (f t))) :
-    Tendsto (F · a) l (𝓝 (f a)) := by
-  refine tendsto_of_le_liminf_of_limsup_le ?_ ?_ ?_ ?_
-  · exact le_liminf_of_eventually_monotone_of_tendsto_on_dense hF hD htop hbot
-      hfa.continuousWithinAt hlim
-  · exact limsup_le_of_eventually_monotone_of_tendsto_on_dense hF hD htop hbot
-      hfa.continuousWithinAt hlim
-  · -- create an analogue of `Filter.IsCoboundedUnder.trans` for `IsBoundedUnder` to replace
-    -- `isBoundedUnder_le.mono_le`
-    refine (hlim ⊤ htop).isBoundedUnder_le.mono_le ?_
-    filter_upwards [hF] with i hi using hi le_top
-  · refine (hlim ⊥ hbot).isBoundedUnder_ge.mono_ge ?_
-    filter_upwards [hF] with i hi using hi bot_le
-
-end MonotoneLim
-
-section PredictablePartLimMono
-
-lemma predictableSeqStep_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P) (n : ℕ) (t : ι) :
-    ∀ᵐ ω ∂P, Monotone fun t ↦ predictableSeqStep P S 𝓕 n t ω := by
-  sorry
-
-lemma predictableConvexStep_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) (t : ι) :
-    ∀ᵐ ω ∂P, Monotone fun t ↦ predictableConvexStep hd hs n t ω := by
-  sorry
-
-lemma predictablePartLim_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) (t : ι) :
-    ∀ᵐ ω ∂P, Monotone fun t ↦ predictablePartLim hd hs t ω := by
-  sorry
-
-end PredictablePartLimMono
-
-section PredictableConvexStepPredictable
-
-/-- The mesh step-extension of the discrete predictable part is left-continuous in time. -/
-lemma predictableSeqStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (n : ℕ) (ω : Ω) (t : ι) :
-    ContinuousWithinAt (fun s ↦ predictableSeqStep P S 𝓕 n s ω) (Set.Iio t) t := by
-  sorry
-
-/-- `predictableConvexStep` is left-continuous in time. -/
-lemma predictableConvexStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) (ω : Ω) (t : ι) :
-    ContinuousWithinAt (fun s ↦ predictableConvexStep hd hs n s ω) (Set.Iio t) t := by
-  sorry
-
-/-- The mesh step-extension of the discrete predictable part is strongly adapted. -/
-lemma stronglyAdapted_predictableSeqStep {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} (P : Measure Ω) [IsFiniteMeasure P] (S : ι → Ω → ℝ)
-    (𝓕 : Filtration ι mΩ) (n : ℕ) :
-    StronglyAdapted 𝓕 (predictableSeqStep P S 𝓕 n) := by
-  refine fun t => Finset.stronglyMeasurable_sum _ fun u _ => ?_
-  by_cases htu : t ∈ meshPredIoc n u
-  · have : meshFiltration 𝓕 n (pred u) ≤ 𝓕 t := by simpa [meshFiltration] using 𝓕.mono htu.1.le
-    simpa [htu] using (stronglyMeasurable_pred_predictablePart (S ∘ Subtype.val)
-      (meshFiltration 𝓕 n) P u).mono this
-  · simpa [htu] using stronglyMeasurable_zero
-
-/-- The convexly averaged mesh step-extension of the predictable parts is strongly adapted. -/
-lemma stronglyAdapted_predictableConvexStep {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) :
-    StronglyAdapted 𝓕 (predictableConvexStep hd hs n) := by
-  intro t
-  simpa [predictableConvexStep, Finsupp.sum] using
-    Finset.stronglyMeasurable_sum ((weight hd hs n).weights.support) fun m _hm ↦
-      (stronglyAdapted_predictableSeqStep P S 𝓕 m t).const_smul ((weight hd hs n).weights m)
-
-/-- The convexly averaged mesh step-extension of the predictable parts is strongly predictable. -/
-lemma isStronglyPredictable_predictableConvexStep {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    [OrderTopology ι] [DenselyOrdered ι] {mΩ : MeasurableSpace Ω} {P : Measure Ω}
-    [IsFiniteMeasure P] {S : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P)
-    (hs : Submartingale S 𝓕 P) (n : ℕ) :
-    IsStronglyPredictable 𝓕 (predictableConvexStep hd hs n) :=
-  (stronglyAdapted_predictableConvexStep hd hs n).isStronglyPredictable_of_leftContinuous
-    (predictableConvexStep_leftContinuous hd hs n)
-
-end PredictableConvexStepPredictable
-
-section PredictablePartIsStronglyPredictable
-
-/-- The pointwise limsup of strongly predictable processes is strongly predictable. -/
-lemma IsStronglyPredictable.limsup {ι Ω E : Type*} [Preorder ι] [OrderBot ι]
-    {mΩ : MeasurableSpace Ω} {𝓕 : Filtration ι mΩ} [TopologicalSpace E] [MeasurableSpace E]
-    [BorelSpace E] [TopologicalSpace.PseudoMetrizableSpace E] [ConditionallyCompleteLinearOrder E]
-    [OrderTopology E] [SecondCountableTopology E] {X : ℕ → ι → Ω → E}
-    (hX : ∀ n, IsStronglyPredictable 𝓕 (X n)) :
-    IsStronglyPredictable 𝓕 (fun t ω ↦ limsup (fun n ↦ X n t ω) atTop) := by
-  rw [IsStronglyPredictable, stronglyMeasurable_iff_measurable]
-  exact Measurable.limsup fun n => stronglyMeasurable_iff_measurable.1 (hX n)
-
-/-- The limsup of convexly averaged mesh step-extension of the predictable parts is strongly
-predictable. -/
-lemma isStronglyPredictable_limsup_predictableConvexStep {ι Ω : Type*} [TopologicalSpace ι]
-    [T1Space ι] [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι]
-    [OrderTop ι] [OrderTopology ι] [DenselyOrdered ι] {mΩ : MeasurableSpace Ω} {P : Measure Ω}
-    [IsFiniteMeasure P] {S : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P)
-    (hs : Submartingale S 𝓕 P) :
-    IsStronglyPredictable 𝓕 (fun t ω => limsup (predictableConvexStep hd hs · t ω) atTop) :=
-  IsStronglyPredictable.limsup fun n => isStronglyPredictable_predictableConvexStep hd hs n
-
-/-- For each stopping time `τ`, `limsup (fun n => stoppedValue 𝒜^n τ) atTop ≤ stoppedValue A τ`
-almost everywhere. Use `limsup_le_of_eventually_monotone_of_tendsto_on_dense`. -/
-lemma limsup_stoppedValue_predictableConvexStep_ae_le_stoppedValue_predictablePartLim {ι Ω : Type*}
-    [TopologicalSpace ι] [T1Space ι] [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι]
-    [OrderBot ι] [OrderTop ι] [OrderTopology ι] [DenselyOrdered ι] {mΩ : MeasurableSpace Ω}
-    {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P)
-    (hs : Submartingale S 𝓕 P) {τ : Ω → WithTop ι} (hτ : IsStoppingTime 𝓕 τ)
-    (hc : ∀ᵐ ω ∂P, IsCadlag (S · ω)) :
-    limsup (fun n => stoppedValue (predictableConvexStep hd hs n) τ) atTop ≤ᵐ[P]
-      stoppedValue (predictablePartLim hd hs) τ := by
-  sorry
-
-/-- Prove that `∫ ω, stoppedValue 𝒜^n τ ω ∂P` converges to `∫ ω, stoppedValue A τ ω ∂P`. -/
-lemma integral_stoppedValue_predictableConvexStep_tendsto_stoppedValue_predictablePartLim
-    {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι] [SecondCountableTopology ι] [MeasurableSpace ι]
-    [LinearOrder ι] [OrderBot ι] [OrderTop ι] [OrderTopology ι] [DenselyOrdered ι]
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) {τ : Ω → WithTop ι}
-    (hτ : IsStoppingTime 𝓕 τ) :
-    Tendsto (fun n => ∫ ω, stoppedValue (predictableConvexStep hd hs n) τ ω ∂P) atTop
-      (𝓝 <| ∫ ω, stoppedValue (predictablePartLim hd hs) τ ω ∂P) := by
-  sorry
-
-/-- Reverse Fatou's lemma. See also `limsup_lintegral_le`. -/
-lemma limsup_integral_le_integral_limsup_of_tendsto_integral_posPart_sub {Ω : Type*}
-    {mΩ : MeasurableSpace Ω} {P : Measure Ω} {X : ℕ → Ω → ℝ} {Y : Ω → ℝ}
-    (hX_nonneg : ∀ n, 0 ≤ᵐ[P] X n) (hY : Integrable Y P) (hY_nonneg : 0 ≤ᵐ[P] Y)
-    (h_tendsto : Tendsto (fun n => ∫ ω, max (X n ω - Y ω) 0 ∂P) atTop (𝓝 0)) :
-    limsup (fun n => ∫ ω, X n ω ∂P) atTop ≤ ∫ ω, limsup (fun n => X n ω) atTop ∂P := by
-  sorry
-
-/-- For each stopping time `τ`, `limsup (fun n => stoppedValue 𝒜^n τ) atTop = stoppedValue A τ`
-almost everywhere. -/
-lemma limsup_stoppedValue_predictableConvexStep_ae_eq_stoppedValue_predictablePartLim {ι Ω : Type*}
-    [TopologicalSpace ι] [T1Space ι] [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι]
-    [OrderBot ι] [OrderTop ι] [OrderTopology ι] [DenselyOrdered ι] {mΩ : MeasurableSpace Ω}
-    {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P)
-    (hs : Submartingale S 𝓕 P) {τ : Ω → WithTop ι} (hτ : IsStoppingTime 𝓕 τ)
-    (hc : ∀ᵐ ω ∂P, IsCadlag (S · ω)) :
-    limsup (fun n => stoppedValue (predictableConvexStep hd hs n) τ) atTop =ᵐ[P]
-      stoppedValue (predictablePartLim hd hs) τ := by
-  refine (integral_eq_iff_of_ae_le ?_ ?_ ?_).1 ?_
-  · -- maybe it is better to first prove an analogue of `ae_eq_of_ae_le_of_lintegral_le` that
-    -- asssumes `0 ≤ f` instead of integrability of `f`.
-    sorry
-  · sorry
-  · exact
-      limsup_stoppedValue_predictableConvexStep_ae_le_stoppedValue_predictablePartLim hd hs hτ hc
-  · refine le_antisymm ?_ ?_
-    · refine integral_mono_of_nonneg ?_ ?_ ?_
-      · sorry
-      · sorry
-      · exact (limsup_stoppedValue_predictableConvexStep_ae_le_stoppedValue_predictablePartLim
-          hd hs hτ hc)
-    · calc
-      ∫ ω, stoppedValue (predictablePartLim hd hs) τ ω ∂P =
-        limsup (fun n => ∫ ω, stoppedValue (predictableConvexStep hd hs n) τ ω ∂P) atTop :=
-        ((integral_stoppedValue_predictableConvexStep_tendsto_stoppedValue_predictablePartLim
-          hd hs hτ).limsup_eq).symm
-        -- Use Fatou's lemma for the following sorry
-        -- We use integral instead of lintegral because
-        -- 1. `ae_eq_of_ae_le_of_lintegral_le` is the analogue of `ae_eq_of_ae_le_of_lintegral_le`,
-        -- but it still requires a proof that the lintegral is not equal to infinity.
-        -- 2. these processes are naturally real valued.
-        -- 3. I think it is useful to prove reverse Fatou's lemma for integral as one should be
-        -- able to apply for functions taking negative values.
-      _ ≤ _ := by sorry
-
-/-- Show that `fun t ω => limsup (predictableConvexStep hd hs · t ω` and `predictablePartLim hd hs`
-are indistinguishable. -/
-lemma limsup_predictableConvexStep_eq_predictablePartLim {ι Ω : Type*}
-    [TopologicalSpace ι] [T1Space ι] [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι]
-    [OrderBot ι] [OrderTop ι] [OrderTopology ι] [DenselyOrdered ι] {mΩ : MeasurableSpace Ω}
-    {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P)
-    (hs : Submartingale S 𝓕 P) {τ : Ω → WithTop ι} (hτ : IsStoppingTime 𝓕 τ) :
-    ∀ᵐ ω ∂P, ∀ t, limsup (predictableConvexStep hd hs · t ω) atTop =
-      predictablePartLim hd hs t ω := by
-  sorry
-
-end PredictablePartIsStronglyPredictable
-
-section DoobMeyer
-
-theorem ClassD.doob_meyer {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
-    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    [SuccOrder ι] {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P) :
-    ∃ (M A : ι → Ω → ℝ), S = M + A ∧ Martingale M 𝓕 P ∧ (∀ ω, IsCadlag (M · ω)) ∧
-      IsStronglyPredictable 𝓕 A ∧ (∀ ω, IsCadlag (A · ω)) ∧ (∀ ω, Monotone (A · ω)) := by
-  sorry
-
-end DoobMeyer
+namespace ProbabilityTheory
 
 variable {ι Ω : Type*} [LinearOrder ι] [OrderBot ι] [TopologicalSpace ι] [OrderTopology ι]
   {mΩ : MeasurableSpace Ω} {P : Measure Ω} {X : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ}
   [MeasurableSpace ι]
 
-namespace ProbabilityTheory
+omit [TopologicalSpace ι] [OrderTopology ι] [MeasurableSpace ι] in
+/-- Adding an integrable `𝓕_⊥`-measurable random variable as a time-constant process preserves
+the martingale property.  This is the non-local closure fact needed after localization in the
+normalized Doob-Meyer proof. -/
+lemma _root_.MeasureTheory.Martingale.add_const_fun [SigmaFiniteFiltration P 𝓕]
+    {M : ι → Ω → ℝ} {Z : Ω → ℝ} (hM : Martingale M 𝓕 P)
+    (hZ_meas : StronglyMeasurable[𝓕 ⊥] Z) (hZ_int : Integrable Z P) :
+    Martingale (M + fun _ ↦ Z) 𝓕 P := by
+  exact hM.add (martingale_const_fun 𝓕 P hZ_meas hZ_int)
+
+omit [TopologicalSpace ι] [OrderTopology ι] [MeasurableSpace ι] in
+/-- A time-constant process generated by an `𝓕_⊥`-measurable random variable is strongly
+predictable. -/
+lemma _root_.MeasureTheory.IsStronglyPredictable.const_fun {Z : Ω → ℝ}
+    (hZ : StronglyMeasurable[𝓕 ⊥] Z) :
+    IsStronglyPredictable 𝓕 (fun _ : ι => Z) := by
+  rw [MeasureTheory.IsStronglyPredictable]
+  rw [stronglyMeasurable_iff_measurable]
+  have hsnd : @Measurable (ι × Ω) Ω 𝓕.predictable (𝓕 ⊥) Prod.snd := by
+    rw [measurable_iff_comap_le, MeasurableSpace.comap_le_iff_le_map]
+    intro s hs
+    rw [MeasurableSpace.map_def]
+    have hpre : Prod.snd ⁻¹' s = (Set.univ : Set ι) ×ˢ s := by
+      ext p
+      simp
+    rw [hpre]
+    exact MeasureTheory.measurableSet_predictable_univ_prod (𝓕 := 𝓕) hs
+  simpa [Function.uncurry] using hZ.measurable.comp hsnd
+
+omit [TopologicalSpace ι] [OrderTopology ι] [MeasurableSpace ι] in
+/-- Strong predictability is stable under subtracting real-valued processes. -/
+lemma _root_.MeasureTheory.IsStronglyPredictable.sub {U V : ι → Ω → ℝ}
+    (hU : IsStronglyPredictable 𝓕 U) (hV : IsStronglyPredictable 𝓕 V) :
+    IsStronglyPredictable 𝓕 (U - V) := by
+  rw [MeasureTheory.IsStronglyPredictable] at hU hV ⊢
+  simpa [Function.uncurry, Pi.sub_apply] using hU.sub hV
+
+omit [OrderBot ι] [TopologicalSpace ι] [OrderTopology ι] [MeasurableSpace ι] in
+/-- Real-valued bounded-variation functions are stable under subtraction. -/
+lemma _root_.BoundedVariationOn.sub {f g : ι → ℝ} {s : Set ι}
+    (hf : BoundedVariationOn f s) (hg : BoundedVariationOn g s) :
+    BoundedVariationOn (f - g) s := by
+  have hle : eVariationOn (f - g) s ≤ eVariationOn f s + eVariationOn g s := by
+    rw [eVariationOn]
+    refine iSup_le ?_
+    rintro ⟨n, u, hu, hus⟩
+    calc
+      (∑ i ∈ Finset.range n,
+          edist ((f - g) (u (i + 1))) ((f - g) (u i)))
+          ≤ ∑ i ∈ Finset.range n,
+              (edist (f (u (i + 1))) (f (u i)) +
+                edist (g (u (i + 1))) (g (u i))) := by
+            refine Finset.sum_le_sum fun i _ ↦ ?_
+            simp only [Pi.sub_apply]
+            calc
+              edist (f (u (i + 1)) - g (u (i + 1))) (f (u i) - g (u i))
+                  ≤ edist (f (u (i + 1)) - g (u (i + 1)))
+                      (f (u i) - g (u (i + 1))) +
+                    edist (f (u i) - g (u (i + 1))) (f (u i) - g (u i)) :=
+                    edist_triangle _ _ _
+              _ = edist (f (u (i + 1))) (f (u i)) +
+                    edist (g (u (i + 1))) (g (u i)) := by
+                    rw [edist_sub_right, edist_sub_left]
+      _ = (∑ i ∈ Finset.range n, edist (f (u (i + 1))) (f (u i))) +
+            ∑ i ∈ Finset.range n, edist (g (u (i + 1))) (g (u i)) := by
+          rw [Finset.sum_add_distrib]
+      _ ≤ eVariationOn f s + eVariationOn g s := by
+          exact add_le_add (eVariationOn.sum_le hu hus) (eVariationOn.sum_le hu hus)
+  exact ne_top_of_le_ne_top (ENNReal.add_ne_top.2 ⟨hf, hg⟩) hle
+
+omit [OrderBot ι] [TopologicalSpace ι] [OrderTopology ι] [MeasurableSpace ι] in
+/-- Locally bounded variation is stable under subtraction for real-valued paths. -/
+lemma _root_.LocallyBoundedVariationOn.sub {f g : ι → ℝ} {s : Set ι}
+    (hf : LocallyBoundedVariationOn f s) (hg : LocallyBoundedVariationOn g s) :
+    LocallyBoundedVariationOn (f - g) s := by
+  intro a b ha hb
+  exact (hf a b ha hb).sub (hg a b ha hb)
+
+omit [OrderBot ι] [TopologicalSpace ι] [OrderTopology ι] [MeasurableSpace ι] in
+/-- Pathwise running-sup estimate for subtracting a time-constant random variable. -/
+lemma runningSup_norm_sub_const_le (A : ι → Ω → ℝ) (Z : Ω → ℝ) (t : ι) (ω : Ω) :
+    (⨆ s ≤ t, ‖A s ω - Z ω‖ₑ) ≤ (⨆ s ≤ t, ‖A s ω‖ₑ) + ‖Z ω‖ₑ := by
+  refine iSup₂_le fun s hs ↦ ?_
+  calc
+    ‖A s ω - Z ω‖ₑ ≤ ‖A s ω‖ₑ + ‖Z ω‖ₑ := by
+      simpa [sub_eq_add_neg] using enorm_add_le (A s ω) (-Z ω)
+    _ ≤ (⨆ u ≤ t, ‖A u ω‖ₑ) + ‖Z ω‖ₑ :=
+      add_le_add (le_iSup₂_of_le s hs le_rfl) le_rfl
+
+/-- Subtracting an integrable `𝓕_⊥`-measurable time-constant random variable preserves
+integrable running sup, under the usual hypotheses that turn strong progressivity into a
+strongly measurable running-sup process. -/
+lemma HasIntegrableSup.sub_const_fun
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [PolishSpace κ]
+    [mΩ' : MeasurableSpace Ω'] {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [𝓕'.IsComplete P'] [𝓕'.IsRightContinuous]
+    {A : κ → Ω' → ℝ} {Z : Ω' → ℝ}
+    (hA_int : HasIntegrableSup (mΩ := mΩ') A P')
+    (hA_prog : IsStronglyProgressive 𝓕' A)
+    (hZ_meas : StronglyMeasurable[𝓕' ⊥] Z)
+    (hZ_int : Integrable (fun ω ↦ ‖Z ω‖ₑ) P') :
+    HasIntegrableSup (mΩ := mΩ') (A - fun _ ↦ Z) P' := by
+  have hZ_prog : IsStronglyProgressive 𝓕' (fun _ : κ ↦ Z) := by
+    intro i
+    exact ((hZ_meas.mono (𝓕'.mono bot_le)).comp_measurable measurable_snd)
+  have hsup_shift : HasStronglyMeasurableSupProcess (mΩ := mΩ') (A - fun _ : κ ↦ Z) := by
+    simpa [Pi.sub_apply] using
+      (MeasureTheory.IsStronglyProgressive.hasStronglyMeasurableSupProcess (𝓕 := 𝓕') P'
+        (hA_prog.sub hZ_prog))
+  refine ⟨hsup_shift, fun t ↦ ?_⟩
+  have hdom : Integrable (fun ω ↦ (⨆ s ≤ t, ‖A s ω‖ₑ) + ‖Z ω‖ₑ) P' :=
+    (hA_int.2 t).add hZ_int
+  refine Integrable.mono_enorm hdom
+    (hsup_shift.comp_measurable (measurable_const.prodMk measurable_id)).aestronglyMeasurable
+    ?_
+  filter_upwards with ω
+  have hle := runningSup_norm_sub_const_le A Z t ω
+  simpa [Pi.sub_apply, enorm_eq_self] using hle
+
+/-- Local version of `HasIntegrableSup.sub_const_fun` for the normalization shift
+`A_t - A_⊥`.  The stopped initial value is integrable because it is the running supremum of the
+stopped process at `⊥`. -/
+lemma HasLocallyIntegrableSup.sub_initial
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [PolishSpace κ]
+    [mΩ' : MeasurableSpace Ω'] {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [𝓕'.IsComplete P'] [𝓕'.IsRightContinuous]
+    {A : κ → Ω' → ℝ}
+    (hA_int : HasLocallyIntegrableSup (mΩ := mΩ') A 𝓕' P')
+    (hA_prog : IsStronglyProgressive 𝓕' A) :
+    HasLocallyIntegrableSup (mΩ := mΩ') (A - fun _ ω ↦ A ⊥ ω) 𝓕' P' := by
+  rcases hA_int with ⟨τ, hτ, hτA⟩
+  refine ⟨τ, hτ, fun n ↦ ?_⟩
+  let Xn : κ → Ω' → ℝ :=
+    stoppedProcess (fun i ↦ {ω | ⊥ < τ n ω}.indicator (A i)) (τ n)
+  let Zn : Ω' → ℝ := {ω | ⊥ < τ n ω}.indicator (fun ω ↦ A ⊥ ω)
+  have hXn_prog : IsStronglyProgressive 𝓕' Xn := by
+    exact isStable_isStronglyProgressive A hA_prog (τ n) (hτ.isStoppingTime n)
+  have hZn_meas : StronglyMeasurable[𝓕' ⊥] Zn := by
+    exact (hA_prog.stronglyAdapted ⊥).indicator
+      ((hτ.isStoppingTime n).measurableSet_gt ⊥)
+  have hZn_int : Integrable (fun ω ↦ ‖Zn ω‖ₑ) P' := by
+    have hbot := (hτA n).2 (⊥ : κ)
+    simpa [Xn, Zn, stoppedProcess] using hbot
+  have hshift := (hτA n).sub_const_fun hXn_prog hZn_meas hZn_int
+  convert hshift using 1
+  ext t ω
+  by_cases hω : ⊥ < τ n ω <;>
+    simp [Zn, stoppedProcess, Pi.sub_apply, hω]
+
+/-- Adding the initial value of a strongly progressive process with locally integrable running
+supremum to a local martingale preserves the local martingale property under the usual hypotheses
+needed for stopped-martingale stability. -/
+lemma IsLocalMartingale.add_initial_of_hasLocallyIntegrableSup
+    [SecondCountableTopology ι] [BorelSpace ι] [PseudoMetrizableSpace ι]
+    [IsFiniteMeasure P] [Approximable 𝓕 P]
+    {M A : ι → Ω → ℝ} (hM : IsLocalMartingale M 𝓕 P)
+    (hA_prog : IsStronglyProgressive 𝓕 A)
+    (hA_int : HasLocallyIntegrableSup A 𝓕 P) :
+    IsLocalMartingale (M + fun _ ω => A ⊥ ω) 𝓕 P := by
+  let τ : ℕ → Ω → WithTop ι := hM.localSeq ⊓ hA_int.localSeq
+  refine ⟨τ, hM.isLocalizingSequence_localSeq.min hA_int.isLocalizingSequence_localSeq,
+    fun n => ?_⟩
+  let S : Set Ω := {ω | ⊥ < τ n ω}
+  let Z : Ω → ℝ := S.indicator (fun ω => A ⊥ ω)
+  have hMτ_mart : Martingale (stoppedProcess (fun i => S.indicator (M i)) (τ n)) 𝓕 P := by
+    have hm := (isStable_martingale
+      (stoppedProcess (fun i => {ω | ⊥ < hM.localSeq n ω}.indicator (M i))
+        (hM.localSeq n))
+      (hM.stoppedProcess_localSeq n) (hA_int.localSeq n)
+      (hA_int.isLocalizingSequence_localSeq.isStoppingTime n)).1
+    convert hm using 1
+    ext i ω
+    simp_rw [S, τ, stoppedProcess_indicator_comm, Pi.inf_apply, lt_inf_iff,
+      inf_comm (hM.localSeq n)]
+    rw [← stoppedProcess_stoppedProcess, ← stoppedProcess_indicator_comm, Set.setOf_and,
+      Set.inter_comm]
+    simp_rw [← Set.indicator_indicator]
+    rfl
+  have hMτ_cad :
+      ∀ ω, IsCadlag (stoppedProcess (fun i => S.indicator (M i)) (τ n) · ω) := by
+    have hc := (isStable_martingale
+      (stoppedProcess (fun i => {ω | ⊥ < hM.localSeq n ω}.indicator (M i))
+        (hM.localSeq n))
+      (hM.stoppedProcess_localSeq n) (hA_int.localSeq n)
+      (hA_int.isLocalizingSequence_localSeq.isStoppingTime n)).2
+    intro ω
+    convert hc ω using 1
+    ext i
+    simp_rw [S, τ, stoppedProcess_indicator_comm, Pi.inf_apply, lt_inf_iff,
+      inf_comm (hM.localSeq n)]
+    rw [← stoppedProcess_stoppedProcess, ← stoppedProcess_indicator_comm, Set.setOf_and,
+      Set.inter_comm]
+    simp_rw [← Set.indicator_indicator]
+    rfl
+  have hAτ : HasIntegrableSup (stoppedProcess (fun i => S.indicator (A i)) (τ n)) P := by
+    have h := isStable_hasIntegrableSup
+      (stoppedProcess (fun i => {ω | ⊥ < hA_int.localSeq n ω}.indicator (A i))
+        (hA_int.localSeq n))
+      (hA_int.stoppedProcess_localSeq n) (hM.localSeq n)
+      (hM.isLocalizingSequence_localSeq.isStoppingTime n)
+    convert h using 1
+    ext i ω
+    simp_rw [S, τ, stoppedProcess_indicator_comm, Pi.inf_apply, lt_inf_iff]
+    rw [← stoppedProcess_stoppedProcess, ← stoppedProcess_indicator_comm, Set.setOf_and]
+    simp_rw [← Set.indicator_indicator]
+    rfl
+  have hZ_meas : StronglyMeasurable[𝓕 ⊥] Z := by
+    have hτ_stop := (hM.isLocalizingSequence_localSeq.min
+      hA_int.isLocalizingSequence_localSeq).isStoppingTime n
+    exact (hA_prog.stronglyAdapted ⊥).indicator (hτ_stop.measurableSet_gt ⊥)
+  have hZ_int : Integrable Z P := by
+    have hZ_strong : StronglyMeasurable Z := hZ_meas.mono (𝓕.le ⊥)
+    have hZ_ae : AEStronglyMeasurable Z P := hZ_strong.aestronglyMeasurable
+    rw [← integrable_enorm_iff hZ_ae]
+    have hbot := hAτ.2 (⊥ : ι)
+    convert hbot using 1
+    ext ω
+    by_cases hω : ω ∈ S
+    · simp only [le_bot_iff, iSup_iSup_eq_left]
+      change ‖S.indicator (fun ω => A ⊥ ω) ω‖ₑ =
+        ‖S.indicator (fun ω =>
+          A (min (((⊥ : ι) : WithTop ι)) (τ n ω)).untopA ω) ω‖ₑ
+      rw [Set.indicator_of_mem hω, Set.indicator_of_mem hω]
+      rw [show (min (((⊥ : ι) : WithTop ι)) (τ n ω)).untopA = (⊥ : ι) by
+        rw [WithTop.coe_bot]
+        rw [min_eq_left (bot_le : (⊥ : WithTop ι) ≤ τ n ω)]
+        rfl]
+    · have hω' : ¬ ⊥ < τ n ω := by simpa [S] using hω
+      simp [Z, S, stoppedProcess, hω']
+  refine ⟨?_, ?_⟩
+  · convert hMτ_mart.add_const_fun hZ_meas hZ_int using 1
+    ext i ω
+    by_cases hω : ω ∈ S
+    · have hω' : ⊥ < τ n ω := by simpa [S] using hω
+      simp [Z, S, stoppedProcess, hω']
+    · have hω' : ¬ ⊥ < τ n ω := by simpa [S] using hω
+      simp [Z, S, stoppedProcess, hω']
+  · intro ω
+    have hZ_cadlag : IsCadlag (fun _ : ι => Z ω) :=
+      (continuous_const : Continuous fun _ : ι => Z ω).isCadlag
+    have hsum := (hMτ_cad ω).add hZ_cadlag
+    convert hsum using 1
+    ext i
+    by_cases hω : ω ∈ S
+    · have hω' : ⊥ < τ n ω := by simpa [S] using hω
+      simp [Z, S, stoppedProcess, hω']
+    · have hω' : ¬ ⊥ < τ n ω := by simpa [S] using hω
+      simp [Z, S, stoppedProcess, hω']
+
+/-- Real-valued local martingales are stable under subtraction. -/
+lemma IsLocalMartingale.sub
+    [SecondCountableTopology ι] [BorelSpace ι] [PseudoMetrizableSpace ι]
+    [IsFiniteMeasure P] [Approximable 𝓕 P] {M N : ι → Ω → ℝ}
+    (hM : IsLocalMartingale M 𝓕 P) (hN : IsLocalMartingale N 𝓕 P) :
+    IsLocalMartingale (M - N) 𝓕 P := by
+  let τ : ℕ → Ω → WithTop ι := hM.localSeq ⊓ hN.localSeq
+  refine ⟨τ, hM.isLocalizingSequence_localSeq.min hN.isLocalizingSequence_localSeq,
+    fun n => ?_⟩
+  let S : Set Ω := {ω | ⊥ < τ n ω}
+  have hMτ_mart :
+      Martingale (stoppedProcess (fun i => S.indicator (M i)) (τ n)) 𝓕 P := by
+    have hm := (isStable_martingale
+      (stoppedProcess (fun i => {ω | ⊥ < hM.localSeq n ω}.indicator (M i))
+        (hM.localSeq n))
+      (hM.stoppedProcess_localSeq n) (hN.localSeq n)
+      (hN.isLocalizingSequence_localSeq.isStoppingTime n)).1
+    convert hm using 1
+    ext i ω
+    simp_rw [S, τ, stoppedProcess_indicator_comm, Pi.inf_apply, lt_inf_iff,
+      inf_comm (hM.localSeq n)]
+    rw [← stoppedProcess_stoppedProcess, ← stoppedProcess_indicator_comm, Set.setOf_and,
+      Set.inter_comm]
+    simp_rw [← Set.indicator_indicator]
+    rfl
+  have hMτ_cad :
+      ∀ ω, IsCadlag (stoppedProcess (fun i => S.indicator (M i)) (τ n) · ω) := by
+    have hc := (isStable_martingale
+      (stoppedProcess (fun i => {ω | ⊥ < hM.localSeq n ω}.indicator (M i))
+        (hM.localSeq n))
+      (hM.stoppedProcess_localSeq n) (hN.localSeq n)
+      (hN.isLocalizingSequence_localSeq.isStoppingTime n)).2
+    intro ω
+    convert hc ω using 1
+    ext i
+    simp_rw [S, τ, stoppedProcess_indicator_comm, Pi.inf_apply, lt_inf_iff,
+      inf_comm (hM.localSeq n)]
+    rw [← stoppedProcess_stoppedProcess, ← stoppedProcess_indicator_comm, Set.setOf_and,
+      Set.inter_comm]
+    simp_rw [← Set.indicator_indicator]
+    rfl
+  have hNτ_mart :
+      Martingale (stoppedProcess (fun i => S.indicator (N i)) (τ n)) 𝓕 P := by
+    have hn := (isStable_martingale
+      (stoppedProcess (fun i => {ω | ⊥ < hN.localSeq n ω}.indicator (N i))
+        (hN.localSeq n))
+      (hN.stoppedProcess_localSeq n) (hM.localSeq n)
+      (hM.isLocalizingSequence_localSeq.isStoppingTime n)).1
+    convert hn using 1
+    ext i ω
+    simp_rw [S, τ, stoppedProcess_indicator_comm, Pi.inf_apply, lt_inf_iff]
+    rw [← stoppedProcess_stoppedProcess, ← stoppedProcess_indicator_comm, Set.setOf_and]
+    simp_rw [← Set.indicator_indicator]
+    rfl
+  have hNτ_cad :
+      ∀ ω, IsCadlag (stoppedProcess (fun i => S.indicator (N i)) (τ n) · ω) := by
+    have hc := (isStable_martingale
+      (stoppedProcess (fun i => {ω | ⊥ < hN.localSeq n ω}.indicator (N i))
+        (hN.localSeq n))
+      (hN.stoppedProcess_localSeq n) (hM.localSeq n)
+      (hM.isLocalizingSequence_localSeq.isStoppingTime n)).2
+    intro ω
+    convert hc ω using 1
+    ext i
+    simp_rw [S, τ, stoppedProcess_indicator_comm, Pi.inf_apply, lt_inf_iff]
+    rw [← stoppedProcess_stoppedProcess, ← stoppedProcess_indicator_comm, Set.setOf_and]
+    simp_rw [← Set.indicator_indicator]
+    rfl
+  refine ⟨?_, ?_⟩
+  · convert hMτ_mart.sub hNτ_mart using 1
+    ext i ω
+    by_cases hω : ω ∈ S
+    · have hω' : ⊥ < τ n ω := by simpa [S] using hω
+      simp [S, stoppedProcess, Pi.sub_apply, hω']
+    · have hω' : ¬ ⊥ < τ n ω := by simpa [S] using hω
+      simp [S, stoppedProcess, Pi.sub_apply, hω']
+  · intro ω
+    have hneg :
+        IsCadlag
+          (fun i : ι =>
+            (-1 : ℝ) • stoppedProcess (fun i => S.indicator (N i)) (τ n) i ω) :=
+      (hNτ_cad ω).const_smul (-1)
+    have hadd :
+        IsCadlag
+          ((fun i : ι => stoppedProcess (fun i => S.indicator (M i)) (τ n) i ω) +
+            fun i => (-1 : ℝ) • stoppedProcess (fun i => S.indicator (N i)) (τ n) i ω) :=
+      (hMτ_cad ω).add hneg
+    convert hadd using 1
+    ext i
+    by_cases hω : ω ∈ S
+    · have hω' : ⊥ < τ n ω := by simpa [S] using hω
+      simp [S, stoppedProcess, Pi.sub_apply, sub_eq_add_neg, hω']
+    · have hω' : ¬ ⊥ < τ n ω := by simpa [S] using hω
+      simp [S, stoppedProcess, Pi.sub_apply, sub_eq_add_neg, hω']
+
+/-- Strong predictability is stable under stopped-process localization with the usual
+localizing indicator. -/
+lemma _root_.MeasureTheory.IsStronglyPredictable.stoppedProcess_indicator
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ]
+    {mΩ' : MeasurableSpace Ω'} {𝓕' : Filtration κ mΩ'}
+    {U : κ → Ω' → ℝ} (hU : IsStronglyPredictable 𝓕' U)
+    {τ : Ω' → WithTop κ} (hτ : IsStoppingTime 𝓕' τ) :
+    IsStronglyPredictable 𝓕'
+      (stoppedProcess (fun i ↦ {ω | ⊥ < τ ω}.indicator (U i)) τ) := by
+  rw [MeasureTheory.IsStronglyPredictable] at hU ⊢
+  let M : κ × Ω' → κ × Ω' :=
+    fun p ↦ ((min (↑p.1 : WithTop κ) (τ p.2)).untopA, p.2)
+  have hM : @Measurable (κ × Ω') (κ × Ω') 𝓕'.predictable 𝓕'.predictable M := by
+    rw [measurable_iff_comap_le, MeasurableSpace.comap_le_iff_le_map]
+    refine MeasurableSpace.generateFrom_le ?_
+    rintro _ (⟨A, hA, rfl⟩ | ⟨i, A, hA, rfl⟩)
+    · rw [MeasurableSpace.map_def]
+      rw [show M ⁻¹' ({⊥} ×ˢ A) =
+          ({⊥} ×ˢ A) ∪ (Set.univ ×ˢ (A ∩ {ω | τ ω ≤ (⊥ : κ)})) by
+        ext p
+        rcases p with ⟨t, ω⟩
+        have hbot : ((min (↑t : WithTop κ) (τ ω)).untopA = (⊥ : κ)) ↔
+            t = ⊥ ∨ τ ω ≤ (⊥ : κ) := by
+          have hmin_ne : min (↑t : WithTop κ) (τ ω) ≠ ⊤ :=
+            ne_top_of_le_ne_top WithTop.coe_ne_top (min_le_left _ _)
+          rw [← WithTop.coe_inj]
+          rw [WithTop.untopA_eq_untop hmin_ne, WithTop.coe_untop]
+          change min (↑t : WithTop κ) (τ ω) = (⊥ : WithTop κ) ↔
+            t = ⊥ ∨ τ ω ≤ (⊥ : κ)
+          rw [min_eq_bot]
+          simp [le_bot_iff]
+        simp [M, Set.mem_prod, hbot, le_bot_iff]
+        tauto]
+      exact (measurableSet_predictable_singleton_bot_prod hA).union
+        (measurableSet_predictable_univ_prod (hA.inter (hτ.measurableSet_le ⊥)))
+    · rw [MeasurableSpace.map_def]
+      rw [show M ⁻¹' (Set.Ioi i ×ˢ A) =
+          Set.Ioi i ×ˢ (A ∩ {ω | (i : WithTop κ) < τ ω}) by
+        ext p
+        rcases p with ⟨t, ω⟩
+        have hi : (i < (min (↑t : WithTop κ) (τ ω)).untopA) ↔
+            i < t ∧ (↑i : WithTop κ) < τ ω := by
+          have hmin_ne : min (↑t : WithTop κ) (τ ω) ≠ ⊤ :=
+            ne_top_of_le_ne_top WithTop.coe_ne_top (min_le_left _ _)
+          rw [WithTop.lt_untopA_iff hmin_ne]
+          simp [lt_inf_iff]
+        simp [M, Set.mem_prod, hi]
+        tauto]
+      exact measurableSet_predictable_Ioi_prod (hA.inter (hτ.measurableSet_gt i))
+  have hS : MeasurableSet[𝓕'.predictable] {p : κ × Ω' | ⊥ < τ p.2} := by
+    convert measurableSet_predictable_univ_prod (𝓕 := 𝓕') (hτ.measurableSet_gt ⊥)
+      using 1
+    ext p
+    simp [Set.mem_prod]
+  have h_eq : Function.uncurry
+      (stoppedProcess (fun i ↦ {ω | ⊥ < τ ω}.indicator (U i)) τ) =
+      {p : κ × Ω' | ⊥ < τ p.2}.indicator (Function.uncurry U ∘ M) := by
+    ext p
+    rcases p with ⟨t, ω⟩
+    simp [stoppedProcess, M, Set.indicator_apply]
+  rw [h_eq]
+  exact StronglyMeasurable.indicator (hU.comp_measurable hM) hS
+
+/-- A locally bounded-variation path remains locally bounded variation after deterministic
+stopping at a `WithTop` time. -/
+lemma _root_.LocallyBoundedVariationOn.stoppedProcess
+    {κ : Type*} [ConditionallyCompleteLinearOrderBot κ] {f : κ → ℝ}
+    (hf : LocallyBoundedVariationOn f Set.univ) (a : WithTop κ) :
+    LocallyBoundedVariationOn
+      (fun t : κ => f (min (↑t : WithTop κ) a).untopA) Set.univ := by
+  intro r u _ _
+  by_cases ha : a ≤ (r : WithTop κ)
+  · have hconst :
+        LocallyBoundedVariationOn (fun _ : κ => f a.untopA) Set.univ := by
+      exact (monotoneOn_const :
+        MonotoneOn (fun _ : κ => f a.untopA) Set.univ).locallyBoundedVariationOn
+    have heq : Set.EqOn
+        (fun t : κ => f (min (↑t : WithTop κ) a).untopA)
+        (fun _ : κ => f a.untopA) (Set.univ ∩ Set.Icc r u) := by
+      intro x hx
+      have hax : a ≤ (x : WithTop κ) := le_trans ha (WithTop.coe_le_coe.2 hx.2.1)
+      simp [min_eq_right hax]
+    change eVariationOn (fun t : κ => f (min (↑t : WithTop κ) a).untopA)
+        (Set.univ ∩ Set.Icc r u) ≠ ∞
+    rw [show eVariationOn (fun t : κ => f (min (↑t : WithTop κ) a).untopA)
+        (Set.univ ∩ Set.Icc r u) =
+        eVariationOn (fun _ : κ => f a.untopA) (Set.univ ∩ Set.Icc r u) from
+        eVariationOn.congr heq]
+    exact hconst r u (Set.mem_univ _) (Set.mem_univ _)
+  · have hle : eVariationOn (fun t : κ => f (min (↑t : WithTop κ) a).untopA)
+        (Set.univ ∩ Set.Icc r u) ≤ eVariationOn f (Set.univ ∩ Set.Icc r u) := by
+      rw [eVariationOn]
+      refine iSup_le ?_
+      rintro ⟨n, v, hv, hvs⟩
+      let g : κ → κ := fun t => (min (↑t : WithTop κ) a).untopA
+      have hg_mono : Monotone g := by
+        intro x y hxy
+        have hmin_ne_y : min (↑y : WithTop κ) a ≠ ⊤ :=
+          ne_top_of_le_ne_top WithTop.coe_ne_top (min_le_left _ _)
+        exact WithTop.untopA_mono hmin_ne_y
+          (min_le_min (WithTop.coe_le_coe.2 hxy) le_rfl)
+      have hg_mem : ∀ x ∈ Set.univ ∩ Set.Icc r u, g x ∈ Set.univ ∩ Set.Icc r u := by
+        intro x hx
+        have hrx : r ≤ x := hx.2.1
+        have hxu : x ≤ u := hx.2.2
+        have hmin_ne : min (↑x : WithTop κ) a ≠ ⊤ :=
+          ne_top_of_le_ne_top WithTop.coe_ne_top (min_le_left _ _)
+        have hrtop : (r : WithTop κ) < a := lt_of_not_ge ha
+        have hrg : r ≤ g x := by
+          rw [WithTop.le_untopA_iff hmin_ne]
+          exact le_inf (WithTop.coe_le_coe.2 hrx) hrtop.le
+        have hgu : g x ≤ u := by
+          rw [WithTop.untopA_le_iff hmin_ne]
+          exact le_trans (min_le_left _ _) (WithTop.coe_le_coe.2 hxu)
+        exact ⟨Set.mem_univ _, hrg, hgu⟩
+      have hsum := eVariationOn.sum_le (f := f) (s := Set.univ ∩ Set.Icc r u)
+        (n := n) (u := fun i => g (v i))
+        (fun i j hij => hg_mono (hv hij))
+        (fun i => hg_mem (v i) (hvs i))
+      simpa [g] using hsum
+    exact ne_top_of_le_ne_top (hf r u (Set.mem_univ _) (Set.mem_univ _)) hle
+
+/-- Pathwise locally bounded variation is stable under stopped-process localization with the
+usual localizing indicator. -/
+lemma locallyBoundedVariationOn_stoppedProcess_indicator
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ]
+    {N : κ → Ω' → ℝ} (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {τ : Ω' → WithTop κ} (ω : Ω') :
+    LocallyBoundedVariationOn
+      ((stoppedProcess (fun i ↦ {ω | ⊥ < τ ω}.indicator (N i)) τ) · ω) Set.univ := by
+  by_cases hω : ⊥ < τ ω
+  · convert (hN_var ω).stoppedProcess (τ ω) using 1
+    ext t
+    simp [stoppedProcess, hω]
+  · have hzero : LocallyBoundedVariationOn (fun _ : κ => (0 : ℝ)) Set.univ := by
+      exact (monotoneOn_const :
+        MonotoneOn (fun _ : κ => (0 : ℝ)) Set.univ).locallyBoundedVariationOn
+    convert hzero using 1
+    ext t
+    simp [stoppedProcess, hω]
+
+/-- A deterministic horizon bound is preserved by stopped-process localization with the usual
+localizing indicator. -/
+lemma _root_.MeasureTheory.stoppedProcess_indicator_bound_on_Icc
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ]
+    {N : κ → Ω' → ℝ} {τ : Ω' → WithTop κ} {ω : Ω'} {t : κ} {C : ℝ}
+    (hC_nonneg : 0 ≤ C)
+    (hbound : ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C) :
+    ∀ s ∈ Set.Icc (⊥ : κ) t,
+      ‖stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ s ω‖ ≤ C := by
+  intro s hs
+  by_cases hω : (⊥ : κ) < τ ω
+  · let g : κ :=
+      (min (↑s : WithTop κ) (τ ω)).untopA
+    have hmin_ne : min (↑s : WithTop κ) (τ ω) ≠ ⊤ :=
+      ne_top_of_le_ne_top WithTop.coe_ne_top (min_le_left _ _)
+    have hg_mem : g ∈ Set.Icc (⊥ : κ) t := by
+      refine ⟨bot_le, ?_⟩
+      rw [WithTop.untopA_le_iff hmin_ne]
+      exact le_trans (min_le_left _ _) (WithTop.coe_le_coe.2 hs.2)
+    have hmem : ω ∈ {ω | (⊥ : κ) < τ ω} := hω
+    change ‖{ω | (⊥ : κ) < τ ω}.indicator (N g) ω‖ ≤ C
+    rw [Set.indicator_of_mem hmem]
+    exact hbound g hg_mem
+  · have hnotmem : ω ∉ {ω | (⊥ : κ) < τ ω} := hω
+    change ‖{ω | (⊥ : κ) < τ ω}.indicator
+      (N (min (↑s : WithTop κ) (τ ω)).untopA) ω‖ ≤ C
+    rw [Set.indicator_of_notMem hnotmem]
+    simpa using hC_nonneg
+
+/-- A stopped/indicator path is bounded on `[⊥, t]` if the original path is bounded strictly
+before the stop and the finite stop value is bounded whenever the stop lies in the horizon. -/
+lemma _root_.MeasureTheory.stoppedProcess_indicator_bound_on_Icc_of_pre_stop_bound
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ]
+    {N : κ → Ω' → ℝ} {τ : Ω' → WithTop κ} {ω : Ω'} {t : κ} {C : ℝ}
+    (hC_nonneg : 0 ≤ C)
+    (hpre : ∀ r ∈ Set.Icc (⊥ : κ) t, (r : WithTop κ) < τ ω → ‖N r ω‖ ≤ C)
+    (hstop : (⊥ : κ) < τ ω → τ ω ≠ ⊤ → τ ω ≤ (t : WithTop κ) →
+      ‖N (τ ω).untopA ω‖ ≤ C) :
+    ∀ s ∈ Set.Icc (⊥ : κ) t,
+      ‖stoppedProcess (fun i ↦ {ω' : Ω' | (⊥ : κ) < τ ω'}.indicator (N i))
+        τ s ω‖ ≤ C := by
+  intro s hs
+  by_cases hbotτ : (⊥ : κ) < τ ω
+  · have hmem : ω ∈ {ω' : Ω' | (⊥ : κ) < τ ω'} := hbotτ
+    by_cases hsτ : (s : WithTop κ) < τ ω
+    · rw [stoppedProcess_eq_of_le hsτ.le, Set.indicator_of_mem hmem]
+      exact hpre s hs hsτ
+    · have hτs : τ ω ≤ (s : WithTop κ) := le_of_not_gt hsτ
+      have hτ_ne_top : τ ω ≠ ⊤ :=
+        ne_top_of_le_ne_top WithTop.coe_ne_top hτs
+      have hτt : τ ω ≤ (t : WithTop κ) :=
+        le_trans hτs (WithTop.coe_le_coe.2 hs.2)
+      rw [stoppedProcess_eq_of_ge hτs, Set.indicator_of_mem hmem]
+      exact hstop hbotτ hτ_ne_top hτt
+  · have hnotmem : ω ∉ {ω' : Ω' | (⊥ : κ) < τ ω'} := hbotτ
+    change ‖{ω' : Ω' | (⊥ : κ) < τ ω'}.indicator
+      (N (min (↑s : WithTop κ) (τ ω)).untopA) ω‖ ≤ C
+    rw [Set.indicator_of_notMem hnotmem]
+    simpa using hC_nonneg
+
+/-- Almost-sure packaging of
+`MeasureTheory.stoppedProcess_indicator_bound_on_Icc_of_pre_stop_bound`. -/
+lemma _root_.MeasureTheory.ae_stoppedProcess_indicator_bound_on_Icc_of_pre_stop_bound
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {N : κ → Ω' → ℝ} {τ : Ω' → WithTop κ} {t : κ} {C : ℝ}
+    (hC_nonneg : 0 ≤ C)
+    (hpre : ∀ᵐ ω ∂P', ∀ r ∈ Set.Icc (⊥ : κ) t,
+      (r : WithTop κ) < τ ω → ‖N r ω‖ ≤ C)
+    (hstop : ∀ᵐ ω ∂P', (⊥ : κ) < τ ω → τ ω ≠ ⊤ →
+      τ ω ≤ (t : WithTop κ) → ‖N (τ ω).untopA ω‖ ≤ C) :
+    ∀ᵐ ω ∂P', ∀ s ∈ Set.Icc (⊥ : κ) t,
+      ‖stoppedProcess (fun i ↦ {ω' : Ω' | (⊥ : κ) < τ ω'}.indicator (N i))
+        τ s ω‖ ≤ C := by
+  filter_upwards [hpre, hstop] with ω hω_pre hω_stop
+  exact MeasureTheory.stoppedProcess_indicator_bound_on_Icc_of_pre_stop_bound
+    (N := N) (τ := τ) (ω := ω) (t := t) (C := C)
+    hC_nonneg hω_pre hω_stop
+
+/-- The extended variation on `[⊥, t]` of a stopped/indicator path is bounded by the
+extended variation of the original path on the same horizon. -/
+lemma _root_.BoundedVariationOn.eVariationOn_stoppedProcess_indicator_le_Icc
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ]
+    {N : κ → Ω' → ℝ} {τ : Ω' → WithTop κ} (ω : Ω') (t : κ) :
+    eVariationOn
+        ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+        (Set.Icc (⊥ : κ) t) ≤
+      eVariationOn (N · ω) (Set.Icc (⊥ : κ) t) := by
+  rw [eVariationOn]
+  refine iSup_le ?_
+  rintro ⟨n, v, hv, hvs⟩
+  by_cases hω : (⊥ : κ) < τ ω
+  · let g : κ → κ := fun s => (min (↑s : WithTop κ) (τ ω)).untopA
+    have hg_mono : Monotone g := by
+      intro x y hxy
+      have hmin_ne_y : min (↑y : WithTop κ) (τ ω) ≠ ⊤ :=
+        ne_top_of_le_ne_top WithTop.coe_ne_top (min_le_left _ _)
+      exact WithTop.untopA_mono hmin_ne_y
+        (min_le_min (WithTop.coe_le_coe.2 hxy) le_rfl)
+    have hg_mem : ∀ s ∈ Set.Icc (⊥ : κ) t, g s ∈ Set.Icc (⊥ : κ) t := by
+      intro s hs
+      have hmin_ne : min (↑s : WithTop κ) (τ ω) ≠ ⊤ :=
+        ne_top_of_le_ne_top WithTop.coe_ne_top (min_le_left _ _)
+      refine ⟨bot_le, ?_⟩
+      rw [WithTop.untopA_le_iff hmin_ne]
+      exact le_trans (min_le_left _ _) (WithTop.coe_le_coe.2 hs.2)
+    have hsum := eVariationOn.sum_le (f := (N · ω)) (s := Set.Icc (⊥ : κ) t)
+      (n := n) (u := fun i => g (v i))
+      (fun i j hij => hg_mono (hv hij))
+      (fun i => hg_mem (v i) (hvs i))
+    have hmem : ω ∈ {ω | (⊥ : κ) < τ ω} := hω
+    calc
+      (∑ i ∈ Finset.range n,
+          edist
+            (((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+              (v (i + 1)))
+            (((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+              (v i)))
+          =
+        ∑ i ∈ Finset.range n,
+          edist (N (g (v (i + 1))) ω) (N (g (v i)) ω) := by
+            refine Finset.sum_congr rfl fun i _hi => ?_
+            change
+              edist ({ω | (⊥ : κ) < τ ω}.indicator (N (g (v (i + 1)))) ω)
+                ({ω | (⊥ : κ) < τ ω}.indicator (N (g (v i))) ω) =
+              edist (N (g (v (i + 1))) ω) (N (g (v i)) ω)
+            rw [Set.indicator_of_mem hmem, Set.indicator_of_mem hmem]
+      _ ≤ eVariationOn (N · ω) (Set.Icc (⊥ : κ) t) := hsum
+  · have hsum_zero :
+        (∑ i ∈ Finset.range n,
+          edist
+            (((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+              (v (i + 1)))
+            (((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+              (v i))) = 0 := by
+      have hnotmem : ω ∉ {ω | (⊥ : κ) < τ ω} := hω
+      refine Finset.sum_eq_zero fun i _hi => ?_
+      change
+        edist
+          ({ω | (⊥ : κ) < τ ω}.indicator
+            (N (min (↑(v (i + 1)) : WithTop κ) (τ ω)).untopA) ω)
+          ({ω | (⊥ : κ) < τ ω}.indicator
+            (N (min (↑(v i) : WithTop κ) (τ ω)).untopA) ω) = 0
+      rw [Set.indicator_of_notMem hnotmem, Set.indicator_of_notMem hnotmem]
+      simp
+    rw [hsum_zero]
+    exact bot_le
+
+/-- Bounded variation and a deterministic real total-variation bound transfer to the
+stopped/indicator path on the same deterministic horizon. -/
+lemma _root_.BoundedVariationOn.stoppedProcess_indicator_variation_bound_on_Icc
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ]
+    {N : κ → Ω' → ℝ} {τ : Ω' → WithTop κ} {ω : Ω'} {t : κ} {V : ℝ}
+    (hvar : BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t))
+    (hV : (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V) :
+    BoundedVariationOn
+        ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+        (Set.Icc (⊥ : κ) t) ∧
+      (eVariationOn
+        ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+        (Set.Icc (⊥ : κ) t)).toReal ≤ V := by
+  have hle := BoundedVariationOn.eVariationOn_stoppedProcess_indicator_le_Icc
+    (N := N) (τ := τ) ω t
+  have hstop_var :
+      BoundedVariationOn
+        ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+        (Set.Icc (⊥ : κ) t) :=
+    ne_top_of_le_ne_top hvar hle
+  refine ⟨hstop_var, ?_⟩
+  exact le_trans (ENNReal.toReal_mono hvar hle) hV
+
+/-- The extended variation on `[⊥, t]` of a stopped/indicator path is bounded by the
+extended variation of the original path on the closed pre-stop part of the horizon. -/
+lemma _root_.BoundedVariationOn.eVariationOn_stoppedProcess_indicator_le_closed_pre_stop_Icc
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ]
+    {N : κ → Ω' → ℝ} {τ : Ω' → WithTop κ} (ω : Ω') (t : κ) :
+    eVariationOn
+        ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+        (Set.Icc (⊥ : κ) t) ≤
+      eVariationOn (N · ω)
+        {r : κ | r ∈ Set.Icc (⊥ : κ) t ∧ (r : WithTop κ) ≤ τ ω} := by
+  rw [eVariationOn]
+  refine iSup_le ?_
+  rintro ⟨n, v, hv, hvs⟩
+  by_cases hω : (⊥ : κ) < τ ω
+  · let g : κ → κ := fun s => (min (↑s : WithTop κ) (τ ω)).untopA
+    have hg_mono : Monotone g := by
+      intro x y hxy
+      have hmin_ne_y : min (↑y : WithTop κ) (τ ω) ≠ ⊤ :=
+        ne_top_of_le_ne_top WithTop.coe_ne_top (min_le_left _ _)
+      exact WithTop.untopA_mono hmin_ne_y
+        (min_le_min (WithTop.coe_le_coe.2 hxy) le_rfl)
+    have hg_mem : ∀ s ∈ Set.Icc (⊥ : κ) t,
+        g s ∈ {r : κ | r ∈ Set.Icc (⊥ : κ) t ∧ (r : WithTop κ) ≤ τ ω} := by
+      intro s hs
+      have hmin_ne : min (↑s : WithTop κ) (τ ω) ≠ ⊤ :=
+        ne_top_of_le_ne_top WithTop.coe_ne_top (min_le_left _ _)
+      refine ⟨⟨bot_le, ?_⟩, ?_⟩
+      · rw [WithTop.untopA_le_iff hmin_ne]
+        exact le_trans (min_le_left _ _) (WithTop.coe_le_coe.2 hs.2)
+      · change ((min (↑s : WithTop κ) (τ ω)).untopA : WithTop κ) ≤ τ ω
+        rw [WithTop.untopA_eq_untop hmin_ne, WithTop.coe_untop]
+        exact min_le_right _ _
+    have hsum := eVariationOn.sum_le (f := (N · ω))
+      (s := {r : κ | r ∈ Set.Icc (⊥ : κ) t ∧ (r : WithTop κ) ≤ τ ω})
+      (n := n) (u := fun i => g (v i))
+      (fun i j hij => hg_mono (hv hij))
+      (fun i => hg_mem (v i) (hvs i))
+    have hmem : ω ∈ {ω | (⊥ : κ) < τ ω} := hω
+    calc
+      (∑ i ∈ Finset.range n,
+          edist
+            (((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+              (v (i + 1)))
+            (((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+              (v i)))
+          =
+        ∑ i ∈ Finset.range n,
+          edist (N (g (v (i + 1))) ω) (N (g (v i)) ω) := by
+            refine Finset.sum_congr rfl fun i _hi => ?_
+            change
+              edist ({ω | (⊥ : κ) < τ ω}.indicator (N (g (v (i + 1)))) ω)
+                ({ω | (⊥ : κ) < τ ω}.indicator (N (g (v i))) ω) =
+              edist (N (g (v (i + 1))) ω) (N (g (v i)) ω)
+            rw [Set.indicator_of_mem hmem, Set.indicator_of_mem hmem]
+      _ ≤ eVariationOn (N · ω)
+          {r : κ | r ∈ Set.Icc (⊥ : κ) t ∧ (r : WithTop κ) ≤ τ ω} := hsum
+  · have hsum_zero :
+        (∑ i ∈ Finset.range n,
+          edist
+            (((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+              (v (i + 1)))
+            (((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+              (v i))) = 0 := by
+      have hnotmem : ω ∉ {ω | (⊥ : κ) < τ ω} := hω
+      refine Finset.sum_eq_zero fun i _hi => ?_
+      change
+        edist
+          ({ω | (⊥ : κ) < τ ω}.indicator
+            (N (min (↑(v (i + 1)) : WithTop κ) (τ ω)).untopA) ω)
+          ({ω | (⊥ : κ) < τ ω}.indicator
+            (N (min (↑(v i) : WithTop κ) (τ ω)).untopA) ω) = 0
+      rw [Set.indicator_of_notMem hnotmem, Set.indicator_of_notMem hnotmem]
+      simp
+    rw [hsum_zero]
+    exact bot_le
+
+set_option linter.style.longLine false in
+/-- Bounded variation and a deterministic real total-variation bound on the closed pre-stop
+horizon transfer to the stopped/indicator path on the full deterministic horizon. -/
+lemma _root_.BoundedVariationOn.stoppedProcess_indicator_variation_bound_on_Icc_of_closed_pre_stop_bound
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ]
+    {N : κ → Ω' → ℝ} {τ : Ω' → WithTop κ} {ω : Ω'} {t : κ} {V : ℝ}
+    (hvar : BoundedVariationOn (N · ω)
+      {r : κ | r ∈ Set.Icc (⊥ : κ) t ∧ (r : WithTop κ) ≤ τ ω})
+    (hV : (eVariationOn (N · ω)
+      {r : κ | r ∈ Set.Icc (⊥ : κ) t ∧ (r : WithTop κ) ≤ τ ω}).toReal ≤ V) :
+    BoundedVariationOn
+        ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+        (Set.Icc (⊥ : κ) t) ∧
+      (eVariationOn
+        ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+        (Set.Icc (⊥ : κ) t)).toReal ≤ V := by
+  have hle := BoundedVariationOn.eVariationOn_stoppedProcess_indicator_le_closed_pre_stop_Icc
+    (N := N) (τ := τ) ω t
+  have hstop_var :
+      BoundedVariationOn
+        ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+        (Set.Icc (⊥ : κ) t) :=
+    ne_top_of_le_ne_top hvar hle
+  refine ⟨hstop_var, ?_⟩
+  exact le_trans (ENNReal.toReal_mono hvar hle) hV
+
+/-- Almost-everywhere packaging of the pre-stop horizon-bound transfer and the closed pre-stop
+variation-bound transfer. -/
+lemma _root_.MeasureTheory.ae_stoppedProcess_indicator_bound_variation_on_Icc_of_pre_stop_bound
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {N : κ → Ω' → ℝ} {τ : Ω' → WithTop κ} {t : κ} {C V : ℝ}
+    (hC_nonneg : 0 ≤ C)
+    (hpre_bound : ∀ᵐ ω ∂P', ∀ r ∈ Set.Icc (⊥ : κ) t,
+      (r : WithTop κ) < τ ω → ‖N r ω‖ ≤ C)
+    (hstop_bound : ∀ᵐ ω ∂P', (⊥ : κ) < τ ω → τ ω ≠ ⊤ →
+      τ ω ≤ (t : WithTop κ) → ‖N (τ ω).untopA ω‖ ≤ C)
+    (hvar_bound : ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω)
+          {r : κ | r ∈ Set.Icc (⊥ : κ) t ∧ (r : WithTop κ) ≤ τ ω} ∧
+        (eVariationOn (N · ω)
+          {r : κ | r ∈ Set.Icc (⊥ : κ) t ∧ (r : WithTop κ) ≤ τ ω}).toReal ≤ V) :
+    (∀ᵐ ω ∂P', ∀ s ∈ Set.Icc (⊥ : κ) t,
+      ‖stoppedProcess (fun i ↦ {ω' : Ω' | (⊥ : κ) < τ ω'}.indicator (N i))
+        τ s ω‖ ≤ C) ∧
+      (∀ᵐ ω ∂P',
+        BoundedVariationOn
+            ((stoppedProcess (fun i ↦ {ω' : Ω' | (⊥ : κ) < τ ω'}.indicator (N i))
+              τ) · ω)
+            (Set.Icc (⊥ : κ) t) ∧
+          (eVariationOn
+            ((stoppedProcess (fun i ↦ {ω' : Ω' | (⊥ : κ) < τ ω'}.indicator (N i))
+              τ) · ω)
+            (Set.Icc (⊥ : κ) t)).toReal ≤ V) := by
+  refine ⟨?_, ?_⟩
+  · exact MeasureTheory.ae_stoppedProcess_indicator_bound_on_Icc_of_pre_stop_bound
+      (N := N) (τ := τ) (t := t) (C := C) hC_nonneg hpre_bound hstop_bound
+  · filter_upwards [hvar_bound] with ω hω_var
+    exact
+      BoundedVariationOn.stoppedProcess_indicator_variation_bound_on_Icc_of_closed_pre_stop_bound
+        (N := N) (τ := τ) (ω := ω) hω_var.1 hω_var.2
+
+/-- Almost-everywhere packaging of the deterministic stopped/indicator horizon-bound and
+variation-bound transfers. -/
+lemma _root_.MeasureTheory.ae_stoppedProcess_indicator_bound_variation_on_Icc
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {N : κ → Ω' → ℝ} {τ : Ω' → WithTop κ} {t : κ} {C V : ℝ}
+    (hC_nonneg : 0 ≤ C)
+    (hbound : ∀ᵐ ω ∂P', ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C)
+    (hvar_bound : ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V) :
+    (∀ᵐ ω ∂P', ∀ s ∈ Set.Icc (⊥ : κ) t,
+      ‖stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ s ω‖ ≤ C) ∧
+      (∀ᵐ ω ∂P',
+        BoundedVariationOn
+            ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+            (Set.Icc (⊥ : κ) t) ∧
+          (eVariationOn
+            ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+            (Set.Icc (⊥ : κ) t)).toReal ≤ V) := by
+  refine ⟨?_, ?_⟩
+  · filter_upwards [hbound] with ω hω_bound
+    exact MeasureTheory.stoppedProcess_indicator_bound_on_Icc
+      (N := N) (τ := τ) (ω := ω) hC_nonneg hω_bound
+  · filter_upwards [hvar_bound] with ω hω_var
+    exact BoundedVariationOn.stoppedProcess_indicator_variation_bound_on_Icc
+      (N := N) (τ := τ) (ω := ω) hω_var.1 hω_var.2
+
+/-- Pathwise continuity on a deterministic horizon is preserved by stopped-process localization
+with the usual localizing indicator. -/
+lemma _root_.MeasureTheory.stoppedProcess_indicator_continuousOn_Icc
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ]
+    {N : κ → Ω' → ℝ} {τ : Ω' → WithTop κ} {ω : Ω'} {t : κ}
+    (hcont : ContinuousOn (N · ω) (Set.Icc (⊥ : κ) t)) :
+    ContinuousOn
+      ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω)
+      (Set.Icc (⊥ : κ) t) := by
+  by_cases hω : (⊥ : κ) < τ ω
+  · have hmem : ω ∈ {ω | (⊥ : κ) < τ ω} := hω
+    by_cases htop : τ ω = ⊤
+    · exact hcont.congr (by
+        intro s _hs
+        simp [stoppedProcess, htop])
+    · obtain ⟨a, ha⟩ := WithTop.ne_top_iff_exists.mp htop
+      have hbot_a : (⊥ : κ) ≤ a := by
+        have hbot_a_lt : (⊥ : κ) < a :=
+          WithTop.coe_lt_coe.mp (by simpa [← ha] using hω)
+        exact hbot_a_lt.le
+      have hg_cont : ContinuousOn (fun s : κ => min s a) (Set.Icc (⊥ : κ) t) :=
+        (Continuous.min continuous_id continuous_const).continuousOn
+      have hg_maps : Set.MapsTo (fun s : κ => min s a)
+          (Set.Icc (⊥ : κ) t) (Set.Icc (⊥ : κ) t) := by
+        intro s hs
+        exact ⟨le_min hs.1 hbot_a, le_trans (min_le_left _ _) hs.2⟩
+      refine (hcont.comp' hg_cont hg_maps).congr ?_
+      intro s _hs
+      change {ω | (⊥ : κ) < τ ω}.indicator
+          (N (min (↑s : WithTop κ) (τ ω)).untopA) ω =
+        N (min s a) ω
+      rw [Set.indicator_of_mem hmem]
+      rw [← ha, ← WithTop.coe_min, WithTop.untopA_coe]
+  · have hnotmem : ω ∉ {ω | (⊥ : κ) < τ ω} := hω
+    have hzero : ContinuousOn (fun _ : κ => (0 : ℝ)) (Set.Icc (⊥ : κ) t) :=
+      continuousOn_const
+    exact hzero.congr (by
+      intro s _hs
+      change {ω | (⊥ : κ) < τ ω}.indicator
+          (N (min (↑s : WithTop κ) (τ ω)).untopA) ω = 0
+      rw [Set.indicator_of_notMem hnotmem])
+
+/-- The deterministic section of the predictable sigma-algebra at a non-initial time is
+measurable with respect to the past sigma-algebra generated by all strictly earlier filtration
+levels. -/
+lemma _root_.MeasureTheory.Filtration.measurable_prod_mk_predictable_past
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ]
+    {mΩ' : MeasurableSpace Ω'} (𝓕' : Filtration κ mΩ') {t : κ}
+    (ht : (⊥ : κ) < t) :
+    @Measurable Ω' (κ × Ω') (⨆ s : {s : κ // s < t}, 𝓕' s)
+      𝓕'.predictable (fun ω => (t, ω)) := by
+  rw [measurable_iff_comap_le]
+  unfold Filtration.predictable
+  rw [MeasurableSpace.comap_generateFrom]
+  refine MeasurableSpace.generateFrom_le ?_
+  rintro _ ⟨S, hS, rfl⟩
+  rcases hS with (⟨A, hA, rfl⟩ | ⟨i, A, hA, rfl⟩)
+  · simp [Set.preimage, Set.mem_prod, ne_of_gt ht]
+  · by_cases hi : i < t
+    · have hA_past : MeasurableSet[(⨆ s : {s : κ // s < t}, 𝓕' s)] A := by
+        exact (le_iSup (fun s : {s : κ // s < t} => 𝓕' s) ⟨i, hi⟩) _ hA
+      simpa [Set.preimage, Set.mem_prod, hi] using hA_past
+    · simp [Set.preimage, Set.mem_prod, hi]
+
+/-- A strongly predictable process sampled at a non-initial deterministic time is measurable
+with respect to the sigma-algebra generated by all strictly earlier filtration levels. -/
+lemma _root_.MeasureTheory.IsStronglyPredictable.stronglyMeasurable_past
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ]
+    {mΩ' : MeasurableSpace Ω'} {𝓕' : Filtration κ mΩ'}
+    {U : κ → Ω' → ℝ} (hU : IsStronglyPredictable 𝓕' U)
+    {t : κ} (ht : (⊥ : κ) < t) :
+    StronglyMeasurable[(⨆ s : {s : κ // s < t}, 𝓕' s)] (U t) := by
+  rw [MeasureTheory.IsStronglyPredictable] at hU
+  simpa [Function.comp_def, Function.uncurry] using
+    hU.comp_measurable (𝓕'.measurable_prod_mk_predictable_past ht)
+
+set_option linter.style.longLine false in
+/-- At a left-isolated deterministic time, strong predictability makes the future section
+measurable at the greatest strict predecessor. -/
+lemma _root_.MeasureTheory.IsStronglyPredictable.stronglyMeasurable_left_isolated_past
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ]
+    {mΩ' : MeasurableSpace Ω'} {𝓕' : Filtration κ mΩ'}
+    {U : κ → Ω' → ℝ} (hU : IsStronglyPredictable 𝓕' U)
+    {s t : κ} (ht : (⊥ : κ) < t) (hst : s < t)
+    (hprev : ∀ r : κ, r < t → r ≤ s) :
+    StronglyMeasurable[𝓕' s] (U t) := by
+  have _hst_used : s < t := hst
+  have hpast :
+      StronglyMeasurable[(⨆ r : {r : κ // r < t}, 𝓕' r)] (U t) :=
+    hU.stronglyMeasurable_past ht
+  exact hpast.mono (iSup_le fun r => 𝓕'.mono (hprev r.1 r.2))
+
+/-- A past-measurable martingale value with zero conditional expectation against the past
+sigma-algebra is zero almost surely.  This is the conditional-expectation reduction used at the
+start of the predictable-jump argument. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_predictable_finiteVariation_past_measurable_value
+    {κ Ω' : Type*} [LinearOrder κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P') {t : κ}
+    (hN_t_past : StronglyMeasurable[(⨆ s : {s : κ // s < t}, 𝓕' s)] (N t))
+    (hN_t_cond : P'[N t | (⨆ s : {s : κ // s < t}, 𝓕' s)] =ᵐ[P'] 0) :
+    N t =ᵐ[P'] 0 := by
+  let mPast : MeasurableSpace Ω' := ⨆ s : {s : κ // s < t}, 𝓕' s
+  have hmPast : mPast ≤ mΩ' := by
+    dsimp [mPast]
+    exact iSup_le fun s => 𝓕'.le s
+  have hcond_eq : P'[N t | mPast] = N t := by
+    exact MeasureTheory.condExp_of_stronglyMeasurable hmPast
+      (by simpa [mPast] using hN_t_past) (hN.integrable t)
+  simpa [mPast, hcond_eq] using hN_t_cond
+
+set_option linter.style.longLine false in
+/-- If a martingale increment is already measurable at the earlier filtration time, then the
+martingale conditional-expectation identity forces that increment to vanish almost surely. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_predictable_finiteVariation_past_measurable_zero_increment
+    {κ Ω' : Type*} [LinearOrder κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P') {s t : κ}
+    (hst : s ≤ t) (hinc_meas : StronglyMeasurable[𝓕' s] (N t - N s)) :
+    N t - N s =ᵐ[P'] 0 := by
+  have hcond_ns_eq : P'[N s | 𝓕' s] = N s := by
+    exact MeasureTheory.condExp_of_stronglyMeasurable (𝓕'.le s) (hN.stronglyMeasurable s)
+      (hN.integrable s)
+  have hcond_ns : P'[N s | 𝓕' s] =ᵐ[P'] N s :=
+    EventuallyEq.of_eq hcond_ns_eq
+  have hcond_inc : P'[N t - N s | 𝓕' s] =ᵐ[P'] 0 := by
+    calc
+      P'[N t - N s | 𝓕' s] =ᵐ[P'] P'[N t | 𝓕' s] - P'[N s | 𝓕' s] :=
+        MeasureTheory.condExp_sub (hN.integrable t) (hN.integrable s) (𝓕' s)
+      _ =ᵐ[P'] N s - N s :=
+        (hN.condExp_ae_eq hst).sub hcond_ns
+      _ =ᵐ[P'] 0 := by simp
+  have hcond_eq : P'[N t - N s | 𝓕' s] = N t - N s := by
+    exact MeasureTheory.condExp_of_stronglyMeasurable (𝓕'.le s) hinc_meas
+      ((hN.integrable t).sub (hN.integrable s))
+  simpa [hcond_eq] using hcond_inc
+
+set_option linter.style.longLine false in
+/-- A predictable martingale whose greatest predecessor value is zero is zero at the
+left-isolated successor. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_predictable_left_isolated_of_previous
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_pred : IsStronglyPredictable 𝓕' N)
+    {s t : κ} (ht : (⊥ : κ) < t) (hst : s < t)
+    (hprev : ∀ r : κ, r < t → r ≤ s) (hs_zero : N s =ᵐ[P'] 0) :
+    N t =ᵐ[P'] 0 := by
+  have hNt_meas : StronglyMeasurable[𝓕' s] (N t) :=
+    hN_pred.stronglyMeasurable_left_isolated_past ht hst hprev
+  have hinc_meas : StronglyMeasurable[𝓕' s] (N t - N s) := by
+    simpa [Pi.sub_apply] using hNt_meas.sub (hN.stronglyMeasurable s)
+  have hinc_zero : N t - N s =ᵐ[P'] 0 :=
+    hN.eq_zero_of_predictable_finiteVariation_past_measurable_zero_increment hst.le hinc_meas
+  filter_upwards [hinc_zero, hs_zero] with ω hinc hs
+  have ht_eq : N t ω = N s ω :=
+    sub_eq_zero.mp (by simpa [Pi.sub_apply] using hinc)
+  exact ht_eq.trans hs
+
+/-- A predictable martingale is zero at a time immediately above the bottom time when its bottom
+value is pointwise zero. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_predictable_bottom_immediate
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_pred : IsStronglyPredictable 𝓕' N) (hN_zero : ∀ ω, N ⊥ ω = 0)
+    {t : κ} (ht : (⊥ : κ) < t)
+    (hbot_prev : ∀ r : κ, r < t → r ≤ (⊥ : κ)) :
+    N t =ᵐ[P'] 0 := by
+  exact hN.eq_zero_of_predictable_left_isolated_of_previous hN_pred ht ht hbot_prev
+    (Eventually.of_forall hN_zero)
+
+/-- Multiplying a future martingale increment by an earlier strongly measurable random variable
+gives zero expectation, provided the product is integrable.  This is the martingale
+orthogonality input for the bounded finite-variation square-increment argument. -/
+lemma _root_.MeasureTheory.Martingale.integral_mul_increment_eq_zero_of_stronglyMeasurable
+    {κ Ω' : Type*} [LinearOrder κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P') {s t : κ}
+    (hst : s ≤ t) {Z : Ω' → ℝ}
+    (hZ_meas : StronglyMeasurable[𝓕' s] Z)
+    (hprod_int : Integrable (fun ω => Z ω * (N t ω - N s ω)) P') :
+    ∫ ω, Z ω * (N t ω - N s ω) ∂P' = 0 := by
+  let Y : Ω' → ℝ := N t - N s
+  have hY_int : Integrable Y P' := by
+    simpa [Y] using (hN.integrable t).sub (hN.integrable s)
+  have hcond_ns_eq : P'[N s | 𝓕' s] = N s := by
+    exact MeasureTheory.condExp_of_stronglyMeasurable (𝓕'.le s)
+      (hN.stronglyMeasurable s) (hN.integrable s)
+  have hcond_ns : P'[N s | 𝓕' s] =ᵐ[P'] N s :=
+    EventuallyEq.of_eq hcond_ns_eq
+  have hcondY : P'[Y | 𝓕' s] =ᵐ[P'] 0 := by
+    calc
+      P'[Y | 𝓕' s] =ᵐ[P'] P'[N t | 𝓕' s] - P'[N s | 𝓕' s] := by
+        simpa [Y] using
+          MeasureTheory.condExp_sub (hN.integrable t) (hN.integrable s) (𝓕' s)
+      _ =ᵐ[P'] N s - N s :=
+        (hN.condExp_ae_eq hst).sub hcond_ns
+      _ =ᵐ[P'] 0 := by simp
+  have hcond_prod : P'[fun ω => Z ω * Y ω | 𝓕' s] =ᵐ[P'] 0 := by
+    calc
+      P'[fun ω => Z ω * Y ω | 𝓕' s]
+          =ᵐ[P'] fun ω => Z ω * P'[Y | 𝓕' s] ω := by
+          exact MeasureTheory.condExp_mul_of_stronglyMeasurable_left hZ_meas
+            (by simpa [Y, Pi.mul_apply, Pi.sub_apply] using hprod_int) hY_int
+      _ =ᵐ[P'] 0 := by
+          filter_upwards [hcondY] with ω hω
+          simp [hω]
+  calc
+    ∫ ω, Z ω * (N t ω - N s ω) ∂P' =
+        ∫ ω, P'[fun ω => Z ω * Y ω | 𝓕' s] ω ∂P' := by
+      exact (MeasureTheory.integral_condExp (μ := P') (m := 𝓕' s)
+        (f := fun ω => Z ω * Y ω) (𝓕'.le s)).symm
+    _ = 0 :=
+      MeasureTheory.integral_eq_zero_of_ae hcond_prod
+
+/-- Orthogonality of disjoint deterministic martingale increments in expectation, with the
+product-integrability hypothesis separated out for bounded/localized applications. -/
+lemma _root_.MeasureTheory.Martingale.integral_increment_mul_increment_eq_zero
+    {κ Ω' : Type*} [LinearOrder κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    {a b c d : κ} (hab : a ≤ b) (hbc : b ≤ c) (hcd : c ≤ d)
+    (hprod_int : Integrable (fun ω => (N b ω - N a ω) * (N d ω - N c ω)) P') :
+    ∫ ω, (N b ω - N a ω) * (N d ω - N c ω) ∂P' = 0 := by
+  have hleft_meas : StronglyMeasurable[𝓕' c] (N b - N a) := by
+    exact ((hN.stronglyMeasurable b).mono (𝓕'.mono hbc)).sub
+      ((hN.stronglyMeasurable a).mono (𝓕'.mono (le_trans hab hbc)))
+  exact hN.integral_mul_increment_eq_zero_of_stronglyMeasurable hcd hleft_meas hprod_int
+
+/-- Conditional expectation preserves an a.e. zero random variable.  This is the final
+conditional-expectation endpoint used after the finite-variation martingale argument has shown
+the fixed-time value itself is zero almost surely. -/
+lemma _root_.MeasureTheory.condExp_ae_eq_zero_of_ae_eq_zero
+    {Ω' : Type*} {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {m : MeasurableSpace Ω'}
+    {X : Ω' → ℝ} (hX : X =ᵐ[P'] 0) :
+    P'[X | m] =ᵐ[P'] 0 := by
+  calc
+    P'[X | m] =ᵐ[P'] P'[(0 : Ω' → ℝ) | m] :=
+      MeasureTheory.condExp_congr_ae hX
+    _ =ᵐ[P'] 0 := by simp
+
+/-- On a time line with a bottom element, locally bounded variation on all compact intervals
+gives a left limit at every deterministic time.  This packages the pathwise left-limit input
+needed for the predictable-jump removal step. -/
+lemma _root_.LocallyBoundedVariationOn.exists_tendsto_left_univ
+    {κ E : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] [PseudoEMetricSpace E] [CompleteSpace E] {f : κ → E}
+    (hf : LocallyBoundedVariationOn f Set.univ) (x : κ) :
+    ∃ l, Tendsto f (nhdsWithin x (Set.Iio x)) (nhds l) := by
+  have hbv : BoundedVariationOn f (Set.Icc (⊥ : κ) x) := by
+    simpa using hf (⊥ : κ) x (Set.mem_univ _) (Set.mem_univ _)
+  rcases hbv.exists_tendsto_left x with ⟨l, hl⟩
+  refine ⟨l, ?_⟩
+  have hset : Set.Iic x ∩ Set.Iio x = Set.Iio x := by
+    ext y
+    constructor
+    · intro hy
+      exact hy.2
+    · intro hy
+      exact ⟨le_of_lt hy, hy⟩
+  simpa [hset] using hl
+
+set_option linter.style.longLine false in
+/-- Along an explicit deterministic sequence approaching `t` from the left, the left-limit
+random variable of a finite-variation martingale is measurable with respect to the sigma-algebra
+generated by the strictly earlier filtration levels. -/
+lemma _root_.MeasureTheory.Martingale.stronglyMeasurable_leftLim_past_of_left_approach
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P')
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {t : κ} {u : ℕ → κ} (hu_lt : ∀ n, u n < t)
+    (hu_tendsto : Tendsto u atTop (nhdsWithin t (Set.Iio t))) :
+    StronglyMeasurable[(⨆ s : {s : κ // s < t}, 𝓕' s)]
+      (fun ω => Function.leftLim (N · ω) t) := by
+  let mPast : MeasurableSpace Ω' := ⨆ s : {s : κ // s < t}, 𝓕' s
+  change StronglyMeasurable[mPast] (fun ω => Function.leftLim (N · ω) t)
+  refine stronglyMeasurable_of_tendsto (m := mPast) (u := atTop)
+    (f := fun n ω => N (u n) ω) ?_ ?_
+  · intro n
+    exact (hN.stronglyMeasurable (u n)).mono
+      (by
+        dsimp [mPast]
+        exact le_iSup (fun s : {s : κ // s < t} => 𝓕' s) ⟨u n, hu_lt n⟩)
+  · rw [tendsto_pi_nhds]
+    intro ω
+    simpa [Function.comp_def] using
+      (tendsto_leftLim_of_tendsto ((hN_var ω).exists_tendsto_left_univ t)).comp
+        hu_tendsto
+
+set_option linter.style.longLine false in
+/-- For a strongly predictable finite-variation martingale, the deterministic jump at `t`
+computed using an explicit left-approaching sequence is measurable with respect to the past
+sigma-algebra. -/
+lemma _root_.MeasureTheory.Martingale.stronglyMeasurable_jump_leftLim_past_of_left_approach
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {t : κ} (ht : (⊥ : κ) < t) {u : ℕ → κ} (hu_lt : ∀ n, u n < t)
+    (hu_tendsto : Tendsto u atTop (nhdsWithin t (Set.Iio t))) :
+    StronglyMeasurable[(⨆ s : {s : κ // s < t}, 𝓕' s)]
+      (fun ω => N t ω - Function.leftLim (N · ω) t) := by
+  have hNt :
+      StronglyMeasurable[(⨆ s : {s : κ // s < t}, 𝓕' s)] (N t) :=
+    hN_pred.stronglyMeasurable_past ht
+  have hleft :
+      StronglyMeasurable[(⨆ s : {s : κ // s < t}, 𝓕' s)]
+        (fun ω => Function.leftLim (N · ω) t) :=
+    hN.stronglyMeasurable_leftLim_past_of_left_approach hN_var hu_lt hu_tendsto
+  simpa [Pi.sub_apply] using hNt.sub hleft
+
+set_option linter.style.longLine false in
+/-- If an integrable random variable is measurable with respect to the sigma-algebra generated by
+the strict past of a filtration and has zero integral on every earlier-filtration set, then it is
+zero almost surely. -/
+lemma _root_.MeasureTheory.Filtration.ae_eq_zero_of_past_setIntegral_eq_zero
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ] {mΩ' : MeasurableSpace Ω'}
+    {P' : Measure Ω'} (𝓕' : Filtration κ mΩ') [IsFiniteMeasure P']
+    {X : Ω' → ℝ} {t : κ} (ht : (⊥ : κ) < t)
+    (hX_int : Integrable X P')
+    (hX_past : StronglyMeasurable[(⨆ s : {s : κ // s < t}, 𝓕' s)] X)
+    (hzero : ∀ s : {s : κ // s < t}, ∀ A : Set Ω',
+      MeasurableSet[𝓕' s] A → ∫ ω in A, X ω ∂P' = 0) :
+    X =ᵐ[P'] 0 := by
+  let mPast : MeasurableSpace Ω' := ⨆ s : {s : κ // s < t}, 𝓕' s
+  let C : Set (Set Ω') :=
+    {A | ∃ s : {s : κ // s < t}, MeasurableSet[𝓕' s] A}
+  have hmPast_le : mPast ≤ mΩ' := by
+    dsimp [mPast]
+    exact iSup_le fun s => 𝓕'.le s
+  have hmPast_eq : mPast = MeasurableSpace.generateFrom C := by
+    dsimp [mPast, C]
+    simpa using
+      (MeasurableSpace.measurableSpace_iSup_eq
+        (fun s : {s : κ // s < t} => 𝓕' s))
+  have hC_pi : IsPiSystem C := by
+    intro A hA B hB hnonempty
+    rcases hA with ⟨s, hA⟩
+    rcases hB with ⟨r, hB⟩
+    by_cases hsr : s.1 ≤ r.1
+    · refine ⟨r, ?_⟩
+      exact MeasurableSet.inter ((𝓕'.mono hsr) A hA) hB
+    · have hrs : r.1 ≤ s.1 := le_of_not_ge hsr
+      refine ⟨s, ?_⟩
+      exact MeasurableSet.inter hA ((𝓕'.mono hrs) B hB)
+  have hzero_past :
+      ∀ A : Set Ω', MeasurableSet[mPast] A → ∫ ω in A, X ω ∂P' = 0 := by
+    intro A hA
+    refine MeasurableSpace.induction_on_inter (m := mPast) (s := C)
+      (C := fun A _ => ∫ ω in A, X ω ∂P' = 0)
+      hmPast_eq hC_pi ?empty ?basic ?compl ?iUnion A hA
+    · simp
+    · intro A hA
+      rcases hA with ⟨s, hA⟩
+      exact hzero s A hA
+    · intro A hA_meas hA_zero
+      have hA_meas_ambient : @MeasurableSet Ω' mΩ' A :=
+        hmPast_le A hA_meas
+      have htotal : ∫ ω, X ω ∂P' = 0 := by
+        simpa using hzero ⟨⊥, ht⟩ Set.univ (MeasurableSet.univ)
+      calc
+        ∫ ω in Aᶜ, X ω ∂P' = ∫ ω, X ω ∂P' - ∫ ω in A, X ω ∂P' := by
+          exact MeasureTheory.setIntegral_compl hA_meas_ambient hX_int
+        _ = 0 := by simp [htotal, hA_zero]
+    · intro f hdisj hfm hfzero
+      have hfm_ambient : ∀ i, @MeasurableSet Ω' mΩ' (f i) :=
+        fun i => hmPast_le (f i) (hfm i)
+      calc
+        ∫ ω in ⋃ i, f i, X ω ∂P' = ∑' i, ∫ ω in f i, X ω ∂P' := by
+          exact MeasureTheory.integral_iUnion hfm_ambient hdisj hX_int.integrableOn
+        _ = 0 := by simp [hfzero]
+  have hX_past' : StronglyMeasurable[mPast] X := by
+    simpa [mPast] using hX_past
+  exact MeasureTheory.ae_eq_zero_of_forall_setIntegral_eq_of_finStronglyMeasurable_trim
+    hmPast_le
+    (fun A hA hAfin => hX_int.integrableOn)
+    (fun A hA hAfin => hzero_past A hA)
+    (hX_past'.finStronglyMeasurable (P'.trim hmPast_le))
+
+set_option linter.style.longLine false in
+/-- A strongly predictable finite-variation martingale has no deterministic jump at `t` once the
+jump is integrable and its integral over every strict-past filtration set is zero. -/
+lemma _root_.MeasureTheory.Martingale.ae_eq_leftLim_of_left_approach_past_setIntegral_zero
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {t : κ} (ht : (⊥ : κ) < t) {u : ℕ → κ} (hu_lt : ∀ n, u n < t)
+    (hu_tendsto : Tendsto u atTop (nhdsWithin t (Set.Iio t)))
+    (hjump_int : Integrable (fun ω => N t ω - Function.leftLim (N · ω) t) P')
+    (hzero : ∀ s : {s : κ // s < t}, ∀ A : Set Ω',
+      MeasurableSet[𝓕' s] A →
+        ∫ ω in A, (N t ω - Function.leftLim (N · ω) t) ∂P' = 0) :
+    N t =ᵐ[P'] fun ω => Function.leftLim (N · ω) t := by
+  have hjump_meas :
+      StronglyMeasurable[(⨆ s : {s : κ // s < t}, 𝓕' s)]
+        (fun ω => N t ω - Function.leftLim (N · ω) t) :=
+    hN.stronglyMeasurable_jump_leftLim_past_of_left_approach
+      hN_pred hN_var ht hu_lt hu_tendsto
+  have hjump_zero :
+      (fun ω => N t ω - Function.leftLim (N · ω) t) =ᵐ[P'] 0 :=
+    𝓕'.ae_eq_zero_of_past_setIntegral_eq_zero ht hjump_int hjump_meas hzero
+  filter_upwards [hjump_zero] with ω hω
+  exact sub_eq_zero.mp hω
+
+set_option linter.style.longLine false in
+/-- A future martingale increment has zero set integral over any event measurable at an
+earlier deterministic time. -/
+lemma _root_.MeasureTheory.Martingale.setIntegral_increment_eq_zero_of_measurableSet
+    {κ Ω' : Type*} [LinearOrder κ] {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') {s u v : κ} (hsu : s ≤ u) (huv : u ≤ v)
+    {A : Set Ω'} (hA : MeasurableSet[𝓕' s] A) :
+    ∫ ω in A, (N v ω - N u ω) ∂P' = 0 := by
+  have hA_u : MeasurableSet[𝓕' u] A := (𝓕'.mono hsu) A hA
+  have heq : ∫ ω in A, N u ω ∂P' = ∫ ω in A, N v ω ∂P' :=
+    hN.setIntegral_eq huv hA_u
+  have hsub :
+      ∫ ω in A, (N v ω - N u ω) ∂P' =
+        ∫ ω in A, N v ω ∂P' - ∫ ω in A, N u ω ∂P' :=
+    MeasureTheory.integral_sub
+      ((hN.integrable v).integrableOn) ((hN.integrable u).integrableOn)
+  rw [hsub]
+  simp [heq]
+
+set_option linter.style.longLine false in
+/-- Dominated convergence turns zero set integrals of left-approaching martingale increments
+into the zero set integral of the deterministic left jump. -/
+lemma _root_.MeasureTheory.Martingale.setIntegral_jump_leftLim_eq_zero_of_left_approach_of_dominated
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P')
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {t : κ} {u : ℕ → κ} (hu_lt : ∀ n, u n < t)
+    (hu_tendsto : Tendsto u atTop (nhdsWithin t (Set.Iio t)))
+    {s : {s : κ // s < t}} {A : Set Ω'} (hA : MeasurableSet[𝓕' s] A)
+    (hu_ge : ∀ᶠ n in atTop, s.1 ≤ u n) {bound : Ω' → ℝ}
+    (hbound_int : Integrable bound (P'.restrict A))
+    (hbound : ∀ n, ∀ᵐ ω ∂P'.restrict A, ‖N t ω - N (u n) ω‖ ≤ bound ω) :
+    ∫ ω in A, (N t ω - Function.leftLim (N · ω) t) ∂P' = 0 := by
+  let F : ℕ → Ω' → ℝ := fun n ω => N t ω - N (u n) ω
+  let G : Ω' → ℝ := fun ω => N t ω - Function.leftLim (N · ω) t
+  have hF_sm : ∀ n, AEStronglyMeasurable (F n) (P'.restrict A) := by
+    intro n
+    have hsm : StronglyMeasurable (F n) := by
+      dsimp [F]
+      exact ((hN.stronglyMeasurable t).mono (𝓕'.le t)).sub
+        ((hN.stronglyMeasurable (u n)).mono (𝓕'.le (u n)))
+    exact hsm.aestronglyMeasurable
+  have hF_tendsto :
+      ∀ᵐ ω ∂P'.restrict A, Tendsto (fun n => F n ω) atTop (nhds (G ω)) := by
+    filter_upwards with ω
+    have hleft : Tendsto (fun n : ℕ => N (u n) ω) atTop
+        (nhds (Function.leftLim (N · ω) t)) := by
+      simpa [Function.comp_def] using
+        (tendsto_leftLim_of_tendsto ((hN_var ω).exists_tendsto_left_univ t)).comp
+          hu_tendsto
+    dsimp [F, G]
+    exact tendsto_const_nhds.sub hleft
+  have hintegral_tendsto :
+      Tendsto (fun n => ∫ ω, F n ω ∂P'.restrict A) atTop
+        (nhds (∫ ω, G ω ∂P'.restrict A)) :=
+    MeasureTheory.tendsto_integral_of_dominated_convergence
+      bound hF_sm hbound_int hbound hF_tendsto
+  have hzero_eventually :
+      ∀ᶠ n in atTop, ∫ ω in A, (N t ω - N (u n) ω) ∂P' = 0 := by
+    filter_upwards [hu_ge] with n hn
+    exact hN.setIntegral_increment_eq_zero_of_measurableSet hn (le_of_lt (hu_lt n)) hA
+  have hzero_tendsto :
+      Tendsto (fun n => ∫ ω, F n ω ∂P'.restrict A) atTop (nhds 0) := by
+    apply tendsto_const_nhds.congr'
+    filter_upwards [hzero_eventually] with n hn
+    simpa [F] using hn.symm
+  have hlim : ∫ ω, G ω ∂P'.restrict A = 0 :=
+    tendsto_nhds_unique hintegral_tendsto hzero_tendsto
+  simpa [G] using hlim
+
+set_option linter.style.longLine false in
+/-- A deterministic sequence converging to `t` from the left is eventually above every fixed
+strict-past time `s < t`. -/
+lemma _root_.Filter.Tendsto.eventually_const_le_of_nhdsWithin_Iio
+    {κ : Type*} [LinearOrder κ] [TopologicalSpace κ] [OrderTopology κ]
+    {u : ℕ → κ} {s t : κ}
+    (hu : Tendsto u atTop (nhdsWithin t (Set.Iio t))) (hst : s < t) :
+    ∀ᶠ n in atTop, s ≤ u n := by
+  have hIoi : Set.Ioi s ∈ nhds t := Ioi_mem_nhds hst
+  have hIoi_within : Set.Ioi s ∈ nhdsWithin t (Set.Iio t) :=
+    nhdsWithin_le_nhds hIoi
+  filter_upwards [hu hIoi_within] with n hn
+  exact le_of_lt hn
+
+/-- A deterministic horizon bound controls increments from a point in `[⊥, t]` to the endpoint. -/
+lemma _root_.MeasureTheory.norm_sub_le_two_mul_of_Icc_bound
+    {κ Ω' : Type*} [Preorder κ] [OrderBot κ] {N : κ → Ω' → ℝ}
+    {t u : κ} {ω : Ω'} {C : ℝ} (hC_nonneg : 0 ≤ C)
+    (hu : u ∈ Set.Icc (⊥ : κ) t)
+    (hbound : ∀ r ∈ Set.Icc (⊥ : κ) t, ‖N r ω‖ ≤ C) :
+    ‖N t ω - N u ω‖ ≤ 2 * C := by
+  have _hC_nonneg_used : 0 ≤ C := hC_nonneg
+  have ht_mem : t ∈ Set.Icc (⊥ : κ) t := ⟨bot_le, le_rfl⟩
+  calc
+    ‖N t ω - N u ω‖ ≤ ‖N t ω‖ + ‖N u ω‖ := norm_sub_le _ _
+    _ ≤ C + C := add_le_add (hbound t ht_mem) (hbound u hu)
+    _ = 2 * C := by ring
+
+set_option linter.style.longLine false in
+/-- A deterministic a.e. bound on `[⊥, t]` supplies the domination needed to remove the predictable
+jump along an explicit left-approaching sequence. -/
+lemma _root_.MeasureTheory.Martingale.ae_eq_leftLim_of_left_approach_past_setIntegral_zero_of_bound
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {t : κ} (ht : (⊥ : κ) < t) {u : ℕ → κ} (hu_lt : ∀ n, u n < t)
+    (hu_tendsto : Tendsto u atTop (nhdsWithin t (Set.Iio t)))
+    {C : ℝ} (hC_nonneg : 0 ≤ C)
+    (hbound_horizon : ∀ᵐ ω ∂P', ∀ r ∈ Set.Icc (⊥ : κ) t, ‖N r ω‖ ≤ C)
+    (hjump_int : Integrable (fun ω => N t ω - Function.leftLim (N · ω) t) P') :
+    N t =ᵐ[P'] fun ω => Function.leftLim (N · ω) t := by
+  refine hN.ae_eq_leftLim_of_left_approach_past_setIntegral_zero
+    hN_pred hN_var ht hu_lt hu_tendsto hjump_int ?_
+  intro s A hA
+  have hu_ge : ∀ᶠ n in atTop, s.1 ≤ u n :=
+    hu_tendsto.eventually_const_le_of_nhdsWithin_Iio s.2
+  refine hN.setIntegral_jump_leftLim_eq_zero_of_left_approach_of_dominated
+    hN_var hu_lt hu_tendsto hA hu_ge
+    (bound := fun _ : Ω' => 2 * C) ?_ ?_
+  · exact MeasureTheory.integrable_const (2 * C)
+  · intro n
+    filter_upwards [MeasureTheory.ae_restrict_of_ae hbound_horizon] with ω hω_bound
+    have hu_mem : u n ∈ Set.Icc (⊥ : κ) t := ⟨bot_le, le_of_lt (hu_lt n)⟩
+    exact MeasureTheory.norm_sub_le_two_mul_of_Icc_bound
+      (N := N) (t := t) (u := u n) (ω := ω) hC_nonneg hu_mem hω_bound
+
+set_option linter.style.longLine false in
+/-- A deterministic a.e. horizon bound makes the deterministic left jump integrable. -/
+lemma _root_.MeasureTheory.Martingale.integrable_jump_leftLim_of_left_approach_of_bound
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {t : κ} (ht : (⊥ : κ) < t) {u : ℕ → κ} (hu_lt : ∀ n, u n < t)
+    (hu_tendsto : Tendsto u atTop (nhdsWithin t (Set.Iio t)))
+    {C : ℝ} (hC_nonneg : 0 ≤ C)
+    (hbound_horizon : ∀ᵐ ω ∂P', ∀ r ∈ Set.Icc (⊥ : κ) t, ‖N r ω‖ ≤ C) :
+    Integrable (fun ω => N t ω - Function.leftLim (N · ω) t) P' := by
+  have hmPast_le : (⨆ s : {s : κ // s < t}, 𝓕' s) ≤ mΩ' := by
+    exact iSup_le fun s => 𝓕'.le s
+  have hjump_sm :
+      StronglyMeasurable (fun ω => N t ω - Function.leftLim (N · ω) t) :=
+    (hN.stronglyMeasurable_jump_leftLim_past_of_left_approach
+      hN_pred hN_var ht hu_lt hu_tendsto).mono hmPast_le
+  refine Integrable.of_bound hjump_sm.aestronglyMeasurable (2 * C) ?_
+  filter_upwards [hbound_horizon] with ω hω_bound
+  have hleft :
+      Tendsto (fun n : ℕ => N (u n) ω) atTop
+        (nhds (Function.leftLim (N · ω) t)) := by
+    simpa [Function.comp_def] using
+      (tendsto_leftLim_of_tendsto ((hN_var ω).exists_tendsto_left_univ t)).comp
+        hu_tendsto
+  have hjump_tendsto :
+      Tendsto (fun n : ℕ => N t ω - N (u n) ω) atTop
+        (nhds (N t ω - Function.leftLim (N · ω) t)) := by
+    exact tendsto_const_nhds.sub hleft
+  have hnorm_tendsto :
+      Tendsto (fun n : ℕ => ‖N t ω - N (u n) ω‖) atTop
+        (nhds ‖N t ω - Function.leftLim (N · ω) t‖) := by
+    exact hjump_tendsto.norm
+  refine le_of_tendsto hnorm_tendsto (Eventually.of_forall ?_)
+  intro n
+  have hu_mem : u n ∈ Set.Icc (⊥ : κ) t := ⟨bot_le, le_of_lt (hu_lt n)⟩
+  exact MeasureTheory.norm_sub_le_two_mul_of_Icc_bound
+    (N := N) (t := t) (u := u n) (ω := ω) hC_nonneg hu_mem hω_bound
+
+set_option linter.style.longLine false in
+/-- Bounded-horizon jump removal without a separate jump-integrability hypothesis. -/
+lemma _root_.MeasureTheory.Martingale.ae_eq_leftLim_of_left_approach_past_setIntegral_zero_of_bound_no_integrability
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {t : κ} (ht : (⊥ : κ) < t) {u : ℕ → κ} (hu_lt : ∀ n, u n < t)
+    (hu_tendsto : Tendsto u atTop (nhdsWithin t (Set.Iio t)))
+    {C : ℝ} (hC_nonneg : 0 ≤ C)
+    (hbound_horizon : ∀ᵐ ω ∂P', ∀ r ∈ Set.Icc (⊥ : κ) t, ‖N r ω‖ ≤ C) :
+    N t =ᵐ[P'] fun ω => Function.leftLim (N · ω) t := by
+  have hjump_int :
+      Integrable (fun ω => N t ω - Function.leftLim (N · ω) t) P' :=
+    hN.integrable_jump_leftLim_of_left_approach_of_bound
+      hN_pred hN_var ht hu_lt hu_tendsto hC_nonneg hbound_horizon
+  exact hN.ae_eq_leftLim_of_left_approach_past_setIntegral_zero_of_bound
+    hN_pred hN_var ht hu_lt hu_tendsto hC_nonneg hbound_horizon hjump_int
+
+set_option linter.style.longLine false in
+/-- Stopped/indicator version of bounded-horizon jump removal along an explicit
+left-approaching deterministic sequence. -/
+lemma _root_.MeasureTheory.Martingale.ae_eq_leftLim_stoppedProcess_indicator_of_left_approach_of_bound
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [SecondCountableTopology κ]
+    [PseudoMetrizableSpace κ] {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] [Approximable 𝓕' P']
+    {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_cadlag : ∀ ω, IsCadlag (N · ω)) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {τ : Ω' → WithTop κ} (hτ : IsStoppingTime 𝓕' τ) {t : κ}
+    (ht : (⊥ : κ) < t) {u : ℕ → κ} (hu_lt : ∀ n, u n < t)
+    (hu_tendsto : Tendsto u atTop (nhdsWithin t (Set.Iio t)))
+    {C : ℝ} (hC_nonneg : 0 ≤ C)
+    (hbound_horizon : ∀ᵐ ω ∂P',
+      ∀ r ∈ Set.Icc (⊥ : κ) t, ‖N r ω‖ ≤ C) :
+    stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ t =ᵐ[P']
+      fun ω => Function.leftLim
+        ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω) t := by
+  let Z : κ → Ω' → ℝ :=
+    stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ
+  have hZ_mart : Martingale Z 𝓕' P' := by
+    simpa [Z] using hN.stoppedProcess_indicator
+      (fun ω ↦ (hN_cadlag ω).right_continuous) hτ
+  have hZ_pred : IsStronglyPredictable 𝓕' Z := by
+    simpa [Z] using hN_pred.stoppedProcess_indicator hτ
+  have hZ_var : ∀ ω, LocallyBoundedVariationOn (Z · ω) Set.univ := by
+    intro ω
+    simpa [Z] using locallyBoundedVariationOn_stoppedProcess_indicator
+      (N := N) (τ := τ) hN_var ω
+  have hZ_bound : ∀ᵐ ω ∂P',
+      ∀ r ∈ Set.Icc (⊥ : κ) t, ‖Z r ω‖ ≤ C := by
+    filter_upwards [hbound_horizon] with ω hω_bound
+    intro r hr
+    simpa [Z] using MeasureTheory.stoppedProcess_indicator_bound_on_Icc
+      (N := N) (τ := τ) (ω := ω) (t := t) (C := C)
+      hC_nonneg hω_bound r hr
+  simpa [Z] using hZ_mart.ae_eq_leftLim_of_left_approach_past_setIntegral_zero_of_bound_no_integrability
+    hZ_pred hZ_var ht hu_lt hu_tendsto hC_nonneg hZ_bound
+
+set_option linter.style.longLine false in
+/-- Localizing-family stopped/indicator bounded-horizon jump removal along an explicit
+left-approaching deterministic sequence. -/
+lemma _root_.MeasureTheory.Martingale.ae_eq_leftLim_localizingSequence_stoppedProcess_indicator_of_left_approach_of_bound
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [SecondCountableTopology κ]
+    [PseudoMetrizableSpace κ] {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] [Approximable 𝓕' P']
+    {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_cadlag : ∀ ω, IsCadlag (N · ω)) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {τ : ℕ → Ω' → WithTop κ} (hτ : IsLocalizingSequence 𝓕' τ P')
+    {t : κ} (ht : (⊥ : κ) < t) {u : ℕ → κ} (hu_lt : ∀ n, u n < t)
+    (hu_tendsto : Tendsto u atTop (nhdsWithin t (Set.Iio t)))
+    {C : ℕ → ℝ} (hC_nonneg : ∀ n, 0 ≤ C n)
+    (hbound_horizon : ∀ n, ∀ᵐ ω ∂P',
+      ∀ r ∈ Set.Icc (⊥ : κ) t, ‖N r ω‖ ≤ C n) :
+    ∀ n,
+      stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n) t
+        =ᵐ[P'] fun ω => Function.leftLim
+          ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω) t := by
+  intro n
+  exact hN.ae_eq_leftLim_stoppedProcess_indicator_of_left_approach_of_bound
+    (τ := τ n) (C := C n) hN_cadlag hN_pred hN_var (hτ.isStoppingTime n)
+    ht hu_lt hu_tendsto (hC_nonneg n) (hbound_horizon n)
+
+set_option linter.style.longLine false in
+/-- Before the stopping time, a stopped/indicator path agrees with the original path on a
+left-neighborhood of the deterministic time. -/
+lemma _root_.MeasureTheory.stoppedProcess_indicator_eventuallyEq_left_of_lt
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] {N : κ → Ω' → ℝ} {τ : Ω' → WithTop κ} {ω : Ω'} {t : κ}
+    (hτt : (t : WithTop κ) < τ ω) :
+    (fun s : κ =>
+        stoppedProcess (fun i ↦ {ω' : Ω' | (⊥ : κ) < τ ω'}.indicator (N i)) τ s ω)
+      =ᶠ[nhdsWithin t (Set.Iio t)] fun s => N s ω := by
+  let S : Set κ := {s | (s : WithTop κ) < τ ω}
+  have hS_open : IsOpen S := isOpen_Iio.preimage WithTop.continuous_coe
+  have hS_mem : S ∈ nhdsWithin t (Set.Iio t) :=
+    mem_nhdsWithin_of_mem_nhds (hS_open.mem_nhds hτt)
+  have hbotτ : (⊥ : κ) < τ ω :=
+    lt_of_le_of_lt (WithTop.coe_le_coe.2 bot_le) hτt
+  have hmem : ω ∈ {ω' : Ω' | (⊥ : κ) < τ ω'} := hbotτ
+  filter_upwards [hS_mem] with s hs
+  have hsτ : (s : WithTop κ) ≤ τ ω := hs.le
+  rw [stoppedProcess_eq_of_le hsτ, Set.indicator_of_mem hmem]
+
+set_option linter.style.longLine false in
+/-- The left limit of a stopped/indicator path equals the original left limit on the event
+`t < τ`. -/
+lemma _root_.MeasureTheory.leftLim_stoppedProcess_indicator_eq_of_lt
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] {N : κ → Ω' → ℝ} {τ : Ω' → WithTop κ} {ω : Ω'} {t : κ}
+    (hN_var : LocallyBoundedVariationOn (N · ω) Set.univ)
+    (hτt : (t : WithTop κ) < τ ω) :
+    Function.leftLim
+        ((stoppedProcess (fun i ↦ {ω' : Ω' | (⊥ : κ) < τ ω'}.indicator (N i)) τ) · ω) t =
+      Function.leftLim (N · ω) t := by
+  let Z : κ → Ω' → ℝ :=
+    stoppedProcess (fun i ↦ {ω' : Ω' | (⊥ : κ) < τ ω'}.indicator (N i)) τ
+  have hterminal : Z t ω = N t ω := by
+    have hbotτ : (⊥ : κ) < τ ω :=
+      lt_of_le_of_lt (WithTop.coe_le_coe.2 bot_le) hτt
+    have hmem : ω ∈ {ω' : Ω' | (⊥ : κ) < τ ω'} := hbotτ
+    change stoppedProcess (fun i ↦ {ω' : Ω' | (⊥ : κ) < τ ω'}.indicator (N i)) τ
+      t ω = N t ω
+    rw [stoppedProcess_eq_of_le hτt.le, Set.indicator_of_mem hmem]
+  by_cases hleft_bot : nhdsWithin t (Set.Iio t) = ⊥
+  · rw [leftLim_eq_of_eq_bot ((Z · ω)) hleft_bot,
+      leftLim_eq_of_eq_bot (N · ω) hleft_bot]
+    exact hterminal
+  · have heq :
+        ((Z · ω) =ᶠ[nhdsWithin t (Set.Iio t)] fun s : κ => N s ω) := by
+      simpa [Z] using
+        MeasureTheory.stoppedProcess_indicator_eventuallyEq_left_of_lt
+          (N := N) (τ := τ) (ω := ω) (t := t) hτt
+    have hN_left :
+        Tendsto (N · ω) (nhdsWithin t (Set.Iio t))
+          (nhds (Function.leftLim (N · ω) t)) :=
+      tendsto_leftLim_of_tendsto (hN_var.exists_tendsto_left_univ t)
+    have hZ_left :
+        Tendsto (Z · ω) (nhdsWithin t (Set.Iio t))
+          (nhds (Function.leftLim (N · ω) t)) :=
+      hN_left.congr' heq.symm
+    exact leftLim_eq_of_tendsto hleft_bot hZ_left
+
+set_option linter.style.longLine false in
+/-- On the event `{ω | t < τ ω}`, the stopped/indicator jump-removal theorem transfers back to
+the original martingale. -/
+lemma _root_.MeasureTheory.Martingale.ae_eq_leftLim_on_event_of_left_approach_of_bound
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [SecondCountableTopology κ]
+    [PseudoMetrizableSpace κ] {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] [Approximable 𝓕' P']
+    {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_cadlag : ∀ ω, IsCadlag (N · ω)) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {τ : Ω' → WithTop κ} (hτ : IsStoppingTime 𝓕' τ) {t : κ}
+    (ht : (⊥ : κ) < t) {u : ℕ → κ} (hu_lt : ∀ n, u n < t)
+    (hu_tendsto : Tendsto u atTop (nhdsWithin t (Set.Iio t)))
+    {C : ℝ} (hC_nonneg : 0 ≤ C)
+    (hbound_horizon : ∀ᵐ ω ∂P',
+      ∀ r ∈ Set.Icc (⊥ : κ) t, ‖N r ω‖ ≤ C) :
+    ∀ᵐ ω ∂P', (t : WithTop κ) < τ ω →
+      N t ω = Function.leftLim (N · ω) t := by
+  have hstopped :
+      stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ t =ᵐ[P']
+        fun ω => Function.leftLim
+          ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω) t :=
+    hN.ae_eq_leftLim_stoppedProcess_indicator_of_left_approach_of_bound
+      hN_cadlag hN_pred hN_var hτ ht hu_lt hu_tendsto hC_nonneg hbound_horizon
+  filter_upwards [hstopped] with ω hω_stopped hτt
+  have hterminal :
+      stoppedProcess (fun i ↦ {ω' : Ω' | (⊥ : κ) < τ ω'}.indicator (N i)) τ t ω =
+        N t ω := by
+    have hbotτ : (⊥ : κ) < τ ω :=
+      lt_of_le_of_lt (WithTop.coe_le_coe.2 bot_le) hτt
+    have hmem : ω ∈ {ω' : Ω' | (⊥ : κ) < τ ω'} := hbotτ
+    rw [stoppedProcess_eq_of_le hτt.le, Set.indicator_of_mem hmem]
+  have hleft :
+      Function.leftLim
+          ((stoppedProcess (fun i ↦ {ω' : Ω' | (⊥ : κ) < τ ω'}.indicator (N i)) τ) · ω) t =
+        Function.leftLim (N · ω) t :=
+    MeasureTheory.leftLim_stoppedProcess_indicator_eq_of_lt
+      (N := N) (τ := τ) (ω := ω) (t := t) (hN_var ω) hτt
+  calc
+    N t ω =
+        stoppedProcess (fun i ↦ {ω' : Ω' | (⊥ : κ) < τ ω'}.indicator (N i)) τ t ω :=
+      hterminal.symm
+    _ = Function.leftLim
+          ((stoppedProcess (fun i ↦ {ω' : Ω' | (⊥ : κ) < τ ω'}.indicator (N i)) τ) · ω) t :=
+      hω_stopped
+    _ = Function.leftLim (N · ω) t := hleft
+
+set_option linter.style.longLine false in
+/-- Localizing-sequence version of deterministic jump removal, transferred from stopped pieces
+back to the original martingale. -/
+lemma _root_.MeasureTheory.Martingale.ae_eq_leftLim_localizingSequence_of_left_approach_of_bound
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [SecondCountableTopology κ]
+    [PseudoMetrizableSpace κ] {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] [Approximable 𝓕' P']
+    {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_cadlag : ∀ ω, IsCadlag (N · ω)) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {τ : ℕ → Ω' → WithTop κ} (hτ : IsLocalizingSequence 𝓕' τ P')
+    {t : κ} (ht : (⊥ : κ) < t) {u : ℕ → κ} (hu_lt : ∀ n, u n < t)
+    (hu_tendsto : Tendsto u atTop (nhdsWithin t (Set.Iio t)))
+    {C : ℕ → ℝ} (hC_nonneg : ∀ n, 0 ≤ C n)
+    (hbound_horizon : ∀ n, ∀ᵐ ω ∂P',
+      ∀ r ∈ Set.Icc (⊥ : κ) t, ‖N r ω‖ ≤ C n) :
+    N t =ᵐ[P'] fun ω => Function.leftLim (N · ω) t := by
+  have hon_event : ∀ n, ∀ᵐ ω ∂P', (t : WithTop κ) < τ n ω →
+      N t ω = Function.leftLim (N · ω) t := by
+    intro n
+    exact hN.ae_eq_leftLim_on_event_of_left_approach_of_bound
+      (τ := τ n) (C := C n) hN_cadlag hN_pred hN_var (hτ.isStoppingTime n)
+      ht hu_lt hu_tendsto (hC_nonneg n) (hbound_horizon n)
+  have hall_event : ∀ᵐ ω ∂P', ∀ n, (t : WithTop κ) < τ n ω →
+      N t ω = Function.leftLim (N · ω) t :=
+    ae_all_iff.2 hon_event
+  have hcover : ∀ᵐ ω ∂P', ∃ n, (t : WithTop κ) < τ n ω := by
+    filter_upwards [hτ.tendsto_top] with ω htop
+    simp only [tendsto_atTop_nhds] at htop
+    obtain ⟨n, hn⟩ := htop (Set.Ioi (t : WithTop κ)) (by simp) isOpen_Ioi
+    exact ⟨n, hn n le_rfl⟩
+  filter_upwards [hcover, hall_event] with ω hω_cover hω_all
+  rcases hω_cover with ⟨n, hωn⟩
+  exact hω_all n hωn
+
+set_option linter.style.longLine false in
+/-- If all increments from a deterministic left-approaching sequence to `t` are already
+measurable at their earlier times, then a finite-variation martingale has no jump at `t` along
+that sequence. -/
+lemma _root_.MeasureTheory.Martingale.ae_eq_leftLim_of_left_approach_past_measurable_increments
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P')
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {t : κ} {u : ℕ → κ} (hu_lt : ∀ n, u n < t)
+    (hu_tendsto : Tendsto u atTop (nhdsWithin t (Set.Iio t)))
+    (hinc_meas : ∀ n, StronglyMeasurable[𝓕' (u n)] (N t - N (u n))) :
+    N t =ᵐ[P'] fun ω => Function.leftLim (N · ω) t := by
+  have hzero : ∀ n, N t - N (u n) =ᵐ[P'] 0 := fun n =>
+    hN.eq_zero_of_predictable_finiteVariation_past_measurable_zero_increment
+      (le_of_lt (hu_lt n)) (hinc_meas n)
+  have hzero_all : ∀ᵐ ω ∂P', ∀ n, (N t - N (u n)) ω = 0 :=
+    ae_all_iff.2 hzero
+  filter_upwards [hzero_all] with ω hω
+  have hconst :
+      Tendsto (fun n : ℕ => N (u n) ω) atTop (nhds (N t ω)) := by
+    apply tendsto_const_nhds.congr'
+    filter_upwards with n
+    exact sub_eq_zero.mp (by simpa [Pi.sub_apply] using hω n)
+  have hleft :
+      Tendsto (fun n : ℕ => N (u n) ω) atTop
+        (nhds (Function.leftLim (N · ω) t)) := by
+    simpa [Function.comp_def] using
+      (tendsto_leftLim_of_tendsto ((hN_var ω).exists_tendsto_left_univ t)).comp
+        hu_tendsto
+  exact tendsto_nhds_unique hconst hleft
+
+/-- For a finite monotone partition inside `s`, the sum of absolute increments is controlled by
+the total variation.  This is the pathwise estimate used in the square-increment part of the
+predictable finite-variation uniqueness proof. -/
+lemma _root_.BoundedVariationOn.sum_norm_sub_le_toReal_eVariationOn
+      {κ : Type*} [LinearOrder κ] {f : κ → ℝ} {s : Set κ}
+      (hf : BoundedVariationOn f s) {n : ℕ} {u : ℕ → κ}
+      (hu : Monotone u) (hus : ∀ i, u i ∈ s) :
+      (∑ i ∈ Finset.range n, ‖f (u (i + 1)) - f (u i)‖) ≤
+        (eVariationOn f s).toReal := by
+    have hsum_nonneg :
+        0 ≤ (∑ i ∈ Finset.range n, ‖f (u (i + 1)) - f (u i)‖) := by
+      exact Finset.sum_nonneg fun i _ => norm_nonneg _
+    have hsum_enn :
+        ENNReal.ofReal (∑ i ∈ Finset.range n, ‖f (u (i + 1)) - f (u i)‖) ≤
+          eVariationOn f s := by
+      calc
+        ENNReal.ofReal (∑ i ∈ Finset.range n, ‖f (u (i + 1)) - f (u i)‖)
+            = ∑ i ∈ Finset.range n,
+                ENNReal.ofReal ‖f (u (i + 1)) - f (u i)‖ := by
+                rw [ENNReal.ofReal_sum_of_nonneg]
+                exact fun i _ => norm_nonneg _
+        _ = ∑ i ∈ Finset.range n, edist (f (u (i + 1))) (f (u i)) := by
+            refine Finset.sum_congr rfl fun i _ => ?_
+            rw [edist_dist, dist_eq_norm]
+        _ ≤ eVariationOn f s :=
+            eVariationOn.sum_le hu hus
+    have htoReal := ENNReal.toReal_mono hf hsum_enn
+    rw [ENNReal.toReal_ofReal hsum_nonneg] at htoReal
+    exact htoReal
+
+/-- If all increments in a finite monotone partition are bounded by `δ`, then the sum of
+squared increments is bounded by `δ` times the total variation. -/
+lemma _root_.BoundedVariationOn.sq_increment_sum_le_uniform_bound
+      {κ : Type*} [LinearOrder κ] {f : κ → ℝ} {s : Set κ}
+      (hf : BoundedVariationOn f s) {n : ℕ} {u : ℕ → κ} {δ : ℝ}
+      (hu : Monotone u) (hus : ∀ i, u i ∈ s) (hδ : 0 ≤ δ)
+      (hstep : ∀ i, i ∈ Finset.range n → ‖f (u (i + 1)) - f (u i)‖ ≤ δ) :
+      (∑ i ∈ Finset.range n, ‖f (u (i + 1)) - f (u i)‖ ^ 2) ≤
+        δ * (eVariationOn f s).toReal := by
+    calc
+      (∑ i ∈ Finset.range n, ‖f (u (i + 1)) - f (u i)‖ ^ 2)
+          ≤ ∑ i ∈ Finset.range n, δ * ‖f (u (i + 1)) - f (u i)‖ := by
+          refine Finset.sum_le_sum fun i hi => ?_
+          rw [pow_two]
+          exact mul_le_mul_of_nonneg_right (hstep i hi) (norm_nonneg _)
+      _ = δ * (∑ i ∈ Finset.range n, ‖f (u (i + 1)) - f (u i)‖) := by
+          rw [Finset.mul_sum]
+      _ ≤ δ * (eVariationOn f s).toReal := by
+          exact mul_le_mul_of_nonneg_left
+            (hf.sum_norm_sub_le_toReal_eVariationOn hu hus) hδ
+
+/-- Along partitions whose largest increment is bounded by a deterministic quantity tending to
+zero, finite variation forces the square-increment sums to tend to zero.  The stochastic proof
+still has to provide these partitions and the uniform increment bound from continuity. -/
+lemma _root_.BoundedVariationOn.sq_increment_sum_tendsto_zero_of_uniform_bound
+      {κ : Type*} [LinearOrder κ] {f : κ → ℝ} {s : Set κ}
+      (hf : BoundedVariationOn f s) {m : ℕ → ℕ} {u : ℕ → ℕ → κ} {δ : ℕ → ℝ}
+    (hu : ∀ n, Monotone (u n)) (hus : ∀ n i, u n i ∈ s)
+    (hδ_nonneg : ∀ n, 0 ≤ δ n) (hδ_tendsto : Tendsto δ atTop (nhds 0))
+      (hstep : ∀ n i, i ∈ Finset.range (m n) →
+        ‖f (u n (i + 1)) - f (u n i)‖ ≤ δ n) :
+    Tendsto
+      (fun n => ∑ i ∈ Finset.range (m n),
+        ‖f (u n (i + 1)) - f (u n i)‖ ^ 2) atTop (nhds 0) := by
+    refine squeeze_zero
+      (fun n => Finset.sum_nonneg fun i _ => sq_nonneg _)
+      (fun n => hf.sq_increment_sum_le_uniform_bound (hu n) (hus n) (hδ_nonneg n)
+        (hstep n)) ?_
+    have hlim :
+        Tendsto (fun n => δ n * (eVariationOn f s).toReal) atTop
+          (nhds (0 * (eVariationOn f s).toReal)) :=
+      hδ_tendsto.mul tendsto_const_nhds
+    simpa using hlim
+
+/-- Martingale increments have zero conditional expectation from any earlier filtration time. -/
+lemma _root_.MeasureTheory.Martingale.condExp_increment_eq_zero
+    {κ Ω' : Type*} [LinearOrder κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    {s u v : κ} (hsu : s ≤ u) (huv : u ≤ v) :
+    P'[N v - N u | 𝓕' s] =ᵐ[P'] 0 := by
+  have hcond_u : P'[N u | 𝓕' s] =ᵐ[P'] N s := hN.condExp_ae_eq hsu
+  have hcond_v : P'[N v | 𝓕' s] =ᵐ[P'] N s :=
+    hN.condExp_ae_eq (le_trans hsu huv)
+  calc
+    P'[N v - N u | 𝓕' s] =ᵐ[P'] P'[N v | 𝓕' s] - P'[N u | 𝓕' s] :=
+      MeasureTheory.condExp_sub (hN.integrable v) (hN.integrable u) (𝓕' s)
+    _ =ᵐ[P'] N s - N s := hcond_v.sub hcond_u
+    _ =ᵐ[P'] 0 := by simp
+
+/-- Orthogonality in expectation for disjoint deterministic martingale increments.
+
+The product integrability hypothesis is kept explicit; the bounded-continuous core will get it
+from bounded localization. -/
+lemma _root_.MeasureTheory.Martingale.integral_mul_increment_eq_zero
+    {κ Ω' : Type*} [LinearOrder κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    {a b c d : κ} (hab : a ≤ b) (hbc : b ≤ c) (hcd : c ≤ d)
+    (hprod : Integrable (fun ω => (N b ω - N a ω) * (N d ω - N c ω)) P') :
+    ∫ ω, (N b ω - N a ω) * (N d ω - N c ω) ∂P' = 0 := by
+  exact hN.integral_increment_mul_increment_eq_zero hab hbc hcd hprod
+
+/-- A finite sum of consecutive increments telescopes. -/
+lemma _root_.Finset.sum_range_sub_consecutive {G : Type*} [AddCommGroup G]
+    (f : ℕ → G) (n : ℕ) :
+    (∑ i ∈ Finset.range n, (f (i + 1) - f i)) = f n - f 0 := by
+  induction n with
+  | zero => simp
+  | succ n ih =>
+      rw [Finset.sum_range_succ, ih]
+      abel
+
+/-- The finite partition increment sum equals the terminal value for a martingale normalized at
+the bottom time. -/
+lemma _root_.MeasureTheory.Martingale.partition_increment_sum_eq_terminal
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P') (hN_zero : ∀ ω, N ⊥ ω = 0)
+    {u : ℕ → κ} {n : ℕ} {t : κ} (hu0 : u 0 = ⊥) (hun : u n = t) :
+    (fun ω => ∑ i ∈ Finset.range n, (N (u (i + 1)) ω - N (u i) ω)) = N t := by
+  have _hN_used : Martingale N 𝓕' P' := hN
+  ext ω
+  have htel := Finset.sum_range_sub_consecutive (fun i => N (u i) ω) n
+  rw [htel, hun, hu0, hN_zero ω]
+  simp
+
+/-- Orthogonality for two distinct ordered increments in a monotone deterministic partition. -/
+lemma _root_.MeasureTheory.Martingale.integral_partition_cross_increment_eq_zero
+    {κ Ω' : Type*} [LinearOrder κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    {u : ℕ → κ} (hu : Monotone u) {i j : ℕ} (hij : i < j)
+    (hprod : Integrable (fun ω => (N (u (i + 1)) ω - N (u i) ω) *
+      (N (u (j + 1)) ω - N (u j) ω)) P') :
+    ∫ ω, (N (u (i + 1)) ω - N (u i) ω) *
+      (N (u (j + 1)) ω - N (u j) ω) ∂P' = 0 := by
+  have hab : u i ≤ u (i + 1) := hu (Nat.le_succ i)
+  have hbc : u (i + 1) ≤ u j := hu (Nat.succ_le_of_lt hij)
+  have hcd : u j ≤ u (j + 1) := hu (Nat.le_succ j)
+  exact hN.integral_increment_mul_increment_eq_zero hab hbc hcd hprod
+
+/-- A uniform bound on the partition values gives integrability of products of two adjacent
+increments.  This supplies the explicit integrability premise in the finite-partition
+orthogonality lemma after bounded localization. -/
+lemma _root_.MeasureTheory.Martingale.integrable_partition_increment_mul_increment_of_bound
+    {κ Ω' : Type*} [LinearOrder κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    {u : ℕ → κ} {C : ℝ} (hC_nonneg : 0 ≤ C)
+    (hbound : ∀ᵐ ω ∂P', ∀ k, ‖N (u k) ω‖ ≤ C) (i j : ℕ) :
+    Integrable
+      (fun ω => (N (u (i + 1)) ω - N (u i) ω) *
+        (N (u (j + 1)) ω - N (u j) ω)) P' := by
+  have hleft_sm : StronglyMeasurable
+      (fun ω => N (u (i + 1)) ω - N (u i) ω) :=
+    ((hN.stronglyMeasurable (u (i + 1))).mono (𝓕'.le (u (i + 1)))).sub
+      ((hN.stronglyMeasurable (u i)).mono (𝓕'.le (u i)))
+  have hright_sm : StronglyMeasurable
+      (fun ω => N (u (j + 1)) ω - N (u j) ω) :=
+    ((hN.stronglyMeasurable (u (j + 1))).mono (𝓕'.le (u (j + 1)))).sub
+      ((hN.stronglyMeasurable (u j)).mono (𝓕'.le (u j)))
+  refine Integrable.of_bound
+    ((hleft_sm.mul hright_sm).aestronglyMeasurable) (4 * C ^ 2) ?_
+  filter_upwards [hbound] with ω hω
+  have hleft : ‖N (u (i + 1)) ω - N (u i) ω‖ ≤ 2 * C := by
+    calc
+      ‖N (u (i + 1)) ω - N (u i) ω‖
+          ≤ ‖N (u (i + 1)) ω‖ + ‖N (u i) ω‖ := norm_sub_le _ _
+      _ ≤ C + C := add_le_add (hω (i + 1)) (hω i)
+      _ = 2 * C := by ring
+  have hright : ‖N (u (j + 1)) ω - N (u j) ω‖ ≤ 2 * C := by
+    calc
+      ‖N (u (j + 1)) ω - N (u j) ω‖
+          ≤ ‖N (u (j + 1)) ω‖ + ‖N (u j) ω‖ := norm_sub_le _ _
+      _ ≤ C + C := add_le_add (hω (j + 1)) (hω j)
+      _ = 2 * C := by ring
+  calc
+    ‖(N (u (i + 1)) ω - N (u i) ω) *
+        (N (u (j + 1)) ω - N (u j) ω)‖
+        = ‖N (u (i + 1)) ω - N (u i) ω‖ *
+          ‖N (u (j + 1)) ω - N (u j) ω‖ := norm_mul _ _
+    _ ≤ (2 * C) * (2 * C) :=
+        mul_le_mul hleft hright (norm_nonneg _) (by nlinarith)
+    _ = 4 * C ^ 2 := by ring
+
+/-- A uniform bound on partition values makes the product of a partition value and its next
+increment integrable.  This is the induction cross-term used in the terminal square identity. -/
+lemma _root_.MeasureTheory.Martingale.integrable_partition_value_mul_increment_of_bound
+    {κ Ω' : Type*} [LinearOrder κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    {u : ℕ → κ} {C : ℝ} (hC_nonneg : 0 ≤ C)
+    (hbound : ∀ᵐ ω ∂P', ∀ k, ‖N (u k) ω‖ ≤ C) (i : ℕ) :
+    Integrable
+      (fun ω => N (u i) ω * (N (u (i + 1)) ω - N (u i) ω)) P' := by
+  have hvalue_sm : StronglyMeasurable (fun ω => N (u i) ω) :=
+    ((hN.stronglyMeasurable (u i)).mono (𝓕'.le (u i)))
+  have hinc_sm : StronglyMeasurable
+      (fun ω => N (u (i + 1)) ω - N (u i) ω) :=
+    ((hN.stronglyMeasurable (u (i + 1))).mono (𝓕'.le (u (i + 1)))).sub
+      ((hN.stronglyMeasurable (u i)).mono (𝓕'.le (u i)))
+  refine Integrable.of_bound
+    ((hvalue_sm.mul hinc_sm).aestronglyMeasurable) (2 * C ^ 2) ?_
+  filter_upwards [hbound] with ω hω
+  have hinc : ‖N (u (i + 1)) ω - N (u i) ω‖ ≤ 2 * C := by
+    calc
+      ‖N (u (i + 1)) ω - N (u i) ω‖
+          ≤ ‖N (u (i + 1)) ω‖ + ‖N (u i) ω‖ := norm_sub_le _ _
+      _ ≤ C + C := add_le_add (hω (i + 1)) (hω i)
+      _ = 2 * C := by ring
+  calc
+    ‖N (u i) ω * (N (u (i + 1)) ω - N (u i) ω)‖
+        = ‖N (u i) ω‖ * ‖N (u (i + 1)) ω - N (u i) ω‖ := norm_mul _ _
+    _ ≤ C * (2 * C) :=
+        mul_le_mul (hω i) hinc (norm_nonneg _) hC_nonneg
+    _ = 2 * C ^ 2 := by ring
+
+/-- A uniform bound on the partition values gives integrability of each squared adjacent
+increment. -/
+lemma _root_.MeasureTheory.Martingale.integrable_partition_sq_increment_of_bound
+    {κ Ω' : Type*} [LinearOrder κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    {u : ℕ → κ} {C : ℝ} (hC_nonneg : 0 ≤ C)
+    (hbound : ∀ᵐ ω ∂P', ∀ k, ‖N (u k) ω‖ ≤ C) (i : ℕ) :
+    Integrable (fun ω => (N (u (i + 1)) ω - N (u i) ω) ^ 2) P' := by
+  simpa [pow_two] using
+    hN.integrable_partition_increment_mul_increment_of_bound hC_nonneg hbound i i
+
+/-- A bounded deterministic partition has an integrable finite sum of squared adjacent
+increments. -/
+lemma _root_.MeasureTheory.Martingale.integrable_partition_sq_increment_sum_of_bound
+    {κ Ω' : Type*} [LinearOrder κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    {u : ℕ → κ} {C : ℝ} (hC_nonneg : 0 ≤ C)
+    (hbound : ∀ᵐ ω ∂P', ∀ k, ‖N (u k) ω‖ ≤ C) (n : ℕ) :
+    Integrable
+      (fun ω => ∑ i ∈ Finset.range n,
+        (N (u (i + 1)) ω - N (u i) ω) ^ 2) P' := by
+  exact MeasureTheory.integrable_finsetSum (Finset.range n) fun i _ =>
+    hN.integrable_partition_sq_increment_of_bound hC_nonneg hbound i
+
+/-- The integral of a finite sum of squared partition increments is the sum of their
+integrals under the bounded-partition hypotheses. -/
+lemma _root_.MeasureTheory.Martingale.integral_partition_sq_increment_sum_of_bound
+    {κ Ω' : Type*} [LinearOrder κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    {u : ℕ → κ} {C : ℝ} (hC_nonneg : 0 ≤ C)
+    (hbound : ∀ᵐ ω ∂P', ∀ k, ‖N (u k) ω‖ ≤ C) (n : ℕ) :
+    ∫ ω, (∑ i ∈ Finset.range n,
+      (N (u (i + 1)) ω - N (u i) ω) ^ 2) ∂P' =
+      ∑ i ∈ Finset.range n,
+        ∫ ω, (N (u (i + 1)) ω - N (u i) ω) ^ 2 ∂P' := by
+  exact MeasureTheory.integral_finsetSum (Finset.range n) fun i _ =>
+    hN.integrable_partition_sq_increment_of_bound hC_nonneg hbound i
+
+/-- Bounded deterministic partitions have zero cross-integral for ordered adjacent martingale
+increments. -/
+lemma _root_.MeasureTheory.Martingale.integral_partition_cross_increment_eq_zero_of_bound
+    {κ Ω' : Type*} [LinearOrder κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    {u : ℕ → κ} (hu : Monotone u) {C : ℝ} (hC_nonneg : 0 ≤ C)
+    (hbound : ∀ᵐ ω ∂P', ∀ k, ‖N (u k) ω‖ ≤ C) {i j : ℕ} (hij : i < j) :
+    ∫ ω, (N (u (i + 1)) ω - N (u i) ω) *
+      (N (u (j + 1)) ω - N (u j) ω) ∂P' = 0 := by
+  exact hN.integral_partition_cross_increment_eq_zero hu hij
+    (hN.integrable_partition_increment_mul_increment_of_bound hC_nonneg hbound i j)
+
+/-- A bounded martingale value has an integrable square on a finite-measure space. -/
+lemma _root_.MeasureTheory.Martingale.integrable_sq_terminal_of_ae_bound
+    {κ Ω' : Type*} [LinearOrder κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P') {t : κ} {C : ℝ}
+    (hbound : ∀ᵐ ω ∂P', ‖N t ω‖ ≤ C) :
+    Integrable (fun ω => N t ω ^ 2) P' := by
+  have hsm_sq : AEStronglyMeasurable (fun ω => N t ω ^ 2) P' := by
+    have hsm : AEStronglyMeasurable (N t) P' :=
+      ((hN.stronglyMeasurable t).mono (𝓕'.le t)).aestronglyMeasurable
+    simpa [Pi.pow_apply] using hsm.pow 2
+  refine MeasureTheory.Integrable.mono'
+    (MeasureTheory.integrable_const ((max C 0) ^ 2)) hsm_sq ?_
+  filter_upwards [hbound] with ω hω
+  have hmax_nonneg : 0 ≤ max C 0 := le_max_right C 0
+  have hnorm_le : ‖N t ω‖ ≤ max C 0 := le_trans hω (le_max_left C 0)
+  have hsq_le : (N t ω) ^ 2 ≤ (max C 0) ^ 2 := by
+    rw [sq_le_sq]
+    simpa [Real.norm_eq_abs, abs_of_nonneg hmax_nonneg] using hnorm_le
+  calc
+    ‖N t ω ^ 2‖ ≤ (N t ω) ^ 2 := by
+      rw [Real.norm_eq_abs, abs_of_nonneg (sq_nonneg (N t ω))]
+    _ ≤ (max C 0) ^ 2 := hsq_le
+
+/-- Integrated square expansion for a bounded monotone deterministic partition. -/
+lemma _root_.MeasureTheory.Martingale.integral_sq_terminal_eq_partition_sq_sum_of_bound
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_zero : ∀ ω, N ⊥ ω = 0)
+    {u : ℕ → κ} (hu : Monotone u) {n : ℕ} {t : κ}
+    (hu0 : u 0 = ⊥) (hun : u n = t) {C : ℝ} (hC_nonneg : 0 ≤ C)
+    (hbound : ∀ᵐ ω ∂P', ∀ k, ‖N (u k) ω‖ ≤ C) :
+    ∫ ω, N t ω ^ 2 ∂P' =
+      ∑ i ∈ Finset.range n,
+        ∫ ω, (N (u (i + 1)) ω - N (u i) ω) ^ 2 ∂P' := by
+  revert t
+  induction n with
+  | zero =>
+      intro t hun
+      have ht : t = ⊥ := by
+        rw [← hun, hu0]
+      simp [ht, hN_zero]
+  | succ n ih =>
+      intro t hun
+      have hprev :
+          ∫ ω, N (u n) ω ^ 2 ∂P' =
+            ∑ i ∈ Finset.range n,
+              ∫ ω, (N (u (i + 1)) ω - N (u i) ω) ^ 2 ∂P' :=
+        ih (t := u n) rfl
+      have hbound_un : ∀ᵐ ω ∂P', ‖N (u n) ω‖ ≤ C :=
+        hbound.mono fun ω hω => hω n
+      have hprev_sq_int : Integrable (fun ω => N (u n) ω ^ 2) P' :=
+        hN.integrable_sq_terminal_of_ae_bound hbound_un
+      have hlast_sq_int :
+          Integrable (fun ω => (N (u (n + 1)) ω - N (u n) ω) ^ 2) P' :=
+        hN.integrable_partition_sq_increment_of_bound hC_nonneg hbound n
+      have hcross_int :
+          Integrable
+            (fun ω => N (u n) ω * (N (u (n + 1)) ω - N (u n) ω)) P' :=
+        hN.integrable_partition_value_mul_increment_of_bound hC_nonneg hbound n
+      have hcross_zero :
+          ∫ ω, N (u n) ω * (N (u (n + 1)) ω - N (u n) ω) ∂P' = 0 := by
+        exact hN.integral_mul_increment_eq_zero_of_stronglyMeasurable
+          (hu (Nat.le_succ n)) (hN.stronglyMeasurable (u n)) hcross_int
+      have hintegral_add_cross :
+          ∫ ω, ((N (u n) ω ^ 2 +
+            (N (u (n + 1)) ω - N (u n) ω) ^ 2) +
+            2 * (N (u n) ω *
+              (N (u (n + 1)) ω - N (u n) ω))) ∂P' =
+            ∫ ω, (N (u n) ω ^ 2 +
+              (N (u (n + 1)) ω - N (u n) ω) ^ 2) ∂P' +
+            ∫ ω, 2 * (N (u n) ω *
+              (N (u (n + 1)) ω - N (u n) ω)) ∂P' := by
+        simpa [Pi.add_apply] using
+          (MeasureTheory.integral_add (μ := P')
+            (f := fun ω => N (u n) ω ^ 2 +
+              (N (u (n + 1)) ω - N (u n) ω) ^ 2)
+            (g := fun ω => 2 * (N (u n) ω *
+              (N (u (n + 1)) ω - N (u n) ω)))
+            (hprev_sq_int.add hlast_sq_int) (hcross_int.const_mul 2))
+      have hintegral_add_sq :
+          ∫ ω, (N (u n) ω ^ 2 +
+            (N (u (n + 1)) ω - N (u n) ω) ^ 2) ∂P' =
+            ∫ ω, N (u n) ω ^ 2 ∂P' +
+            ∫ ω, (N (u (n + 1)) ω - N (u n) ω) ^ 2 ∂P' := by
+        simpa [Pi.add_apply] using
+          (MeasureTheory.integral_add (μ := P')
+            (f := fun ω => N (u n) ω ^ 2)
+            (g := fun ω => (N (u (n + 1)) ω - N (u n) ω) ^ 2)
+            hprev_sq_int hlast_sq_int)
+      have hstep :
+          ∫ ω, N (u (n + 1)) ω ^ 2 ∂P' =
+            ∫ ω, N (u n) ω ^ 2 ∂P' +
+              ∫ ω, (N (u (n + 1)) ω - N (u n) ω) ^ 2 ∂P' := by
+        calc
+          ∫ ω, N (u (n + 1)) ω ^ 2 ∂P' =
+              ∫ ω, ((N (u n) ω ^ 2 +
+                (N (u (n + 1)) ω - N (u n) ω) ^ 2) +
+                2 * (N (u n) ω *
+                  (N (u (n + 1)) ω - N (u n) ω))) ∂P' := by
+                congr 1
+                ext ω
+                ring
+          _ = ∫ ω, N (u n) ω ^ 2 ∂P' +
+                ∫ ω, (N (u (n + 1)) ω - N (u n) ω) ^ 2 ∂P' +
+                ∫ ω, 2 * (N (u n) ω *
+                  (N (u (n + 1)) ω - N (u n) ω)) ∂P' := by
+                rw [hintegral_add_cross, hintegral_add_sq]
+          _ = ∫ ω, N (u n) ω ^ 2 ∂P' +
+                ∫ ω, (N (u (n + 1)) ω - N (u n) ω) ^ 2 ∂P' := by
+                rw [MeasureTheory.integral_const_mul, hcross_zero]
+                ring
+      calc
+        ∫ ω, N t ω ^ 2 ∂P' =
+            ∫ ω, N (u (n + 1)) ω ^ 2 ∂P' := by
+              rw [← hun]
+        _ = ∫ ω, N (u n) ω ^ 2 ∂P' +
+              ∫ ω, (N (u (n + 1)) ω - N (u n) ω) ^ 2 ∂P' := hstep
+        _ = (∑ i ∈ Finset.range n,
+              ∫ ω, (N (u (i + 1)) ω - N (u i) ω) ^ 2 ∂P') +
+              ∫ ω, (N (u (n + 1)) ω - N (u n) ω) ^ 2 ∂P' := by
+              rw [hprev]
+        _ = ∑ i ∈ Finset.range (n + 1),
+              ∫ ω, (N (u (i + 1)) ω - N (u i) ω) ^ 2 ∂P' := by
+              rw [Finset.sum_range_succ]
+
+/-- If a real random variable has zero square integral, then it is zero almost surely. -/
+lemma _root_.MeasureTheory.ae_eq_zero_of_integral_sq_eq_zero
+    {Ω' : Type*} {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {X : Ω' → ℝ}
+    (hXsq_int : Integrable (fun ω => X ω ^ 2) P')
+    (hXsq_zero : ∫ ω, X ω ^ 2 ∂P' = 0) :
+    X =ᵐ[P'] 0 := by
+  have hsq_zero : (fun ω => X ω ^ 2) =ᵐ[P'] 0 :=
+    (MeasureTheory.integral_eq_zero_iff_of_nonneg
+      (fun ω => sq_nonneg (X ω)) hXsq_int).1 hXsq_zero
+  filter_upwards [hsq_zero] with ω hω
+  exact sq_eq_zero_iff.1 hω
+
+/-- Refining deterministic partitions turn the finite square expansion into a zero terminal
+square integral once the square-increment sums converge to zero and are dominated by a uniform
+variation bound. -/
+lemma _root_.MeasureTheory.Martingale.integral_sq_terminal_eq_zero_of_refining_partitions
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_zero : ∀ ω, N ⊥ ω = 0) {t : κ} {m : ℕ → ℕ} {u : ℕ → ℕ → κ}
+    (hu : ∀ n, Monotone (u n)) (hu0 : ∀ n, u n 0 = ⊥)
+    (hut : ∀ n, u n (m n) = t) (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℝ} (hC_nonneg : 0 ≤ C) (hV_nonneg : 0 ≤ V)
+    (hbound : ∀ n, ∀ᵐ ω ∂P', ∀ k, ‖N (u n k) ω‖ ≤ C)
+    (hvar_bound : ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V)
+    (hF_tendsto : ∀ᵐ ω ∂P',
+      Tendsto
+        (fun n => ∑ i ∈ Finset.range (m n),
+          (N (u n (i + 1)) ω - N (u n i) ω) ^ 2)
+        atTop (nhds 0)) :
+    Integrable (fun ω => N t ω ^ 2) P' ∧
+      ∫ ω, N t ω ^ 2 ∂P' = 0 := by
+  let F : ℕ → Ω' → ℝ := fun n ω =>
+    ∑ i ∈ Finset.range (m n), (N (u n (i + 1)) ω - N (u n i) ω) ^ 2
+  have hterminal_bound : ∀ᵐ ω ∂P', ‖N t ω‖ ≤ C := by
+    filter_upwards [hbound 0] with ω hω
+    simpa [hut 0] using hω (m 0)
+  have hterminal_int : Integrable (fun ω => N t ω ^ 2) P' :=
+    hN.integrable_sq_terminal_of_ae_bound hterminal_bound
+  have _hV_nonneg_used : 0 ≤ V := hV_nonneg
+  have hF_sm : ∀ n, AEStronglyMeasurable (F n) P' := fun n =>
+    (hN.integrable_partition_sq_increment_sum_of_bound hC_nonneg (hbound n) (m n)).1
+  have hF_integral_eq : ∀ n,
+      ∫ ω, F n ω ∂P' = ∫ ω, N t ω ^ 2 ∂P' := by
+    intro n
+    have hsq :=
+      hN.integral_sq_terminal_eq_partition_sq_sum_of_bound hN_zero (hu n) (hu0 n)
+        (hut n) hC_nonneg (hbound n)
+    have hsum :=
+      hN.integral_partition_sq_increment_sum_of_bound hC_nonneg (hbound n) (m n)
+    calc
+      ∫ ω, F n ω ∂P' =
+          ∑ i ∈ Finset.range (m n),
+            ∫ ω, (N (u n (i + 1)) ω - N (u n i) ω) ^ 2 ∂P' := hsum
+      _ = ∫ ω, N t ω ^ 2 ∂P' := hsq.symm
+  have hdom : ∀ n, ∀ᵐ ω ∂P', ‖F n ω‖ ≤ (fun _ : Ω' => 2 * C * V) ω := by
+    intro n
+    filter_upwards [hbound n, hvar_bound] with ω hω_bound hω_var
+    have hdelta_nonneg : 0 ≤ 2 * C := by nlinarith
+    have hstep : ∀ i, i ∈ Finset.range (m n) →
+        ‖N (u n (i + 1)) ω - N (u n i) ω‖ ≤ 2 * C := by
+      intro i _hi
+      calc
+        ‖N (u n (i + 1)) ω - N (u n i) ω‖
+            ≤ ‖N (u n (i + 1)) ω‖ + ‖N (u n i) ω‖ := norm_sub_le _ _
+        _ ≤ C + C := add_le_add (hω_bound (i + 1)) (hω_bound i)
+        _ = 2 * C := by ring
+    have hsumsq_le :
+        (∑ i ∈ Finset.range (m n),
+          ‖N (u n (i + 1)) ω - N (u n i) ω‖ ^ 2) ≤
+            2 * C * V := by
+      calc
+        (∑ i ∈ Finset.range (m n),
+          ‖N (u n (i + 1)) ω - N (u n i) ω‖ ^ 2)
+            ≤ (2 * C) * (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal :=
+            hω_var.1.sq_increment_sum_le_uniform_bound (hu n) (hus n)
+              hdelta_nonneg hstep
+        _ ≤ (2 * C) * V :=
+            mul_le_mul_of_nonneg_left hω_var.2 hdelta_nonneg
+        _ = 2 * C * V := by ring
+    have hnorm_le :
+        ‖F n ω‖ ≤
+          ∑ i ∈ Finset.range (m n),
+            ‖N (u n (i + 1)) ω - N (u n i) ω‖ ^ 2 := by
+      have hnorm_sum :
+          ‖∑ i ∈ Finset.range (m n),
+            (N (u n (i + 1)) ω - N (u n i) ω) ^ 2‖ ≤
+              ∑ i ∈ Finset.range (m n),
+                ‖(N (u n (i + 1)) ω - N (u n i) ω) ^ 2‖ :=
+        norm_sum_le (Finset.range (m n))
+          (fun i => (N (u n (i + 1)) ω - N (u n i) ω) ^ 2)
+      calc
+        ‖F n ω‖ =
+            ‖∑ i ∈ Finset.range (m n),
+              (N (u n (i + 1)) ω - N (u n i) ω) ^ 2‖ := by
+              rfl
+        _ ≤ ∑ i ∈ Finset.range (m n),
+              ‖(N (u n (i + 1)) ω - N (u n i) ω) ^ 2‖ := hnorm_sum
+        _ = ∑ i ∈ Finset.range (m n),
+              ‖N (u n (i + 1)) ω - N (u n i) ω‖ ^ 2 := by
+              refine Finset.sum_congr rfl fun i _hi => ?_
+              rw [pow_two, norm_mul, pow_two]
+    exact le_trans hnorm_le hsumsq_le
+  have hF_tendsto_zero : ∀ᵐ ω ∂P', Tendsto (fun n => F n ω) atTop (nhds 0) := by
+    filter_upwards [hF_tendsto] with ω hω
+    simpa [F] using hω
+  have hF_integral_tendsto :
+      Tendsto (fun n => ∫ ω, F n ω ∂P') atTop (nhds (∫ ω, (0 : ℝ) ∂P')) :=
+    MeasureTheory.tendsto_integral_of_dominated_convergence
+      (fun _ : Ω' => 2 * C * V) hF_sm
+      (MeasureTheory.integrable_const (2 * C * V)) hdom hF_tendsto_zero
+  have hconst_tendsto :
+      Tendsto (fun _ : ℕ => ∫ ω, N t ω ^ 2 ∂P') atTop (nhds 0) := by
+    simpa [hF_integral_eq] using hF_integral_tendsto
+  have hterminal_zero : ∫ ω, N t ω ^ 2 ∂P' = 0 := by
+    simpa using (tendsto_const_nhds_iff.mp hconst_tendsto)
+  exact ⟨hterminal_int, hterminal_zero⟩
+
+set_option linter.style.longLine false in
+/-- Variation-bounded refining partitions give the terminal zero-square-integral identity.
+
+This packages the deterministic partition/modulus hypotheses used before the bounded-continuous
+localization step: a horizon bound supplies the bounded partition values, and the pathwise
+increment modulus plus bounded variation gives the square-increment convergence. -/
+lemma _root_.MeasureTheory.Martingale.integral_sq_terminal_eq_zero_of_bounded_continuous_finiteVariation_of_variation_bound
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_zero : ∀ ω, N ⊥ ω = 0) {t : κ} {m : ℕ → ℕ} {u : ℕ → ℕ → κ}
+    (hu : ∀ n, Monotone (u n)) (hu0 : ∀ n, u n 0 = ⊥)
+    (hut : ∀ n, u n (m n) = t) (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℝ} {δ : ℕ → ℝ} (hC_nonneg : 0 ≤ C) (hV_nonneg : 0 ≤ V)
+    (hδ_nonneg : ∀ n, 0 ≤ δ n) (hδ_tendsto : Tendsto δ atTop (nhds 0))
+    (hbound_horizon : ∀ᵐ ω ∂P', ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C)
+    (hvar_bound : ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V)
+    (hinc_bound : ∀ᵐ ω ∂P',
+      ∀ n i, i ∈ Finset.range (m n) →
+        ‖N (u n (i + 1)) ω - N (u n i) ω‖ ≤ δ n) :
+    Integrable (fun ω => N t ω ^ 2) P' ∧
+      ∫ ω, N t ω ^ 2 ∂P' = 0 := by
+  have hpartition_bound : ∀ n, ∀ᵐ ω ∂P', ∀ k, ‖N (u n k) ω‖ ≤ C := by
+    intro n
+    filter_upwards [hbound_horizon] with ω hω k
+    exact hω (u n k) (hus n k)
+  have hF_tendsto : ∀ᵐ ω ∂P',
+      Tendsto
+        (fun n => ∑ i ∈ Finset.range (m n),
+          (N (u n (i + 1)) ω - N (u n i) ω) ^ 2)
+        atTop (nhds 0) := by
+    filter_upwards [hvar_bound, hinc_bound] with ω hω_var hω_inc
+    have hnorm_tendsto :
+        Tendsto
+          (fun n => ∑ i ∈ Finset.range (m n),
+            ‖N (u n (i + 1)) ω - N (u n i) ω‖ ^ 2)
+          atTop (nhds 0) :=
+      hω_var.1.sq_increment_sum_tendsto_zero_of_uniform_bound hu hus hδ_nonneg
+        hδ_tendsto hω_inc
+    simpa [Real.norm_eq_abs, sq_abs] using hnorm_tendsto
+  exact hN.integral_sq_terminal_eq_zero_of_refining_partitions hN_zero hu hu0 hut hus
+    hC_nonneg hV_nonneg hpartition_bound hvar_bound hF_tendsto
+
+set_option linter.style.longLine false in
+/-- Variation-bounded refining partitions give the terminal zero-square-integral identity when
+the partition increment modulus is allowed to depend on the sample point. -/
+lemma _root_.MeasureTheory.Martingale.integral_sq_terminal_eq_zero_of_bounded_continuous_finiteVariation_of_variation_bound_eventual_modulus
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_zero : ∀ ω, N ⊥ ω = 0) {t : κ} {m : ℕ → ℕ} {u : ℕ → ℕ → κ}
+    (hu : ∀ n, Monotone (u n)) (hu0 : ∀ n, u n 0 = ⊥)
+    (hut : ∀ n, u n (m n) = t) (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℝ} (hC_nonneg : 0 ≤ C) (hV_nonneg : 0 ≤ V)
+    (hbound_horizon : ∀ᵐ ω ∂P', ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C)
+    (hvar_bound : ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V)
+    (hinc_modulus : ∀ᵐ ω ∂P',
+      ∃ δ : ℕ → ℝ, (∀ n, 0 ≤ δ n) ∧ Tendsto δ atTop (nhds 0) ∧
+        ∀ n i, i ∈ Finset.range (m n) →
+          ‖N (u n (i + 1)) ω - N (u n i) ω‖ ≤ δ n) :
+    Integrable (fun ω => N t ω ^ 2) P' ∧
+      ∫ ω, N t ω ^ 2 ∂P' = 0 := by
+  have hpartition_bound : ∀ n, ∀ᵐ ω ∂P', ∀ k, ‖N (u n k) ω‖ ≤ C := by
+    intro n
+    filter_upwards [hbound_horizon] with ω hω k
+    exact hω (u n k) (hus n k)
+  have hF_tendsto : ∀ᵐ ω ∂P',
+      Tendsto
+        (fun n => ∑ i ∈ Finset.range (m n),
+          (N (u n (i + 1)) ω - N (u n i) ω) ^ 2)
+        atTop (nhds 0) := by
+    filter_upwards [hvar_bound, hinc_modulus] with ω hω_var hω_modulus
+    rcases hω_modulus with ⟨δω, hδω_nonneg, hδω_tendsto, hω_inc⟩
+    have hnorm_tendsto :
+        Tendsto
+          (fun n => ∑ i ∈ Finset.range (m n),
+            ‖N (u n (i + 1)) ω - N (u n i) ω‖ ^ 2)
+          atTop (nhds 0) :=
+      hω_var.1.sq_increment_sum_tendsto_zero_of_uniform_bound hu hus hδω_nonneg
+        hδω_tendsto hω_inc
+    simpa [Real.norm_eq_abs, sq_abs] using hnorm_tendsto
+  exact hN.integral_sq_terminal_eq_zero_of_refining_partitions hN_zero hu hu0 hut hus
+    hC_nonneg hV_nonneg hpartition_bound hvar_bound hF_tendsto
+
+set_option linter.style.longLine false in
+/-- Variation-bounded refining partitions give the terminal zero-square-integral identity when
+the largest partition increment tends to zero pathwise.  This isolates the remaining
+mesh-to-modulus step needed for the bounded-continuous finite-variation bridge. -/
+lemma _root_.MeasureTheory.Martingale.integral_sq_terminal_eq_zero_of_bounded_continuous_finiteVariation_of_variation_bound_sup_modulus
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_zero : ∀ ω, N ⊥ ω = 0) {t : κ} {m : ℕ → ℕ} {u : ℕ → ℕ → κ}
+    (hu : ∀ n, Monotone (u n)) (hu0 : ∀ n, u n 0 = ⊥)
+    (hut : ∀ n, u n (m n) = t) (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℝ} (hC_nonneg : 0 ≤ C) (hV_nonneg : 0 ≤ V)
+    (hbound_horizon : ∀ᵐ ω ∂P', ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C)
+    (hvar_bound : ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V)
+    (hmax_inc_tendsto : ∀ᵐ ω ∂P',
+      Tendsto
+        (fun n => (((Finset.range (m n)).sup fun i =>
+          ‖N (u n (i + 1)) ω - N (u n i) ω‖₊ : NNReal) : ℝ))
+        atTop (nhds 0)) :
+    Integrable (fun ω => N t ω ^ 2) P' ∧
+      ∫ ω, N t ω ^ 2 ∂P' = 0 := by
+  refine hN.integral_sq_terminal_eq_zero_of_bounded_continuous_finiteVariation_of_variation_bound_eventual_modulus
+    hN_zero hu hu0 hut hus hC_nonneg hV_nonneg hbound_horizon hvar_bound ?_
+  filter_upwards [hmax_inc_tendsto] with ω hωmax
+  refine ⟨fun n => (((Finset.range (m n)).sup fun i =>
+    ‖N (u n (i + 1)) ω - N (u n i) ω‖₊ : NNReal) : ℝ), ?_, hωmax, ?_⟩
+  · intro n
+    exact NNReal.coe_nonneg _
+  · intro n i hi
+    have hnn :
+        ‖N (u n (i + 1)) ω - N (u n i) ω‖₊ ≤
+          (Finset.range (m n)).sup (fun j =>
+            ‖N (u n (j + 1)) ω - N (u n j) ω‖₊) :=
+      Finset.le_sup (f := fun j =>
+        ‖N (u n (j + 1)) ω - N (u n j) ω‖₊) hi
+    exact_mod_cast hnn
+
+set_option linter.style.longLine false in
+/-- Uniform continuity turns an entourage-mesh condition for finite point families into
+convergence to zero of the finite maximum of adjacent real increments. -/
+lemma _root_.UniformContinuousOn.finite_partition_sup_nnnorm_sub_tendsto_zero
+    {κ : Type*} [UniformSpace κ] {S : Set κ} {f : κ → ℝ}
+    (hf : UniformContinuousOn f S) {m : ℕ → ℕ} {u : ℕ → ℕ → κ}
+    (hus : ∀ n i, u n i ∈ S)
+    (hmesh : ∀ V ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ V) :
+    Tendsto
+      (fun n => (((Finset.range (m n)).sup fun i =>
+        ‖f (u n (i + 1)) - f (u n i)‖₊ : NNReal) : ℝ))
+      atTop (nhds 0) := by
+  rw [Metric.tendsto_nhds]
+  intro ε hε
+  let T : Set (ℝ × ℝ) := {p | dist p.1 p.2 < ε}
+  have hT_mem : T ∈ 𝓤 ℝ :=
+    (Metric.mem_uniformity_dist).2 ⟨ε, hε, fun _ _ hdist => hdist⟩
+  have hpre :
+      {p : κ × κ | (f p.1, f p.2) ∈ T} ∈
+        𝓤 κ ⊓ Filter.principal (S ×ˢ S) := by
+    rw [UniformContinuousOn] at hf
+    exact hf hT_mem
+  rw [Filter.mem_inf_principal] at hpre
+  filter_upwards [hmesh _ hpre] with n hn
+  have hsup_nn :
+      (Finset.range (m n)).sup (fun i =>
+        ‖f (u n (i + 1)) - f (u n i)‖₊) < Real.toNNReal ε := by
+    rw [Finset.sup_lt_iff (Real.toNNReal_pos.2 hε)]
+    intro i hi
+    rw [← NNReal.coe_lt_coe]
+    have hp :
+        (u n i, u n (i + 1)) ∈
+          {p : κ × κ | p ∈ S ×ˢ S → p ∈ {p : κ × κ | (f p.1, f p.2) ∈ T}} :=
+      hn i hi
+    have hdist : dist (f (u n i)) (f (u n (i + 1))) < ε := by
+      exact hp ⟨hus n i, hus n (i + 1)⟩
+    have hinc :
+        ((‖f (u n (i + 1)) - f (u n i)‖₊ : NNReal) : ℝ) < ε := by
+      simpa [Real.dist_eq, abs_sub_comm, Real.norm_eq_abs] using hdist
+    simpa [Real.toNNReal_of_nonneg hε.le] using hinc
+  have hsup_real :
+      (((Finset.range (m n)).sup fun i =>
+        ‖f (u n (i + 1)) - f (u n i)‖₊ : NNReal) : ℝ) < ε := by
+    have hcoe : ((Real.toNNReal ε : NNReal) : ℝ) = ε := by
+      simp [Real.toNNReal_of_nonneg hε.le]
+    exact lt_of_lt_of_eq (by exact_mod_cast hsup_nn) hcoe
+  have hnonneg :
+      0 ≤ (((Finset.range (m n)).sup fun i =>
+        ‖f (u n (i + 1)) - f (u n i)‖₊ : NNReal) : ℝ) :=
+    NNReal.coe_nonneg _
+  simpa [Real.dist_eq, abs_of_nonneg hnonneg] using hsup_real
+
+/-- A continuous real-valued function on a compact order interval is uniformly continuous on
+that interval. -/
+lemma _root_.ContinuousOn.uniformContinuousOn_Icc
+    {κ : Type*} [Preorder κ] [UniformSpace κ] [CompactIccSpace κ]
+    {f : κ → ℝ} {a b : κ} (hf : ContinuousOn f (Set.Icc a b)) :
+    UniformContinuousOn f (Set.Icc a b) := by
+  exact isCompact_Icc.uniformContinuousOn_of_continuous hf
+
+set_option linter.style.longLine false in
+/-- Uniformly continuous paths turn deterministic entourage-mesh partitions into the finite
+maximum increment convergence required by the variation-bounded square-integral endpoint. -/
+lemma _root_.MeasureTheory.Martingale.integral_sq_terminal_eq_zero_of_bounded_continuous_finiteVariation_of_variation_bound_uniformContinuousOn
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ] [UniformSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_zero : ∀ ω, N ⊥ ω = 0) {t : κ} {m : ℕ → ℕ} {u : ℕ → ℕ → κ}
+    (hu : ∀ n, Monotone (u n)) (hu0 : ∀ n, u n 0 = ⊥)
+    (hut : ∀ n, u n (m n) = t) (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℝ} (hC_nonneg : 0 ≤ C) (hV_nonneg : 0 ≤ V)
+    (hbound_horizon : ∀ᵐ ω ∂P', ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C)
+    (hvar_bound : ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V)
+    (hN_unif : ∀ ω, UniformContinuousOn (N · ω) (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ V ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ V) :
+    Integrable (fun ω => N t ω ^ 2) P' ∧
+      ∫ ω, N t ω ^ 2 ∂P' = 0 := by
+  refine hN.integral_sq_terminal_eq_zero_of_bounded_continuous_finiteVariation_of_variation_bound_sup_modulus
+    hN_zero hu hu0 hut hus hC_nonneg hV_nonneg hbound_horizon hvar_bound ?_
+  filter_upwards with ω
+  exact (hN_unif ω).finite_partition_sup_nnnorm_sub_tendsto_zero hus hmesh
+
+set_option linter.style.longLine false in
+/-- Continuous paths on compact order intervals provide the uniform-continuity hypothesis needed
+by the explicit-mesh variation-bounded square-integral endpoint. -/
+lemma _root_.MeasureTheory.Martingale.integral_sq_terminal_eq_zero_of_bounded_continuous_finiteVariation_of_variation_bound_continuousOn
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ] [UniformSpace κ] [CompactIccSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_zero : ∀ ω, N ⊥ ω = 0) {t : κ} {m : ℕ → ℕ} {u : ℕ → ℕ → κ}
+    (hu : ∀ n, Monotone (u n)) (hu0 : ∀ n, u n 0 = ⊥)
+    (hut : ∀ n, u n (m n) = t) (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℝ} (hC_nonneg : 0 ≤ C) (hV_nonneg : 0 ≤ V)
+    (hbound_horizon : ∀ᵐ ω ∂P', ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C)
+    (hvar_bound : ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V)
+    (hN_cont : ∀ ω, ContinuousOn (N · ω) (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ V ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ V) :
+    Integrable (fun ω => N t ω ^ 2) P' ∧
+      ∫ ω, N t ω ^ 2 ∂P' = 0 := by
+  refine hN.integral_sq_terminal_eq_zero_of_bounded_continuous_finiteVariation_of_variation_bound_uniformContinuousOn
+    hN_zero hu hu0 hut hus hC_nonneg hV_nonneg hbound_horizon hvar_bound ?_ hmesh
+  intro ω
+  exact (hN_cont ω).uniformContinuousOn_Icc
+
+set_option linter.style.longLine false in
+/-- Terminal a.e.-zero form of the continuous-path, variation-bounded explicit-mesh endpoint. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_bounded_continuous_finiteVariation_of_variation_bound_continuousOn
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ] [UniformSpace κ] [CompactIccSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_zero : ∀ ω, N ⊥ ω = 0) {t : κ} {m : ℕ → ℕ} {u : ℕ → ℕ → κ}
+    (hu : ∀ n, Monotone (u n)) (hu0 : ∀ n, u n 0 = ⊥)
+    (hut : ∀ n, u n (m n) = t) (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℝ} (hC_nonneg : 0 ≤ C) (hV_nonneg : 0 ≤ V)
+    (hbound_horizon : ∀ᵐ ω ∂P', ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C)
+    (hvar_bound : ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V)
+    (hN_cont : ∀ ω, ContinuousOn (N · ω) (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ V ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ V) :
+    N t =ᵐ[P'] 0 := by
+  rcases hN.integral_sq_terminal_eq_zero_of_bounded_continuous_finiteVariation_of_variation_bound_continuousOn
+    hN_zero hu hu0 hut hus hC_nonneg hV_nonneg hbound_horizon hvar_bound hN_cont hmesh with
+    ⟨hN_sq_int, hN_sq_zero⟩
+  exact MeasureTheory.ae_eq_zero_of_integral_sq_eq_zero hN_sq_int hN_sq_zero
+
+set_option linter.style.longLine false in
+/-- Event-localized terminal a.e.-zero form of the continuous-path, variation-bounded
+explicit-mesh endpoint.  A localized martingale `Z` is zero at the terminal time by the
+global theorem, and terminal agreement transfers that conclusion to the original process on
+the event `E`. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_on_event_of_bounded_continuous_finiteVariation_of_variation_bound_continuousOn
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ] [UniformSpace κ] [CompactIccSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {Z N : κ → Ω' → ℝ} (hZ : Martingale Z 𝓕' P')
+    (hZ_zero : ∀ ω, Z ⊥ ω = 0) {t : κ} {m : ℕ → ℕ} {u : ℕ → ℕ → κ}
+    (hu : ∀ n, Monotone (u n)) (hu0 : ∀ n, u n 0 = ⊥)
+    (hut : ∀ n, u n (m n) = t) (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℝ} (hC_nonneg : 0 ≤ C) (hV_nonneg : 0 ≤ V)
+    (hbound_horizon : ∀ᵐ ω ∂P', ∀ s ∈ Set.Icc (⊥ : κ) t, ‖Z s ω‖ ≤ C)
+    (hvar_bound : ∀ᵐ ω ∂P',
+      BoundedVariationOn (Z · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (Z · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V)
+    (hZ_cont : ∀ ω, ContinuousOn (Z · ω) (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ V ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ V)
+    {E : Set Ω'} (hagree : ∀ᵐ ω ∂P', ω ∈ E → Z t ω = N t ω) :
+    ∀ᵐ ω ∂P', ω ∈ E → N t ω = 0 := by
+  have hZ_terminal : Z t =ᵐ[P'] 0 :=
+    hZ.eq_zero_of_bounded_continuous_finiteVariation_of_variation_bound_continuousOn
+      hZ_zero hu hu0 hut hus hC_nonneg hV_nonneg hbound_horizon hvar_bound
+      hZ_cont hmesh
+  filter_upwards [hZ_terminal, hagree] with ω hZ_zero_terminal hω_agree hωE
+  have hterminal_agree : Z t ω = N t ω := hω_agree hωE
+  simpa [hterminal_agree] using hZ_zero_terminal
+
+/-- Countable exhaustion of event-localized a.e.-zero statements. -/
+lemma _root_.MeasureTheory.ae_eq_zero_of_eventually_event_zero_exhaustion
+    {Ω' : Type*} {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {f : Ω' → ℝ}
+    {E : ℕ → Set Ω'} (hcover : ∀ᵐ ω ∂P', ∃ n, ω ∈ E n)
+    (hzero : ∀ n, ∀ᵐ ω ∂P', ω ∈ E n → f ω = 0) :
+    f =ᵐ[P'] 0 := by
+  have hall_zero : ∀ᵐ ω ∂P', ∀ n, ω ∈ E n → f ω = 0 :=
+    ae_all_iff.2 hzero
+  filter_upwards [hcover, hall_zero] with ω hω_cover hω_zero
+  rcases hω_cover with ⟨n, hωE⟩
+  exact hω_zero n hωE
+
+set_option linter.style.longLine false in
+/-- Countable localized-family terminal a.e.-zero form of the continuous-path,
+variation-bounded explicit-mesh endpoint. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_localized_bounded_continuous_finiteVariation_of_variation_bound_continuousOn
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ] [UniformSpace κ] [CompactIccSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {Z : ℕ → κ → Ω' → ℝ} {N : κ → Ω' → ℝ}
+    (hZ : ∀ n, Martingale (Z n) 𝓕' P') (hZ_zero : ∀ n ω, Z n ⊥ ω = 0)
+    {t : κ} {m : ℕ → ℕ} {u : ℕ → ℕ → κ}
+    (hu : ∀ n, Monotone (u n)) (hu0 : ∀ n, u n 0 = ⊥)
+    (hut : ∀ n, u n (m n) = t) (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {E : ℕ → Set Ω'} {C V : ℕ → ℝ} (hC_nonneg : ∀ n, 0 ≤ C n)
+    (hV_nonneg : ∀ n, 0 ≤ V n)
+    (hbound_horizon : ∀ n, ∀ᵐ ω ∂P',
+      ∀ s ∈ Set.Icc (⊥ : κ) t, ‖Z n s ω‖ ≤ C n)
+    (hvar_bound : ∀ n, ∀ᵐ ω ∂P',
+      BoundedVariationOn (Z n · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (Z n · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V n)
+    (hZ_cont : ∀ n ω, ContinuousOn (Z n · ω) (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ V ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ V)
+    (hcover : ∀ᵐ ω ∂P', ∃ n, ω ∈ E n)
+    (hagree : ∀ n, ∀ᵐ ω ∂P', ω ∈ E n → Z n t ω = N t ω) :
+    N t =ᵐ[P'] 0 := by
+  have hzero : ∀ n, ∀ᵐ ω ∂P', ω ∈ E n → N t ω = 0 := by
+    intro n
+    exact (hZ n).eq_zero_on_event_of_bounded_continuous_finiteVariation_of_variation_bound_continuousOn
+      (hZ_zero n) hu hu0 hut hus (hC_nonneg n) (hV_nonneg n)
+      (hbound_horizon n) (hvar_bound n) (hZ_cont n) hmesh (hagree n)
+  exact MeasureTheory.ae_eq_zero_of_eventually_event_zero_exhaustion hcover hzero
+
+set_option linter.style.longLine false in
+/-- Stopped-process specialization of the countable localized-family terminal a.e.-zero
+wrapper. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_stoppedProcess_bounded_continuous_finiteVariation_of_variation_bound_continuousOn
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ] [UniformSpace κ] [CompactIccSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} {τ : ℕ → Ω' → WithTop κ}
+    (hZ_mart : ∀ n,
+      Martingale
+        (stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n))
+        𝓕' P')
+    (hN_zero : ∀ ω, N ⊥ ω = 0) {t : κ} {m : ℕ → ℕ} {u : ℕ → ℕ → κ}
+    (hu : ∀ n, Monotone (u n)) (hu0 : ∀ n, u n 0 = ⊥)
+    (hut : ∀ n, u n (m n) = t) (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℕ → ℝ} (hC_nonneg : ∀ n, 0 ≤ C n) (hV_nonneg : ∀ n, 0 ≤ V n)
+    (hbound_horizon : ∀ n, ∀ᵐ ω ∂P',
+      ∀ s ∈ Set.Icc (⊥ : κ) t,
+        ‖stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n) s ω‖
+          ≤ C n)
+    (hvar_bound : ∀ n, ∀ᵐ ω ∂P',
+      BoundedVariationOn
+          ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+          (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn
+          ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+          (Set.Icc (⊥ : κ) t)).toReal ≤ V n)
+    (hZ_cont : ∀ n ω,
+      ContinuousOn
+        ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+        (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ V ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ V)
+    (hcover : ∀ᵐ ω ∂P', ∃ n, (t : WithTop κ) < τ n ω) :
+    N t =ᵐ[P'] 0 := by
+  let Z : ℕ → κ → Ω' → ℝ :=
+    fun n ↦ stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)
+  let E : ℕ → Set Ω' := fun n ↦ {ω | (t : WithTop κ) < τ n ω}
+  have hZ_zero : ∀ n ω, Z n ⊥ ω = 0 := by
+    intro n ω
+    by_cases hω : (⊥ : κ) < τ n ω
+    · have hmem : ω ∈ {ω | (⊥ : κ) < τ n ω} := hω
+      change stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)
+        ⊥ ω = 0
+      rw [stoppedProcess_eq_of_le hω.le, Set.indicator_of_mem hmem]
+      exact hN_zero ω
+    · change stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)
+        ⊥ ω = 0
+      rw [stoppedProcess]
+      exact Set.indicator_of_notMem
+        (s := {ω' : Ω' | (⊥ : κ) < τ n ω'}) hω
+        (N (min ((⊥ : κ) : WithTop κ) (τ n ω)).untopA)
+  have hagree : ∀ n, ∀ᵐ ω ∂P', ω ∈ E n → Z n t ω = N t ω := by
+    intro n
+    filter_upwards with ω hωE
+    have htτ : (t : WithTop κ) < τ n ω := hωE
+    have hbotτ : (⊥ : κ) < τ n ω :=
+      lt_of_le_of_lt (WithTop.coe_le_coe.2 bot_le) htτ
+    have hmem : ω ∈ {ω | (⊥ : κ) < τ n ω} := hbotτ
+    change stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)
+      t ω = N t ω
+    rw [stoppedProcess_eq_of_le htτ.le, Set.indicator_of_mem hmem]
+  exact MeasureTheory.Martingale.eq_zero_of_localized_bounded_continuous_finiteVariation_of_variation_bound_continuousOn
+    (Z := Z) (N := N) (E := E) (C := C) (V := V)
+    (fun n ↦ by simpa [Z] using hZ_mart n) hZ_zero hu hu0 hut hus hC_nonneg
+    hV_nonneg (fun n ↦ by simpa [Z] using hbound_horizon n)
+    (fun n ↦ by simpa [Z] using hvar_bound n) (fun n ↦ by simpa [Z] using hZ_cont n)
+    hmesh (by simpa [E] using hcover) hagree
+
+/-- At a fixed deterministic time, a localizing sequence eventually lies above that time on an
+almost-sure set. -/
+lemma _root_.ProbabilityTheory.IsLocalizingSequence.eventually_exists_gt
+    {κ Ω' : Type*} [LinearOrder κ] [TopologicalSpace κ] [OrderTopology κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    {τ : ℕ → Ω' → WithTop κ} (hτ : IsLocalizingSequence 𝓕' τ P') (t : κ) :
+    ∀ᵐ ω ∂P', ∃ n, (t : WithTop κ) < τ n ω := by
+  filter_upwards [hτ.tendsto_top] with ω htop
+  simp only [tendsto_atTop_nhds] at htop
+  obtain ⟨n, hn⟩ := htop (Set.Ioi (t : WithTop κ)) (by simp) isOpen_Ioi
+  exact ⟨n, hn n le_rfl⟩
+
+set_option linter.style.longLine false in
+/-- Localizing-sequence version of the stopped-process continuous finite-variation zero theorem.
+The localizing sequence supplies both the stopped true martingales and the almost-sure cover
+`∃ n, t < τ n`. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_localizingSequence_bounded_continuous_finiteVariation_of_variation_bound_continuousOn
+    {κ Ω' : Type*} [LinearOrder κ] [OrderBot κ] [UniformSpace κ] [OrderTopology κ]
+    [CompactIccSpace κ] [MeasurableSpace κ] [BorelSpace κ] [SecondCountableTopology κ]
+    [PseudoMetrizableSpace κ] {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] [Approximable 𝓕' P']
+    {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_cadlag : ∀ ω, IsCadlag (N · ω)) (hN_zero : ∀ ω, N ⊥ ω = 0)
+    {τ : ℕ → Ω' → WithTop κ} (hτ : IsLocalizingSequence 𝓕' τ P') {t : κ}
+    {m : ℕ → ℕ} {u : ℕ → ℕ → κ} (hu : ∀ n, Monotone (u n))
+    (hu0 : ∀ n, u n 0 = ⊥) (hut : ∀ n, u n (m n) = t)
+    (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℕ → ℝ} (hC_nonneg : ∀ n, 0 ≤ C n) (hV_nonneg : ∀ n, 0 ≤ V n)
+    (hbound_horizon : ∀ n, ∀ᵐ ω ∂P',
+      ∀ s ∈ Set.Icc (⊥ : κ) t,
+        ‖stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n) s ω‖
+          ≤ C n)
+    (hvar_bound : ∀ n, ∀ᵐ ω ∂P',
+      BoundedVariationOn
+          ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+          (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn
+          ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+          (Set.Icc (⊥ : κ) t)).toReal ≤ V n)
+    (hZ_cont : ∀ n ω,
+      ContinuousOn
+        ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+        (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ V ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ V) :
+    N t =ᵐ[P'] 0 := by
+  have hZ_mart : ∀ n,
+      Martingale
+        (stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n))
+        𝓕' P' := by
+    intro n
+    exact hN.stoppedProcess_indicator (fun ω ↦ (hN_cadlag ω).right_continuous)
+      (hτ.isStoppingTime n)
+  exact MeasureTheory.Martingale.eq_zero_of_stoppedProcess_bounded_continuous_finiteVariation_of_variation_bound_continuousOn
+    (N := N) (τ := τ) hZ_mart hN_zero hu hu0 hut hus hC_nonneg hV_nonneg
+    hbound_horizon hvar_bound hZ_cont hmesh (hτ.eventually_exists_gt t)
+
+set_option linter.style.longLine false in
+/-- Bookkeeping wrapper that transfers original-process deterministic horizon and variation
+bounds to each stopped/indicator localization before applying the localizing-sequence zero
+theorem. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_localizingSequence_of_bound_variation_bound_continuousOn
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [UniformSpace κ]
+    [OrderTopology κ] [CompactIccSpace κ] [MeasurableSpace κ] [BorelSpace κ]
+    [SecondCountableTopology κ] [PseudoMetrizableSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_cadlag : ∀ ω, IsCadlag (N · ω))
+    (hN_zero : ∀ ω, N ⊥ ω = 0) {τ : ℕ → Ω' → WithTop κ}
+    (hτ : IsLocalizingSequence 𝓕' τ P') {t : κ} {m : ℕ → ℕ}
+    {u : ℕ → ℕ → κ} (hu : ∀ n, Monotone (u n)) (hu0 : ∀ n, u n 0 = ⊥)
+    (hut : ∀ n, u n (m n) = t) (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℕ → ℝ} (hC_nonneg : ∀ n, 0 ≤ C n) (hV_nonneg : ∀ n, 0 ≤ V n)
+    (hbound_horizon : ∀ n, ∀ᵐ ω ∂P',
+      ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C n)
+    (hvar_bound : ∀ n, ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V n)
+    (hZ_cont : ∀ n ω,
+      ContinuousOn
+        ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+        (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ V ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ V) :
+    N t =ᵐ[P'] 0 := by
+  have hstopped_bounds : ∀ n,
+      (∀ᵐ ω ∂P', ∀ s ∈ Set.Icc (⊥ : κ) t,
+        ‖stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n) s ω‖
+          ≤ C n) ∧
+        (∀ᵐ ω ∂P',
+          BoundedVariationOn
+              ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+              (Set.Icc (⊥ : κ) t) ∧
+            (eVariationOn
+              ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+              (Set.Icc (⊥ : κ) t)).toReal ≤ V n) := by
+    intro n
+    exact MeasureTheory.ae_stoppedProcess_indicator_bound_variation_on_Icc
+      (N := N) (τ := τ n) (t := t) (C := C n) (V := V n)
+      (hC_nonneg n) (hbound_horizon n) (hvar_bound n)
+  exact hN.eq_zero_of_localizingSequence_bounded_continuous_finiteVariation_of_variation_bound_continuousOn
+    hN_cadlag hN_zero hτ hu hu0 hut hus hC_nonneg hV_nonneg
+    (fun n ↦ (hstopped_bounds n).1) (fun n ↦ (hstopped_bounds n).2) hZ_cont hmesh
+
+set_option linter.style.longLine false in
+/-- Bookkeeping wrapper that derives the stopped/indicator path-continuity hypothesis from
+original-path continuity on the deterministic horizon. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_localizingSequence_of_bound_variation_bound_original_continuousOn
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [UniformSpace κ]
+    [OrderTopology κ] [CompactIccSpace κ] [MeasurableSpace κ] [BorelSpace κ]
+    [SecondCountableTopology κ] [PseudoMetrizableSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_cadlag : ∀ ω, IsCadlag (N · ω))
+    (hN_zero : ∀ ω, N ⊥ ω = 0) {τ : ℕ → Ω' → WithTop κ}
+    (hτ : IsLocalizingSequence 𝓕' τ P') {t : κ} {m : ℕ → ℕ}
+    {u : ℕ → ℕ → κ} (hu : ∀ n, Monotone (u n)) (hu0 : ∀ n, u n 0 = ⊥)
+    (hut : ∀ n, u n (m n) = t) (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℕ → ℝ} (hC_nonneg : ∀ n, 0 ≤ C n) (hV_nonneg : ∀ n, 0 ≤ V n)
+    (hbound_horizon : ∀ n, ∀ᵐ ω ∂P',
+      ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C n)
+    (hvar_bound : ∀ n, ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V n)
+    (hN_cont : ∀ ω, ContinuousOn (N · ω) (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ V ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ V) :
+    N t =ᵐ[P'] 0 := by
+  exact hN.eq_zero_of_localizingSequence_of_bound_variation_bound_continuousOn
+    hN_cadlag hN_zero hτ hu hu0 hut hus hC_nonneg hV_nonneg hbound_horizon
+    hvar_bound
+    (fun n ω ↦ MeasureTheory.stoppedProcess_indicator_continuousOn_Icc
+      (N := N) (τ := τ n) (ω := ω) (t := t) (hN_cont ω))
+    hmesh
+
+set_option linter.style.longLine false in
+/-- Localized terminal-zero and left-limit-zero wrapper under explicit deterministic
+left-approach, horizon bounds, variation bounds, pathwise continuity, partitions, and mesh
+hypotheses. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_and_leftLim_eq_zero_of_localizingSequence_of_bound_variation_bound_original_continuousOn
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [UniformSpace κ]
+    [OrderTopology κ] [CompactIccSpace κ] [MeasurableSpace κ] [BorelSpace κ]
+    [SecondCountableTopology κ] [PseudoMetrizableSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_cadlag : ∀ ω, IsCadlag (N · ω))
+    (hN_zero : ∀ ω, N ⊥ ω = 0) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {τ : ℕ → Ω' → WithTop κ} (hτ : IsLocalizingSequence 𝓕' τ P')
+    {t : κ} (ht : (⊥ : κ) < t) {v : ℕ → κ} (hv_lt : ∀ k, v k < t)
+    (hv_tendsto : Tendsto v atTop (nhdsWithin t (Set.Iio t)))
+    {m : ℕ → ℕ} {u : ℕ → ℕ → κ} (hu : ∀ n, Monotone (u n))
+    (hu0 : ∀ n, u n 0 = ⊥) (hut : ∀ n, u n (m n) = t)
+    (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℕ → ℝ} (hC_nonneg : ∀ n, 0 ≤ C n) (hV_nonneg : ∀ n, 0 ≤ V n)
+    (hbound_horizon : ∀ n, ∀ᵐ ω ∂P',
+      ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C n)
+    (hvar_bound : ∀ n, ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V n)
+    (hN_cont : ∀ ω, ContinuousOn (N · ω) (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ V ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ V) :
+    (N t =ᵐ[P'] 0) ∧ ((fun ω => Function.leftLim (N · ω) t) =ᵐ[P'] 0) := by
+  have hzero : N t =ᵐ[P'] 0 :=
+    hN.eq_zero_of_localizingSequence_of_bound_variation_bound_original_continuousOn
+      hN_cadlag hN_zero hτ hu hu0 hut hus hC_nonneg hV_nonneg hbound_horizon
+      hvar_bound hN_cont hmesh
+  have hjump : N t =ᵐ[P'] fun ω => Function.leftLim (N · ω) t :=
+    hN.ae_eq_leftLim_localizingSequence_of_left_approach_of_bound
+      hN_cadlag hN_pred hN_var hτ ht hv_lt hv_tendsto hC_nonneg hbound_horizon
+  exact ⟨hzero, hjump.symm.trans hzero⟩
+
+set_option linter.style.longLine false in
+/-- Stopped/indicator jump removal when the stopped process itself has the deterministic
+horizon bound on `[⊥, t]`. -/
+lemma _root_.MeasureTheory.Martingale.ae_eq_leftLim_stoppedProcess_indicator_of_left_approach_of_stopped_bound
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [SecondCountableTopology κ]
+    [PseudoMetrizableSpace κ] {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] [Approximable 𝓕' P']
+    {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_cadlag : ∀ ω, IsCadlag (N · ω)) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {τ : Ω' → WithTop κ} (hτ : IsStoppingTime 𝓕' τ) {t : κ}
+    (ht : (⊥ : κ) < t) {u : ℕ → κ} (hu_lt : ∀ n, u n < t)
+    (hu_tendsto : Tendsto u atTop (nhdsWithin t (Set.Iio t)))
+    {C : ℝ} (hC_nonneg : 0 ≤ C)
+    (hZ_bound : ∀ᵐ ω ∂P',
+      ∀ r ∈ Set.Icc (⊥ : κ) t,
+        ‖stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ r ω‖ ≤ C) :
+    stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ t =ᵐ[P']
+      fun ω => Function.leftLim
+        ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω) t := by
+  let Z : κ → Ω' → ℝ :=
+    stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ
+  have hZ_mart : Martingale Z 𝓕' P' := by
+    simpa [Z] using hN.stoppedProcess_indicator
+      (fun ω ↦ (hN_cadlag ω).right_continuous) hτ
+  have hZ_pred : IsStronglyPredictable 𝓕' Z := by
+    simpa [Z] using hN_pred.stoppedProcess_indicator hτ
+  have hZ_var : ∀ ω, LocallyBoundedVariationOn (Z · ω) Set.univ := by
+    intro ω
+    simpa [Z] using locallyBoundedVariationOn_stoppedProcess_indicator
+      (N := N) (τ := τ) hN_var ω
+  have hZ_bound' : ∀ᵐ ω ∂P',
+      ∀ r ∈ Set.Icc (⊥ : κ) t, ‖Z r ω‖ ≤ C := by
+    simpa [Z] using hZ_bound
+  simpa [Z] using hZ_mart.ae_eq_leftLim_of_left_approach_past_setIntegral_zero_of_bound_no_integrability
+    hZ_pred hZ_var ht hu_lt hu_tendsto hC_nonneg hZ_bound'
+
+set_option linter.style.longLine false in
+/-- On `{ω | t < τ ω}`, stopped-bound jump removal transfers from the stopped/indicator
+process back to the original martingale. -/
+lemma _root_.MeasureTheory.Martingale.ae_eq_leftLim_on_event_of_left_approach_of_stopped_bound
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [SecondCountableTopology κ]
+    [PseudoMetrizableSpace κ] {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] [Approximable 𝓕' P']
+    {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_cadlag : ∀ ω, IsCadlag (N · ω)) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {τ : Ω' → WithTop κ} (hτ : IsStoppingTime 𝓕' τ) {t : κ}
+    (ht : (⊥ : κ) < t) {u : ℕ → κ} (hu_lt : ∀ n, u n < t)
+    (hu_tendsto : Tendsto u atTop (nhdsWithin t (Set.Iio t)))
+    {C : ℝ} (hC_nonneg : 0 ≤ C)
+    (hZ_bound : ∀ᵐ ω ∂P',
+      ∀ r ∈ Set.Icc (⊥ : κ) t,
+        ‖stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ r ω‖ ≤ C) :
+    ∀ᵐ ω ∂P', (t : WithTop κ) < τ ω →
+      N t ω = Function.leftLim (N · ω) t := by
+  have hstopped :
+      stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ t =ᵐ[P']
+        fun ω => Function.leftLim
+          ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ ω}.indicator (N i)) τ) · ω) t :=
+    hN.ae_eq_leftLim_stoppedProcess_indicator_of_left_approach_of_stopped_bound
+      hN_cadlag hN_pred hN_var hτ ht hu_lt hu_tendsto hC_nonneg hZ_bound
+  filter_upwards [hstopped] with ω hω_stopped hτt
+  have hterminal :
+      stoppedProcess (fun i ↦ {ω' : Ω' | (⊥ : κ) < τ ω'}.indicator (N i)) τ t ω =
+        N t ω := by
+    have hbotτ : (⊥ : κ) < τ ω :=
+      lt_of_le_of_lt (WithTop.coe_le_coe.2 bot_le) hτt
+    have hmem : ω ∈ {ω' : Ω' | (⊥ : κ) < τ ω'} := hbotτ
+    rw [stoppedProcess_eq_of_le hτt.le, Set.indicator_of_mem hmem]
+  have hleft :
+      Function.leftLim
+          ((stoppedProcess (fun i ↦ {ω' : Ω' | (⊥ : κ) < τ ω'}.indicator (N i)) τ) · ω) t =
+        Function.leftLim (N · ω) t :=
+    MeasureTheory.leftLim_stoppedProcess_indicator_eq_of_lt
+      (N := N) (τ := τ) (ω := ω) (t := t) (hN_var ω) hτt
+  calc
+    N t ω =
+        stoppedProcess (fun i ↦ {ω' : Ω' | (⊥ : κ) < τ ω'}.indicator (N i)) τ t ω :=
+      hterminal.symm
+    _ = Function.leftLim
+          ((stoppedProcess (fun i ↦ {ω' : Ω' | (⊥ : κ) < τ ω'}.indicator (N i)) τ) · ω) t :=
+      hω_stopped
+    _ = Function.leftLim (N · ω) t := hleft
+
+set_option linter.style.longLine false in
+/-- Localizing-sequence jump removal from direct stopped/indicator horizon bounds. -/
+lemma _root_.MeasureTheory.Martingale.ae_eq_leftLim_localizingSequence_of_left_approach_of_stopped_bound
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [SecondCountableTopology κ]
+    [PseudoMetrizableSpace κ] {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'}
+    {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] [Approximable 𝓕' P']
+    {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_cadlag : ∀ ω, IsCadlag (N · ω)) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {τ : ℕ → Ω' → WithTop κ} (hτ : IsLocalizingSequence 𝓕' τ P')
+    {t : κ} (ht : (⊥ : κ) < t) {u : ℕ → κ} (hu_lt : ∀ n, u n < t)
+    (hu_tendsto : Tendsto u atTop (nhdsWithin t (Set.Iio t)))
+    {C : ℕ → ℝ} (hC_nonneg : ∀ n, 0 ≤ C n)
+    (hZ_bound : ∀ n, ∀ᵐ ω ∂P',
+      ∀ r ∈ Set.Icc (⊥ : κ) t,
+        ‖stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n) r ω‖
+          ≤ C n) :
+    N t =ᵐ[P'] fun ω => Function.leftLim (N · ω) t := by
+  have hon_event : ∀ n, ∀ᵐ ω ∂P', (t : WithTop κ) < τ n ω →
+      N t ω = Function.leftLim (N · ω) t := by
+    intro n
+    exact hN.ae_eq_leftLim_on_event_of_left_approach_of_stopped_bound
+      (τ := τ n) (C := C n) hN_cadlag hN_pred hN_var (hτ.isStoppingTime n)
+      ht hu_lt hu_tendsto (hC_nonneg n) (hZ_bound n)
+  have hall_event : ∀ᵐ ω ∂P', ∀ n, (t : WithTop κ) < τ n ω →
+      N t ω = Function.leftLim (N · ω) t :=
+    ae_all_iff.2 hon_event
+  have hcover : ∀ᵐ ω ∂P', ∃ n, (t : WithTop κ) < τ n ω := by
+    filter_upwards [hτ.tendsto_top] with ω htop
+    simp only [tendsto_atTop_nhds] at htop
+    obtain ⟨n, hn⟩ := htop (Set.Ioi (t : WithTop κ)) (by simp) isOpen_Ioi
+    exact ⟨n, hn n le_rfl⟩
+  filter_upwards [hcover, hall_event] with ω hω_cover hω_all
+  rcases hω_cover with ⟨n, hωn⟩
+  exact hω_all n hωn
+
+set_option linter.style.longLine false in
+/-- Stopped-bound terminal-zero and left-limit-zero wrapper under explicit deterministic
+left-approach, stopped-piece horizon and variation bounds, stopped-piece continuity, partitions,
+and mesh hypotheses. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_and_leftLim_eq_zero_of_localizingSequence_bounded_continuous_finiteVariation_of_variation_bound_continuousOn
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [UniformSpace κ]
+    [OrderTopology κ] [CompactIccSpace κ] [MeasurableSpace κ] [BorelSpace κ]
+    [SecondCountableTopology κ] [PseudoMetrizableSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_cadlag : ∀ ω, IsCadlag (N · ω))
+    (hN_zero : ∀ ω, N ⊥ ω = 0) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {τ : ℕ → Ω' → WithTop κ} (hτ : IsLocalizingSequence 𝓕' τ P')
+    {t : κ} (ht : (⊥ : κ) < t) {v : ℕ → κ} (hv_lt : ∀ k, v k < t)
+    (hv_tendsto : Tendsto v atTop (nhdsWithin t (Set.Iio t)))
+    {m : ℕ → ℕ} {u : ℕ → ℕ → κ} (hu : ∀ n, Monotone (u n))
+    (hu0 : ∀ n, u n 0 = ⊥) (hut : ∀ n, u n (m n) = t)
+    (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℕ → ℝ} (hC_nonneg : ∀ n, 0 ≤ C n) (hV_nonneg : ∀ n, 0 ≤ V n)
+    (hZ_bound : ∀ n, ∀ᵐ ω ∂P',
+      ∀ s ∈ Set.Icc (⊥ : κ) t,
+        ‖stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n) s ω‖
+          ≤ C n)
+    (hZ_var_bound : ∀ n, ∀ᵐ ω ∂P',
+      BoundedVariationOn
+          ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+          (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn
+          ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+          (Set.Icc (⊥ : κ) t)).toReal ≤ V n)
+    (hZ_cont : ∀ n ω,
+      ContinuousOn
+        ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+        (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ V ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ V) :
+    (N t =ᵐ[P'] 0) ∧ ((fun ω => Function.leftLim (N · ω) t) =ᵐ[P'] 0) := by
+  have hzero : N t =ᵐ[P'] 0 :=
+    hN.eq_zero_of_localizingSequence_bounded_continuous_finiteVariation_of_variation_bound_continuousOn
+      hN_cadlag hN_zero hτ hu hu0 hut hus hC_nonneg hV_nonneg hZ_bound
+      hZ_var_bound hZ_cont hmesh
+  have hjump : N t =ᵐ[P'] fun ω => Function.leftLim (N · ω) t :=
+    hN.ae_eq_leftLim_localizingSequence_of_left_approach_of_stopped_bound
+      hN_cadlag hN_pred hN_var hτ ht hv_lt hv_tendsto hC_nonneg hZ_bound
+  exact ⟨hzero, hjump.symm.trans hzero⟩
+
+/-- Extract a deterministic sequence from a nontrivial left-neighborhood filter. -/
+lemma _root_.Filter.exists_seq_lt_tendsto_nhdsWithin_Iio_of_neBot
+    {κ : Type*} [Preorder κ] [TopologicalSpace κ] [SecondCountableTopology κ]
+    {t : κ} (hleft : (nhdsWithin t (Set.Iio t)).NeBot) :
+    ∃ v : ℕ → κ, (∀ n, v n < t) ∧
+      Tendsto v atTop (nhdsWithin t (Set.Iio t)) := by
+  haveI : NeBot (nhdsWithin t (Set.Iio t)) := hleft
+  have h_eventually : ∀ᶠ x in nhdsWithin t (Set.Iio t), x < t := by
+    simpa only [Set.mem_Iio] using
+      (self_mem_nhdsWithin : ∀ᶠ x in nhdsWithin t (Set.Iio t), x ∈ Set.Iio t)
+  obtain ⟨v, hv_tendsto, hv_lt⟩ :=
+    Filter.exists_seq_forall_of_frequently h_eventually.frequently
+  exact ⟨v, hv_lt, hv_tendsto⟩
+
+set_option linter.style.longLine false in
+/-- Original-bound terminal-zero and left-limit-zero wrapper using a nontrivial
+left-neighborhood filter instead of an explicit left-approaching sequence. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_and_leftLim_eq_zero_of_localizingSequence_of_bound_variation_bound_original_continuousOn_of_neBot_left
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [UniformSpace κ]
+    [OrderTopology κ] [CompactIccSpace κ] [MeasurableSpace κ] [BorelSpace κ]
+    [SecondCountableTopology κ] [PseudoMetrizableSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_cadlag : ∀ ω, IsCadlag (N · ω))
+    (hN_zero : ∀ ω, N ⊥ ω = 0) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {τ : ℕ → Ω' → WithTop κ} (hτ : IsLocalizingSequence 𝓕' τ P')
+    {t : κ} (ht : (⊥ : κ) < t) (hleft : (nhdsWithin t (Set.Iio t)).NeBot)
+    {m : ℕ → ℕ} {u : ℕ → ℕ → κ} (hu : ∀ n, Monotone (u n))
+    (hu0 : ∀ n, u n 0 = ⊥) (hut : ∀ n, u n (m n) = t)
+    (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℕ → ℝ} (hC_nonneg : ∀ n, 0 ≤ C n) (hV_nonneg : ∀ n, 0 ≤ V n)
+    (hbound_horizon : ∀ n, ∀ᵐ ω ∂P',
+      ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C n)
+    (hvar_bound : ∀ n, ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V n)
+    (hN_cont : ∀ ω, ContinuousOn (N · ω) (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ V ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ V) :
+    (N t =ᵐ[P'] 0) ∧ ((fun ω => Function.leftLim (N · ω) t) =ᵐ[P'] 0) := by
+  obtain ⟨v, hv_lt, hv_tendsto⟩ :=
+    Filter.exists_seq_lt_tendsto_nhdsWithin_Iio_of_neBot hleft
+  exact hN.eq_zero_and_leftLim_eq_zero_of_localizingSequence_of_bound_variation_bound_original_continuousOn
+    hN_cadlag hN_zero hN_pred hN_var hτ ht hv_lt hv_tendsto hu hu0 hut hus
+    hC_nonneg hV_nonneg hbound_horizon hvar_bound hN_cont hmesh
+
+set_option linter.style.longLine false in
+/-- Stopped-bound terminal-zero and left-limit-zero wrapper using a nontrivial
+left-neighborhood filter instead of an explicit left-approaching sequence. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_and_leftLim_eq_zero_of_localizingSequence_bounded_continuous_finiteVariation_of_variation_bound_continuousOn_of_neBot_left
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [UniformSpace κ]
+    [OrderTopology κ] [CompactIccSpace κ] [MeasurableSpace κ] [BorelSpace κ]
+    [SecondCountableTopology κ] [PseudoMetrizableSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_cadlag : ∀ ω, IsCadlag (N · ω))
+    (hN_zero : ∀ ω, N ⊥ ω = 0) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {τ : ℕ → Ω' → WithTop κ} (hτ : IsLocalizingSequence 𝓕' τ P')
+    {t : κ} (ht : (⊥ : κ) < t) (hleft : (nhdsWithin t (Set.Iio t)).NeBot)
+    {m : ℕ → ℕ} {u : ℕ → ℕ → κ} (hu : ∀ n, Monotone (u n))
+    (hu0 : ∀ n, u n 0 = ⊥) (hut : ∀ n, u n (m n) = t)
+    (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℕ → ℝ} (hC_nonneg : ∀ n, 0 ≤ C n) (hV_nonneg : ∀ n, 0 ≤ V n)
+    (hZ_bound : ∀ n, ∀ᵐ ω ∂P',
+      ∀ s ∈ Set.Icc (⊥ : κ) t,
+        ‖stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n) s ω‖
+          ≤ C n)
+    (hZ_var_bound : ∀ n, ∀ᵐ ω ∂P',
+      BoundedVariationOn
+          ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+          (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn
+          ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+          (Set.Icc (⊥ : κ) t)).toReal ≤ V n)
+    (hZ_cont : ∀ n ω,
+      ContinuousOn
+        ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+        (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ V ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ V) :
+    (N t =ᵐ[P'] 0) ∧ ((fun ω => Function.leftLim (N · ω) t) =ᵐ[P'] 0) := by
+  obtain ⟨v, hv_lt, hv_tendsto⟩ :=
+    Filter.exists_seq_lt_tendsto_nhdsWithin_Iio_of_neBot hleft
+  exact hN.eq_zero_and_leftLim_eq_zero_of_localizingSequence_bounded_continuous_finiteVariation_of_variation_bound_continuousOn
+    hN_cadlag hN_zero hN_pred hN_var hτ ht hv_lt hv_tendsto hu hu0 hut hus
+    hC_nonneg hV_nonneg hZ_bound hZ_var_bound hZ_cont hmesh
+
+set_option linter.style.longLine false in
+/-- Stopped-bound terminal-zero and left-limit-zero wrapper that derives stopped/indicator
+path-continuity from original-path continuity on the deterministic horizon. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_and_leftLim_eq_zero_of_localizingSequence_bounded_continuous_finiteVariation_of_variation_bound_original_continuousOn_of_neBot_left
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [UniformSpace κ]
+    [OrderTopology κ] [CompactIccSpace κ] [MeasurableSpace κ] [BorelSpace κ]
+    [SecondCountableTopology κ] [PseudoMetrizableSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_cadlag : ∀ ω, IsCadlag (N · ω))
+    (hN_zero : ∀ ω, N ⊥ ω = 0) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {τ : ℕ → Ω' → WithTop κ} (hτ : IsLocalizingSequence 𝓕' τ P')
+    {t : κ} (ht : (⊥ : κ) < t) (hleft : (nhdsWithin t (Set.Iio t)).NeBot)
+    {m : ℕ → ℕ} {u : ℕ → ℕ → κ} (hu : ∀ n, Monotone (u n))
+    (hu0 : ∀ n, u n 0 = ⊥) (hut : ∀ n, u n (m n) = t)
+    (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℕ → ℝ} (hC_nonneg : ∀ n, 0 ≤ C n) (hV_nonneg : ∀ n, 0 ≤ V n)
+    (hZ_bound : ∀ n, ∀ᵐ ω ∂P',
+      ∀ s ∈ Set.Icc (⊥ : κ) t,
+        ‖stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n) s ω‖
+          ≤ C n)
+    (hZ_var_bound : ∀ n, ∀ᵐ ω ∂P',
+      BoundedVariationOn
+          ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+          (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn
+          ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+          (Set.Icc (⊥ : κ) t)).toReal ≤ V n)
+    (hN_cont : ∀ ω, ContinuousOn (N · ω) (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ V ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ V) :
+    (N t =ᵐ[P'] 0) ∧ ((fun ω => Function.leftLim (N · ω) t) =ᵐ[P'] 0) := by
+  exact hN.eq_zero_and_leftLim_eq_zero_of_localizingSequence_bounded_continuous_finiteVariation_of_variation_bound_continuousOn_of_neBot_left
+    hN_cadlag hN_zero hN_pred hN_var hτ ht hleft hu hu0 hut hus hC_nonneg hV_nonneg
+    hZ_bound hZ_var_bound
+    (fun n ω ↦ MeasureTheory.stoppedProcess_indicator_continuousOn_Icc
+      (N := N) (τ := τ n) (ω := ω) (t := t) (hN_cont ω))
+    hmesh
+
+set_option linter.style.longLine false in
+/-- Fixed-time value-zero connector for the three explicit left-branch alternatives. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_localizingSequence_bounded_continuous_finiteVariation_of_variation_bound_original_continuousOn_of_left_branch
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [UniformSpace κ]
+    [OrderTopology κ] [CompactIccSpace κ] [MeasurableSpace κ] [BorelSpace κ]
+    [SecondCountableTopology κ] [PseudoMetrizableSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_cadlag : ∀ ω, IsCadlag (N · ω))
+    (hN_zero : ∀ ω, N ⊥ ω = 0) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {τ : ℕ → Ω' → WithTop κ} (hτ : IsLocalizingSequence 𝓕' τ P')
+    {t : κ} (ht : (⊥ : κ) < t)
+    {m : ℕ → ℕ} {u : ℕ → ℕ → κ} (hu : ∀ n, Monotone (u n))
+    (hu0 : ∀ n, u n 0 = ⊥) (hut : ∀ n, u n (m n) = t)
+    (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℕ → ℝ} (hC_nonneg : ∀ n, 0 ≤ C n) (hV_nonneg : ∀ n, 0 ≤ V n)
+    (hZ_bound : ∀ n, ∀ᵐ ω ∂P',
+      ∀ s ∈ Set.Icc (⊥ : κ) t,
+        ‖stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n) s ω‖
+          ≤ C n)
+    (hZ_var_bound : ∀ n, ∀ᵐ ω ∂P',
+      BoundedVariationOn
+          ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+          (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn
+          ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+          (Set.Icc (⊥ : κ) t)).toReal ≤ V n)
+    (hN_cont : ∀ ω, ContinuousOn (N · ω) (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ V ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ V)
+    (hbranch :
+      (nhdsWithin t (Set.Iio t)).NeBot ∨
+        (∀ r : κ, r < t → r ≤ (⊥ : κ)) ∨
+          ∃ s : κ, s < t ∧ (∀ r : κ, r < t → r ≤ s) ∧ N s =ᵐ[P'] 0) :
+    N t =ᵐ[P'] 0 := by
+  rcases hbranch with hleft | hbranch
+  · exact
+      (hN.eq_zero_and_leftLim_eq_zero_of_localizingSequence_bounded_continuous_finiteVariation_of_variation_bound_original_continuousOn_of_neBot_left
+        hN_cadlag hN_zero hN_pred hN_var hτ ht hleft hu hu0 hut hus hC_nonneg
+        hV_nonneg hZ_bound hZ_var_bound hN_cont hmesh).1
+  · rcases hbranch with hbot_prev | hprev
+    · exact hN.eq_zero_of_predictable_bottom_immediate hN_pred hN_zero ht hbot_prev
+    · rcases hprev with ⟨s, hst, hgreatest, hs_zero⟩
+      exact hN.eq_zero_of_predictable_left_isolated_of_previous hN_pred ht hst
+        hgreatest hs_zero
+
+set_option linter.style.longLine false in
+/-- Original-bound fixed-time value-zero connector for the three explicit left-branch
+alternatives. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_localizingSequence_of_bound_variation_bound_original_continuousOn_of_left_branch
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [UniformSpace κ]
+    [OrderTopology κ] [CompactIccSpace κ] [MeasurableSpace κ] [BorelSpace κ]
+    [SecondCountableTopology κ] [PseudoMetrizableSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_cadlag : ∀ ω, IsCadlag (N · ω))
+    (hN_zero : ∀ ω, N ⊥ ω = 0) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {τ : ℕ → Ω' → WithTop κ} (hτ : IsLocalizingSequence 𝓕' τ P')
+    {t : κ} (ht : (⊥ : κ) < t)
+    {m : ℕ → ℕ} {u : ℕ → ℕ → κ} (hu : ∀ n, Monotone (u n))
+    (hu0 : ∀ n, u n 0 = ⊥) (hut : ∀ n, u n (m n) = t)
+    (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℕ → ℝ} (hC_nonneg : ∀ n, 0 ≤ C n) (hV_nonneg : ∀ n, 0 ≤ V n)
+    (hbound_horizon : ∀ n, ∀ᵐ ω ∂P',
+      ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C n)
+    (hvar_bound : ∀ n, ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V n)
+    (hN_cont : ∀ ω, ContinuousOn (N · ω) (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ W ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ W)
+    (hbranch :
+      (nhdsWithin t (Set.Iio t)).NeBot ∨
+        (∀ r : κ, r < t → r ≤ (⊥ : κ)) ∨
+          ∃ s : κ, s < t ∧ (∀ r : κ, r < t → r ≤ s) ∧ N s =ᵐ[P'] 0) :
+    N t =ᵐ[P'] 0 := by
+  have hstopped_bounds : ∀ n,
+      (∀ᵐ ω ∂P', ∀ s ∈ Set.Icc (⊥ : κ) t,
+        ‖stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n) s ω‖
+          ≤ C n) ∧
+        (∀ᵐ ω ∂P',
+          BoundedVariationOn
+              ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+              (Set.Icc (⊥ : κ) t) ∧
+            (eVariationOn
+              ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+              (Set.Icc (⊥ : κ) t)).toReal ≤ V n) := by
+    intro n
+    exact MeasureTheory.ae_stoppedProcess_indicator_bound_variation_on_Icc
+      (N := N) (τ := τ n) (t := t) (C := C n) (V := V n)
+      (hC_nonneg n) (hbound_horizon n) (hvar_bound n)
+  exact hN.eq_zero_of_localizingSequence_bounded_continuous_finiteVariation_of_variation_bound_original_continuousOn_of_left_branch
+    hN_cadlag hN_zero hN_pred hN_var hτ ht hu hu0 hut hus hC_nonneg hV_nonneg
+    (fun n ↦ (hstopped_bounds n).1) (fun n ↦ (hstopped_bounds n).2) hN_cont hmesh
+    hbranch
+
+/-- In a densely ordered time line with a bottom, every non-bottom point has a nontrivial
+strict-left neighborhood filter. -/
+lemma _root_.Filter.nhdsWithin_Iio_self_neBot_of_bot_lt
+    {κ : Type*} [LinearOrder κ] [OrderBot κ] [TopologicalSpace κ] [OrderTopology κ]
+    [DenselyOrdered κ] {t : κ} (ht : (⊥ : κ) < t) :
+    (nhdsWithin t (Set.Iio t)).NeBot := by
+  simpa only [nhdsWithin] using
+    (nhdsLT_neBot_of_exists_lt (α := κ) (b := t) ⟨⊥, ht⟩)
+
+set_option linter.style.longLine false in
+/-- Pre-stop-bound fixed-time value-zero connector for the three explicit left-branch
+alternatives. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_localizingSequence_of_pre_stop_bound_variation_bound_original_continuousOn_of_left_branch
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [UniformSpace κ]
+    [OrderTopology κ] [CompactIccSpace κ] [MeasurableSpace κ] [BorelSpace κ]
+    [SecondCountableTopology κ] [PseudoMetrizableSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_cadlag : ∀ ω, IsCadlag (N · ω))
+    (hN_zero : ∀ ω, N ⊥ ω = 0) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {τ : ℕ → Ω' → WithTop κ} (hτ : IsLocalizingSequence 𝓕' τ P')
+    {t : κ} (ht : (⊥ : κ) < t)
+    {m : ℕ → ℕ} {u : ℕ → ℕ → κ} (hu : ∀ n, Monotone (u n))
+    (hu0 : ∀ n, u n 0 = ⊥) (hut : ∀ n, u n (m n) = t)
+    (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℕ → ℝ} (hC_nonneg : ∀ n, 0 ≤ C n) (hV_nonneg : ∀ n, 0 ≤ V n)
+    (hpre_bound : ∀ n, ∀ᵐ ω ∂P', ∀ r ∈ Set.Icc (⊥ : κ) t,
+      (r : WithTop κ) < τ n ω → ‖N r ω‖ ≤ C n)
+    (hstop_bound : ∀ n, ∀ᵐ ω ∂P', (⊥ : κ) < τ n ω → τ n ω ≠ ⊤ →
+      τ n ω ≤ (t : WithTop κ) → ‖N (τ n ω).untopA ω‖ ≤ C n)
+    (hvar_bound : ∀ n, ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω)
+          {r : κ | r ∈ Set.Icc (⊥ : κ) t ∧ (r : WithTop κ) ≤ τ n ω} ∧
+        (eVariationOn (N · ω)
+          {r : κ | r ∈ Set.Icc (⊥ : κ) t ∧ (r : WithTop κ) ≤ τ n ω}).toReal ≤ V n)
+    (hN_cont : ∀ ω, ContinuousOn (N · ω) (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ W ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ W)
+    (hbranch :
+      (nhdsWithin t (Set.Iio t)).NeBot ∨
+        (∀ r : κ, r < t → r ≤ (⊥ : κ)) ∨
+          ∃ s : κ, s < t ∧ (∀ r : κ, r < t → r ≤ s) ∧ N s =ᵐ[P'] 0) :
+    N t =ᵐ[P'] 0 := by
+  have hstopped_bounds : ∀ n,
+      (∀ᵐ ω ∂P', ∀ s ∈ Set.Icc (⊥ : κ) t,
+        ‖stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n) s ω‖
+          ≤ C n) ∧
+        (∀ᵐ ω ∂P',
+          BoundedVariationOn
+              ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+              (Set.Icc (⊥ : κ) t) ∧
+            (eVariationOn
+              ((stoppedProcess (fun i ↦ {ω | (⊥ : κ) < τ n ω}.indicator (N i)) (τ n)) · ω)
+              (Set.Icc (⊥ : κ) t)).toReal ≤ V n) := by
+    intro n
+    exact MeasureTheory.ae_stoppedProcess_indicator_bound_variation_on_Icc_of_pre_stop_bound
+      (N := N) (τ := τ n) (t := t) (C := C n) (V := V n)
+      (hC_nonneg n) (hpre_bound n) (hstop_bound n) (hvar_bound n)
+  exact hN.eq_zero_of_localizingSequence_bounded_continuous_finiteVariation_of_variation_bound_original_continuousOn_of_left_branch
+    hN_cadlag hN_zero hN_pred hN_var hτ ht hu hu0 hut hus hC_nonneg hV_nonneg
+    (fun n ↦ (hstopped_bounds n).1) (fun n ↦ (hstopped_bounds n).2) hN_cont hmesh
+    hbranch
+
+set_option linter.style.longLine false in
+/-- Dense-left specialization of the pre-stop localizing-sequence endpoint.  The dense order
+assumption is used only to construct the nontrivial strict-left branch. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_localizingSequence_of_pre_stop_bound_variation_bound_original_continuousOn_of_dense_left
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [UniformSpace κ]
+    [OrderTopology κ] [CompactIccSpace κ] [MeasurableSpace κ] [BorelSpace κ]
+    [SecondCountableTopology κ] [PseudoMetrizableSpace κ] [DenselyOrdered κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_cadlag : ∀ ω, IsCadlag (N · ω))
+    (hN_zero : ∀ ω, N ⊥ ω = 0) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {τ : ℕ → Ω' → WithTop κ} (hτ : IsLocalizingSequence 𝓕' τ P')
+    {t : κ} (ht : (⊥ : κ) < t)
+    {m : ℕ → ℕ} {u : ℕ → ℕ → κ} (hu : ∀ n, Monotone (u n))
+    (hu0 : ∀ n, u n 0 = ⊥) (hut : ∀ n, u n (m n) = t)
+    (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℕ → ℝ} (hC_nonneg : ∀ n, 0 ≤ C n) (hV_nonneg : ∀ n, 0 ≤ V n)
+    (hpre_bound : ∀ n, ∀ᵐ ω ∂P', ∀ r ∈ Set.Icc (⊥ : κ) t,
+      (r : WithTop κ) < τ n ω → ‖N r ω‖ ≤ C n)
+    (hstop_bound : ∀ n, ∀ᵐ ω ∂P', (⊥ : κ) < τ n ω → τ n ω ≠ ⊤ →
+      τ n ω ≤ (t : WithTop κ) → ‖N (τ n ω).untopA ω‖ ≤ C n)
+    (hvar_bound : ∀ n, ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω)
+          {r : κ | r ∈ Set.Icc (⊥ : κ) t ∧ (r : WithTop κ) ≤ τ n ω} ∧
+        (eVariationOn (N · ω)
+          {r : κ | r ∈ Set.Icc (⊥ : κ) t ∧ (r : WithTop κ) ≤ τ n ω}).toReal ≤ V n)
+    (hN_cont : ∀ ω, ContinuousOn (N · ω) (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ W ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ W) :
+    N t =ᵐ[P'] 0 := by
+  have hleft : (nhdsWithin t (Set.Iio t)).NeBot :=
+    Filter.nhdsWithin_Iio_self_neBot_of_bot_lt ht
+  exact hN.eq_zero_of_localizingSequence_of_pre_stop_bound_variation_bound_original_continuousOn_of_left_branch
+    hN_cadlag hN_zero hN_pred hN_var hτ ht hu hu0 hut hus hC_nonneg hV_nonneg
+    hpre_bound hstop_bound hvar_bound hN_cont hmesh (Or.inl hleft)
+
+set_option linter.style.longLine false in
+/-- Fixed-level original-bound fixed-time value-zero connector for the three explicit left-branch
+alternatives.  This is the single-deterministic-bound specialization of the localizing-sequence
+wrapper, using the constant-top localizing sequence. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_bound_variation_bound_original_continuousOn_of_left_branch
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [UniformSpace κ]
+    [OrderTopology κ] [CompactIccSpace κ] [MeasurableSpace κ] [BorelSpace κ]
+    [SecondCountableTopology κ] [PseudoMetrizableSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_cadlag : ∀ ω, IsCadlag (N · ω))
+    (hN_zero : ∀ ω, N ⊥ ω = 0) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {t : κ} (ht : (⊥ : κ) < t)
+    {m : ℕ → ℕ} {u : ℕ → ℕ → κ} (hu : ∀ n, Monotone (u n))
+    (hu0 : ∀ n, u n 0 = ⊥) (hut : ∀ n, u n (m n) = t)
+    (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℝ} (hC_nonneg : 0 ≤ C) (hV_nonneg : 0 ≤ V)
+    (hbound_horizon : ∀ᵐ ω ∂P',
+      ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C)
+    (hvar_bound : ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V)
+    (hN_cont : ∀ ω, ContinuousOn (N · ω) (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ W ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ W)
+    (hbranch :
+      (nhdsWithin t (Set.Iio t)).NeBot ∨
+        (∀ r : κ, r < t → r ≤ (⊥ : κ)) ∨
+          ∃ s : κ, s < t ∧ (∀ r : κ, r < t → r ≤ s) ∧ N s =ᵐ[P'] 0) :
+    N t =ᵐ[P'] 0 := by
+  let τ : ℕ → Ω' → WithTop κ := fun _ _ ↦ ⊤
+  have hτ : IsLocalizingSequence 𝓕' τ P' := by
+    simpa [τ] using (_root_.ProbabilityTheory.isLocalizingSequence_const_top 𝓕' P')
+  exact hN.eq_zero_of_localizingSequence_of_bound_variation_bound_original_continuousOn_of_left_branch
+    (τ := τ) (C := fun _ ↦ C) (V := fun _ ↦ V)
+    hN_cadlag hN_zero hN_pred hN_var hτ ht hu hu0 hut hus
+    (fun _ ↦ hC_nonneg) (fun _ ↦ hV_nonneg)
+    (fun _ ↦ hbound_horizon) (fun _ ↦ hvar_bound) hN_cont hmesh hbranch
+
+set_option linter.style.longLine false in
+/-- If the strict-left neighborhood filter at a non-bottom point is trivial, then the point has
+a greatest strict predecessor. -/
+lemma _root_.Filter.exists_greatest_lt_of_not_neBot_nhdsWithin_Iio
+    {κ : Type*} [LinearOrder κ] [OrderBot κ] [TopologicalSpace κ] [OrderTopology κ]
+    {t : κ} (ht : (⊥ : κ) < t)
+    (hleft : ¬ (nhdsWithin t (Set.Iio t)).NeBot) :
+    ∃ s : κ, s < t ∧ ∀ r : κ, r < t → r ≤ s := by
+  have hbot : nhdsWithin t (Set.Iio t) = ⊥ := Filter.not_neBot.mp hleft
+  have hmem_empty : (∅ : Set κ) ∈ nhdsWithin t (Set.Iio t) :=
+    Filter.empty_mem_iff_bot.mpr hbot
+  rcases mem_nhdsWithin_iff_exists_mem_nhds_inter.mp hmem_empty with
+    ⟨U, hU_nhds, hU_empty⟩
+  rcases exists_Ioc_subset_of_mem_nhds hU_nhds ⟨⊥, ht⟩ with ⟨s, hst, hIoc_subset⟩
+  refine ⟨s, hst, fun r hrt ↦ ?_⟩
+  by_contra hrs
+  have hsr : s < r := lt_of_not_ge hrs
+  have hrU : r ∈ U := hIoc_subset ⟨hsr, hrt.le⟩
+  have hr_empty : r ∈ (∅ : Set κ) := hU_empty ⟨hrU, hrt⟩
+  exact Set.notMem_empty r hr_empty
+
+set_option linter.style.longLine false in
+/-- Fixed-level original-bound endpoint when all strict-past values have already been proved
+zero.  The proof constructs only the explicit branch data required by the left-branch connector. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_bound_variation_bound_original_continuousOn_of_strictPast_zero
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [UniformSpace κ]
+    [OrderTopology κ] [CompactIccSpace κ] [MeasurableSpace κ] [BorelSpace κ]
+    [SecondCountableTopology κ] [PseudoMetrizableSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_cadlag : ∀ ω, IsCadlag (N · ω))
+    (hN_zero : ∀ ω, N ⊥ ω = 0) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {t : κ} (ht : (⊥ : κ) < t)
+    {m : ℕ → ℕ} {u : ℕ → ℕ → κ} (hu : ∀ n, Monotone (u n))
+    (hu0 : ∀ n, u n 0 = ⊥) (hut : ∀ n, u n (m n) = t)
+    (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℝ} (hC_nonneg : 0 ≤ C) (hV_nonneg : 0 ≤ V)
+    (hbound_horizon : ∀ᵐ ω ∂P',
+      ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C)
+    (hvar_bound : ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V)
+    (hN_cont : ∀ ω, ContinuousOn (N · ω) (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ W ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ W)
+    (hprev_zero : ∀ s : κ, s < t → N s =ᵐ[P'] 0) :
+    N t =ᵐ[P'] 0 := by
+  by_cases hleft : (nhdsWithin t (Set.Iio t)).NeBot
+  · exact hN.eq_zero_of_bound_variation_bound_original_continuousOn_of_left_branch
+      hN_cadlag hN_zero hN_pred hN_var ht hu hu0 hut hus hC_nonneg hV_nonneg
+      hbound_horizon hvar_bound hN_cont hmesh (Or.inl hleft)
+  · rcases Filter.exists_greatest_lt_of_not_neBot_nhdsWithin_Iio ht hleft with
+      ⟨s, hst, hgreatest⟩
+    exact hN.eq_zero_of_bound_variation_bound_original_continuousOn_of_left_branch
+      hN_cadlag hN_zero hN_pred hN_var ht hu hu0 hut hus hC_nonneg hV_nonneg
+      hbound_horizon hvar_bound hN_cont hmesh
+      (Or.inr (Or.inr ⟨s, hst, hgreatest, hprev_zero s hst⟩))
+
+set_option linter.style.longLine false in
+/-- Dense-left specialization of the original-bound localizing-sequence endpoint.  The dense
+order assumption is used only to construct the nontrivial strict-left branch. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_localizingSequence_of_bound_variation_bound_original_continuousOn_of_dense_left
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [UniformSpace κ]
+    [OrderTopology κ] [CompactIccSpace κ] [MeasurableSpace κ] [BorelSpace κ]
+    [SecondCountableTopology κ] [PseudoMetrizableSpace κ] [DenselyOrdered κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_cadlag : ∀ ω, IsCadlag (N · ω))
+    (hN_zero : ∀ ω, N ⊥ ω = 0) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {τ : ℕ → Ω' → WithTop κ} (hτ : IsLocalizingSequence 𝓕' τ P')
+    {t : κ} (ht : (⊥ : κ) < t)
+    {m : ℕ → ℕ} {u : ℕ → ℕ → κ} (hu : ∀ n, Monotone (u n))
+    (hu0 : ∀ n, u n 0 = ⊥) (hut : ∀ n, u n (m n) = t)
+    (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℕ → ℝ} (hC_nonneg : ∀ n, 0 ≤ C n) (hV_nonneg : ∀ n, 0 ≤ V n)
+    (hbound_horizon : ∀ n, ∀ᵐ ω ∂P',
+      ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C n)
+    (hvar_bound : ∀ n, ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V n)
+    (hN_cont : ∀ ω, ContinuousOn (N · ω) (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ W ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ W) :
+    N t =ᵐ[P'] 0 := by
+  have hleft : (nhdsWithin t (Set.Iio t)).NeBot :=
+    Filter.nhdsWithin_Iio_self_neBot_of_bot_lt ht
+  exact hN.eq_zero_of_localizingSequence_of_bound_variation_bound_original_continuousOn_of_left_branch
+    hN_cadlag hN_zero hN_pred hN_var hτ ht hu hu0 hut hus hC_nonneg hV_nonneg
+    hbound_horizon hvar_bound hN_cont hmesh (Or.inl hleft)
+
+set_option linter.style.longLine false in
+/-- Dense-left specialization of the fixed-level original-bound endpoint.  The dense order
+assumption is used only to construct the nontrivial strict-left branch. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_bound_variation_bound_original_continuousOn_of_dense_left
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [UniformSpace κ]
+    [OrderTopology κ] [CompactIccSpace κ] [MeasurableSpace κ] [BorelSpace κ]
+    [SecondCountableTopology κ] [PseudoMetrizableSpace κ] [DenselyOrdered κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] {N : κ → Ω' → ℝ}
+    (hN : Martingale N 𝓕' P') (hN_cadlag : ∀ ω, IsCadlag (N · ω))
+    (hN_zero : ∀ ω, N ⊥ ω = 0) (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ)
+    {t : κ} (ht : (⊥ : κ) < t)
+    {m : ℕ → ℕ} {u : ℕ → ℕ → κ} (hu : ∀ n, Monotone (u n))
+    (hu0 : ∀ n, u n 0 = ⊥) (hut : ∀ n, u n (m n) = t)
+    (hus : ∀ n i, u n i ∈ Set.Icc (⊥ : κ) t)
+    {C V : ℝ} (hC_nonneg : 0 ≤ C) (hV_nonneg : 0 ≤ V)
+    (hbound_horizon : ∀ᵐ ω ∂P',
+      ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C)
+    (hvar_bound : ∀ᵐ ω ∂P',
+      BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t) ∧
+        (eVariationOn (N · ω) (Set.Icc (⊥ : κ) t)).toReal ≤ V)
+    (hN_cont : ∀ ω, ContinuousOn (N · ω) (Set.Icc (⊥ : κ) t))
+    (hmesh : ∀ W ∈ 𝓤 κ, ∀ᶠ n in atTop, ∀ i, i ∈ Finset.range (m n) →
+      (u n i, u n (i + 1)) ∈ W) :
+    N t =ᵐ[P'] 0 := by
+  have hleft : (nhdsWithin t (Set.Iio t)).NeBot :=
+    Filter.nhdsWithin_Iio_self_neBot_of_bot_lt ht
+  exact hN.eq_zero_of_bound_variation_bound_original_continuousOn_of_left_branch
+    hN_cadlag hN_zero hN_pred hN_var ht hu hu0 hut hus hC_nonneg hV_nonneg
+    hbound_horizon hvar_bound hN_cont hmesh (Or.inl hleft)
+
+/-- Terminal form of the bounded continuous finite-variation martingale core.
+
+The hypotheses record the bounded-continuous finite-variation setting of the blueprint.  The
+remaining partition/orthogonality/dominated-convergence argument is represented by the explicit
+zero-square-integral premise; once that premise is available, the a.e. zero conclusion is formal. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_bounded_continuous_finiteVariation_core
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_zero : ∀ ω, N ⊥ ω = 0) {t : κ} (ht : (⊥ : κ) < t) {C : ℝ}
+    (hN_bound : ∀ᵐ ω ∂P', ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C)
+    (hN_cont : ∀ ω, ContinuousOn (N · ω) (Set.Icc (⊥ : κ) t))
+    (hN_var : ∀ ω, BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t))
+    (hN_sq_int : Integrable (fun ω => N t ω ^ 2) P')
+    (hN_sq_zero : ∫ ω, N t ω ^ 2 ∂P' = 0) :
+    N t =ᵐ[P'] 0 := by
+  have _hN_used : Martingale N 𝓕' P' := hN
+  have _hN_zero_used : ∀ ω, N ⊥ ω = 0 := hN_zero
+  have _ht_used : (⊥ : κ) < t := ht
+  have _hN_bound_used :
+      ∀ᵐ ω ∂P', ∀ s ∈ Set.Icc (⊥ : κ) t, ‖N s ω‖ ≤ C := hN_bound
+  have _hN_cont_used : ∀ ω, ContinuousOn (N · ω) (Set.Icc (⊥ : κ) t) := hN_cont
+  have _hN_var_used : ∀ ω, BoundedVariationOn (N · ω) (Set.Icc (⊥ : κ) t) := hN_var
+  exact MeasureTheory.ae_eq_zero_of_integral_sq_eq_zero hN_sq_int hN_sq_zero
+
+set_option linter.style.longLine false in
+/-- Reduction from the full predictable finite-variation hypotheses to the bounded-continuous
+finite-variation core.
+
+This is the remaining analytic gap: remove predictable jumps, localize to bounded continuous
+finite-variation pieces on `[⊥, t]`, prove the zero-square-integral premise by martingale
+increment orthogonality along deterministic partitions, and then remove the bounded localization. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_predictable_finiteVariation_bounded_continuous_reduction
+      {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+      [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [PolishSpace κ]
+      {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+      [IsFiniteMeasure P'] [Approximable 𝓕' P'] [𝓕'.IsComplete P'] [𝓕'.IsRightContinuous]
+      {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+      (hN_cadlag : ∀ ω, IsCadlag (N · ω)) (hN_zero : ∀ ω, N ⊥ ω = 0)
+      (hN_pred : IsStronglyPredictable 𝓕' N)
+      (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ) {t : κ}
+      (ht : (⊥ : κ) < t) :
+      N t =ᵐ[P'] 0 := by
+    have _hN_cadlag_used : ∀ ω, IsCadlag (N · ω) := hN_cadlag
+    have _hN_zero_used : ∀ ω, N ⊥ ω = 0 := hN_zero
+    have _hN_pred_used : IsStronglyPredictable 𝓕' N := hN_pred
+    have _hN_var_used : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ := hN_var
+    have _ht_used : (⊥ : κ) < t := ht
+    have hleftLim_exists :
+        ∀ ω, ∃ l, Tendsto (N · ω) (nhdsWithin t (Set.Iio t)) (nhds l) := fun ω =>
+      (hN_var ω).exists_tendsto_left_univ t
+    have _hleftLim_tendsto :
+        ∀ ω, Tendsto (N · ω) (nhdsWithin t (Set.Iio t))
+          (nhds (Function.leftLim (N · ω) t)) := fun ω =>
+        tendsto_leftLim_of_tendsto (hleftLim_exists ω)
+    have horthogonal_increments :
+        ∀ {a b c d : κ}, a ≤ b → b ≤ c → c ≤ d →
+          Integrable (fun ω => (N b ω - N a ω) * (N d ω - N c ω)) P' →
+          ∫ ω, (N b ω - N a ω) * (N d ω - N c ω) ∂P' = 0 := by
+      intro a b c d hab hbc hcd hprod
+      exact hN.integral_increment_mul_increment_eq_zero hab hbc hcd hprod
+    have _horthogonal_increments_used :
+        ∀ {a b c d : κ}, a ≤ b → b ≤ c → c ≤ d →
+          Integrable (fun ω => (N b ω - N a ω) * (N d ω - N c ω)) P' →
+          ∫ ω, (N b ω - N a ω) * (N d ω - N c ω) ∂P' = 0 :=
+      horthogonal_increments
+    -- Remaining work: predictable-jump removal, bounded localization, deterministic
+    -- partition construction, martingale increment orthogonality, and dominated convergence.
+    sorry
+
+/-- Bounded continuous finite-variation martingale bridge on a fixed deterministic horizon.
+
+The deterministic square-increment estimates above close the finite-variation part of the
+blueprint argument.  The remaining stochastic work is to construct the bounded continuous
+localization, prove the martingale increment orthogonality identity along refining deterministic
+partitions, and pass to the limit. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_predictable_finiteVariation_bounded_continuous
+      {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+      [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [PolishSpace κ]
+      {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+      [IsFiniteMeasure P'] [Approximable 𝓕' P'] [𝓕'.IsComplete P'] [𝓕'.IsRightContinuous]
+      {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+      (hN_cadlag : ∀ ω, IsCadlag (N · ω)) (hN_zero : ∀ ω, N ⊥ ω = 0)
+      (hN_pred : IsStronglyPredictable 𝓕' N)
+      (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ) {t : κ}
+      (ht : (⊥ : κ) < t) :
+      N t =ᵐ[P'] 0 := by
+    exact hN.eq_zero_of_predictable_finiteVariation_bounded_continuous_reduction
+      hN_cadlag hN_zero hN_pred hN_var ht
+
+/-- Deep analytic value-zero bridge for predictable finite-variation martingales.
+
+This is the remaining jump-removal and bounded continuous finite-variation square-increment
+argument from the blueprint.  Once this fixed-time a.e. value-zero statement is available,
+`eq_zero_of_predictable_finiteVariation_past_condExp_zero` follows formally by applying
+conditional expectation to an a.e. zero random variable. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_predictable_finiteVariation_value_zero
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [PolishSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] [𝓕'.IsComplete P'] [𝓕'.IsRightContinuous]
+    {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_cadlag : ∀ ω, IsCadlag (N · ω)) (hN_zero : ∀ ω, N ⊥ ω = 0)
+    (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ) {t : κ}
+    (ht : (⊥ : κ) < t) :
+    N t =ᵐ[P'] 0 := by
+  have _hN_cadlag_used : ∀ ω, IsCadlag (N · ω) := hN_cadlag
+  have _hN_zero_used : ∀ ω, N ⊥ ω = 0 := hN_zero
+  have _hN_pred_used : IsStronglyPredictable 𝓕' N := hN_pred
+  have _hN_var_used : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ := hN_var
+  have _ht_used : (⊥ : κ) < t := ht
+  have hzero_of_past_measurable_increment :
+      ∀ {s : κ}, s ≤ t → StronglyMeasurable[𝓕' s] (N t - N s) →
+        N t - N s =ᵐ[P'] 0 := by
+    intro s hst hmeas
+    exact hN.eq_zero_of_predictable_finiteVariation_past_measurable_zero_increment hst hmeas
+  have _hzero_of_past_measurable_increment :
+      ∀ {s : κ}, s ≤ t → StronglyMeasurable[𝓕' s] (N t - N s) →
+        N t - N s =ᵐ[P'] 0 := hzero_of_past_measurable_increment
+  have hleftLim_exists :
+      ∀ ω, ∃ l, Tendsto (N · ω) (nhdsWithin t (Set.Iio t)) (nhds l) := fun ω =>
+    (hN_var ω).exists_tendsto_left_univ t
+  have _hleftLim_tendsto :
+      ∀ ω, Tendsto (N · ω) (nhdsWithin t (Set.Iio t))
+        (nhds (Function.leftLim (N · ω) t)) := fun ω =>
+      tendsto_leftLim_of_tendsto (hleftLim_exists ω)
+  -- The remaining work is the blueprint's jump-removal plus bounded continuous
+  -- finite-variation square-increment argument.
+  exact hN.eq_zero_of_predictable_finiteVariation_bounded_continuous
+    hN_cadlag hN_zero hN_pred hN_var ht
+
+/-- Remaining analytic bridge: the martingale value at `t` has zero conditional expectation
+against the sigma-algebra generated by all strictly earlier filtration levels.
+
+The closed helper above reduces the case where an increment is already measurable at an earlier
+filtration time to the martingale identity.  What remains here is the continuous-time limiting
+argument: use left limits to remove predictable jumps, then use finite variation plus martingale
+orthogonality along refining partitions to show the continuous part has zero square expectation. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_predictable_finiteVariation_past_condExp_zero
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [PolishSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] [𝓕'.IsComplete P'] [𝓕'.IsRightContinuous]
+    {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_cadlag : ∀ ω, IsCadlag (N · ω)) (hN_zero : ∀ ω, N ⊥ ω = 0)
+    (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ) {t : κ}
+    (ht : (⊥ : κ) < t) :
+    P'[N t | (⨆ s : {s : κ // s < t}, 𝓕' s)] =ᵐ[P'] 0 := by
+  exact MeasureTheory.condExp_ae_eq_zero_of_ae_eq_zero
+    (hN.eq_zero_of_predictable_finiteVariation_value_zero
+      hN_cadlag hN_zero hN_pred hN_var ht)
+
+/-- Analytic core of continuous-time predictable finite-variation martingale uniqueness after
+the deterministic-time predictable section has been transferred to the past sigma-algebra.
+
+The remaining proof is the jump-removal and continuous finite-variation square-increment
+argument from the blueprint. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_predictable_finiteVariation_noninitial_analytic
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [PolishSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] [𝓕'.IsComplete P'] [𝓕'.IsRightContinuous]
+    {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_cadlag : ∀ ω, IsCadlag (N · ω)) (hN_zero : ∀ ω, N ⊥ ω = 0)
+    (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ) {t : κ}
+    (ht : (⊥ : κ) < t)
+    (hN_t_past : StronglyMeasurable[(⨆ s : {s : κ // s < t}, 𝓕' s)] (N t)) :
+    N t =ᵐ[P'] 0 := by
+  exact hN.eq_zero_of_predictable_finiteVariation_past_measurable_value hN_t_past
+    (hN.eq_zero_of_predictable_finiteVariation_past_condExp_zero
+      hN_cadlag hN_zero hN_pred hN_var ht)
+
+/-- A strongly predictable càdlàg martingale with locally bounded-variation paths and zero
+initial value is zero at each non-initial deterministic time, almost surely.
+
+This is the remaining continuous-time analytic bridge in the predictable finite-variation
+uniqueness route: after the discrete predictable theorem has removed sampled predictable
+increments, the proof must eliminate predictable jumps and then use the continuous
+finite-variation square-increment argument from the blueprint. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_predictable_finiteVariation_noninitial
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [PolishSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] [𝓕'.IsComplete P'] [𝓕'.IsRightContinuous]
+    {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_cadlag : ∀ ω, IsCadlag (N · ω)) (hN_zero : ∀ ω, N ⊥ ω = 0)
+    (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ) {t : κ}
+    (ht : (⊥ : κ) < t) :
+    N t =ᵐ[P'] 0 := by
+  have hN_t_past :
+    StronglyMeasurable[(⨆ s : {s : κ // s < t}, 𝓕' s)] (N t) :=
+    hN_pred.stronglyMeasurable_past ht
+  exact hN.eq_zero_of_predictable_finiteVariation_noninitial_analytic
+    hN_cadlag hN_zero hN_pred hN_var ht hN_t_past
+
+/-- A discrete strongly predictable martingale with zero initial value is zero at each
+deterministic time, almost surely. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_predictable_finiteVariation_discrete
+    {Ω' : Type*} {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration ℕ mΩ'}
+    [IsFiniteMeasure P'] {N : ℕ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_zero : ∀ ω, N 0 ω = 0) (hN_pred : IsStronglyPredictable 𝓕' N) (n : ℕ) :
+    N n =ᵐ[P'] 0 := by
+  filter_upwards [hN.eq_zero_of_predictable' hN_pred n] with ω hω
+  simpa [hN_zero ω] using hω
+
+/-- A strongly predictable càdlàg martingale with locally bounded-variation paths and zero
+initial value is zero at each deterministic time, almost surely. -/
+lemma _root_.MeasureTheory.Martingale.eq_zero_of_predictable_finiteVariation
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [PolishSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] [𝓕'.IsComplete P'] [𝓕'.IsRightContinuous]
+    {N : κ → Ω' → ℝ} (hN : Martingale N 𝓕' P')
+    (hN_cadlag : ∀ ω, IsCadlag (N · ω)) (hN_zero : ∀ ω, N ⊥ ω = 0)
+    (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ) (t : κ) :
+    N t =ᵐ[P'] 0 := by
+  by_cases ht : t = ⊥
+  · filter_upwards with ω
+    simpa [ht] using hN_zero ω
+  · have hbot : (⊥ : κ) < t := lt_of_le_of_ne bot_le (by
+      intro h
+      exact ht h.symm)
+    exact hN.eq_zero_of_predictable_finiteVariation_noninitial hN_cadlag hN_zero hN_pred hN_var hbot
+
+/-- A strongly predictable càdlàg local martingale with locally bounded-variation paths and
+zero initial value is zero at each deterministic time, almost surely. -/
+lemma IsLocalMartingale.eq_zero_of_predictable_finiteVariation
+    {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+    [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [PolishSpace κ]
+    {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {𝓕' : Filtration κ mΩ'}
+    [IsFiniteMeasure P'] [Approximable 𝓕' P'] [𝓕'.IsComplete P'] [𝓕'.IsRightContinuous]
+    {N : κ → Ω' → ℝ} (hN : IsLocalMartingale N 𝓕' P')
+    (hN_cadlag : ∀ ω, IsCadlag (N · ω)) (hN_zero : ∀ ω, N ⊥ ω = 0)
+    (hN_pred : IsStronglyPredictable 𝓕' N)
+    (hN_var : ∀ ω, LocallyBoundedVariationOn (N · ω) Set.univ) (t : κ) :
+    N t =ᵐ[P'] 0 := by
+  have _hN_cadlag_used : ∀ ω, IsCadlag (N · ω) := hN_cadlag
+  let τ : ℕ → Ω' → WithTop κ := hN.localSeq
+  have hτ : IsLocalizingSequence 𝓕' τ P' := hN.isLocalizingSequence_localSeq
+  have hzero_stopped : ∀ n,
+      stoppedProcess (fun i ↦ {ω | ⊥ < τ n ω}.indicator (N i)) (τ n) t =ᵐ[P'] 0 := by
+    intro n
+    have hmart := (hN.stoppedProcess_localSeq n).1
+    have hcad := (hN.stoppedProcess_localSeq n).2
+    have hzero_bot :
+        ∀ ω, stoppedProcess (fun i ↦ {ω | ⊥ < τ n ω}.indicator (N i)) (τ n) ⊥ ω = 0 := by
+      intro ω
+      by_cases hω : ⊥ < τ n ω
+      · have hmem : ω ∈ {ω | ⊥ < τ n ω} := hω
+        rw [stoppedProcess_eq_of_le hω.le, Set.indicator_of_mem hmem]
+        exact hN_zero ω
+      · simp [stoppedProcess, hω]
+    have hpred :
+        IsStronglyPredictable 𝓕'
+          (stoppedProcess (fun i ↦ {ω | ⊥ < τ n ω}.indicator (N i)) (τ n)) :=
+      hN_pred.stoppedProcess_indicator (hτ.isStoppingTime n)
+    have hvar : ∀ ω,
+        LocallyBoundedVariationOn
+          ((stoppedProcess (fun i ↦ {ω | ⊥ < τ n ω}.indicator (N i)) (τ n)) · ω)
+          Set.univ := by
+      intro ω
+      exact locallyBoundedVariationOn_stoppedProcess_indicator hN_var ω
+    exact hmart.eq_zero_of_predictable_finiteVariation hcad hzero_bot hpred hvar t
+  have hall_zero : ∀ᵐ ω ∂P', ∀ n,
+      stoppedProcess (fun i ↦ {ω | ⊥ < τ n ω}.indicator (N i)) (τ n) t ω = 0 := by
+    exact ae_all_iff.2 hzero_stopped
+  filter_upwards [hτ.tendsto_top, hall_zero] with ω htop hzeros
+  simp only [tendsto_atTop_nhds] at htop
+  obtain ⟨n, hn⟩ := htop (Set.Ioi (t : WithTop κ)) (by simp) isOpen_Ioi
+  have htτ : (t : WithTop κ) < τ n ω := hn n le_rfl
+  have hbotτ : (⊥ : κ) < τ n ω :=
+    lt_of_le_of_lt (WithTop.coe_le_coe.2 bot_le) htτ
+  have hmem : ω ∈ {ω | ⊥ < τ n ω} := hbotτ
+  have hstop_eq :
+      stoppedProcess (fun i ↦ {ω | ⊥ < τ n ω}.indicator (N i)) (τ n) t ω = N t ω := by
+    rw [stoppedProcess_eq_of_le htτ.le, Set.indicator_of_mem hmem]
+  exact hstop_eq ▸ hzeros n
 
 namespace IsLocalSubmartingale
 
 theorem doob_meyer (hX : IsLocalSubmartingale X 𝓕 P) (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
     ∃ (M A : ι → Ω → ℝ), X = M + A ∧ IsLocalMartingale M 𝓕 P ∧ (∀ ω, IsCadlag (M · ω)) ∧
-      IsStronglyProgressive 𝓕 A ∧ (∀ ω, IsCadlag (A · ω)) ∧ (HasLocallyIntegrableSup A 𝓕 P)
-      ∧ (∀ ω, Monotone (A · ω)) := by
+      IsStronglyPredictable 𝓕 A ∧ IsStronglyProgressive 𝓕 A ∧
+      (∀ ω, IsCadlag (A · ω)) ∧ (HasLocallyIntegrableSup A 𝓕 P) ∧
+      (∀ ω, Monotone (A · ω)) := by
   sorry
 
 /-- The local martingale part of the Doob-Meyer decomposition of the local submartingale. -/
@@ -1269,28 +3770,214 @@ lemma isLocalMartingale_martingalePart
     IsLocalMartingale (hX.martingalePart X hX_cadlag) 𝓕 P :=
   (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.1
 
-lemma cadlag_martingalePart (hX : IsLocalSubmartingale X 𝓕 P) (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
+lemma cadlag_martingalePart (hX : IsLocalSubmartingale X 𝓕 P)
+    (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
     ∀ ω, IsCadlag (hX.martingalePart X hX_cadlag · ω) :=
   (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.1
+
+lemma isStronglyPredictable_predictablePart
+    (hX : IsLocalSubmartingale X 𝓕 P) (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
+    IsStronglyPredictable 𝓕 (hX.predictablePart X hX_cadlag) :=
+  (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.2.1
 
 lemma isStronglyProgressive_predictablePart
     (hX : IsLocalSubmartingale X 𝓕 P) (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
     IsStronglyProgressive 𝓕 (hX.predictablePart X hX_cadlag) :=
-  (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.2.1
-
-lemma cadlag_predictablePart (hX : IsLocalSubmartingale X 𝓕 P) (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
-    ∀ ω, IsCadlag (hX.predictablePart X hX_cadlag · ω) :=
   (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.2.2.1
+
+lemma cadlag_predictablePart (hX : IsLocalSubmartingale X 𝓕 P)
+    (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
+    ∀ ω, IsCadlag (hX.predictablePart X hX_cadlag · ω) :=
+  (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.2.2.2.1
 
 lemma hasLocallyIntegrableSup_predictablePart
     (hX : IsLocalSubmartingale X 𝓕 P) (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
     HasLocallyIntegrableSup (hX.predictablePart X hX_cadlag) 𝓕 P :=
-  (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.2.2.2.1
+  (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.2.2.2.2.1
 
 lemma monotone_predictablePart (hX : IsLocalSubmartingale X 𝓕 P)
     (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
     ∀ ω, Monotone (hX.predictablePart X hX_cadlag · ω) :=
-  (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.2.2.2.2
+  (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.2.2.2.2.2
+
+section Normalized
+
+variable {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
+  [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [PolishSpace κ]
+  {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {X' : κ → Ω' → ℝ}
+  {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] [Approximable 𝓕' P']
+  [𝓕'.IsComplete P'] [𝓕'.IsRightContinuous]
+
+/-- A normalized local Doob-Meyer decomposition whose predictable part starts from zero. -/
+theorem doob_meyer_normalized (hX : IsLocalSubmartingale X' 𝓕' P')
+    (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
+    ∃ (M A : κ → Ω' → ℝ), X' = M + A ∧ IsLocalMartingale M 𝓕' P' ∧
+      (∀ ω, IsCadlag (M · ω)) ∧ IsStronglyPredictable 𝓕' A ∧
+      IsStronglyProgressive 𝓕' A ∧ (∀ ω, IsCadlag (A · ω)) ∧
+      HasLocallyIntegrableSup A 𝓕' P' ∧ (∀ ω, Monotone (A · ω)) ∧
+      (∀ ω, A ⊥ ω = 0) := by
+  classical
+  rcases hX.doob_meyer hX_cadlag with
+    ⟨M, A, hXA, hM, hM_cadlag, hA_pred, hA_prog, hA_cadlag, hA_int, hA_mono⟩
+  let C : κ → Ω' → ℝ := fun _ ω => A ⊥ ω
+  have hC_pred : IsStronglyPredictable 𝓕' C := by
+    exact MeasureTheory.IsStronglyPredictable.const_fun (𝓕 := 𝓕')
+      (hA_prog.stronglyAdapted ⊥)
+  have hC_prog : IsStronglyProgressive 𝓕' C := by
+    intro i
+    exact ((hA_prog.stronglyAdapted ⊥).mono (𝓕'.mono bot_le)).comp_measurable measurable_snd
+  have hC_cadlag : ∀ ω, IsCadlag (C · ω) := by
+    intro ω
+    exact (continuous_const : Continuous fun _ : κ => A ⊥ ω).isCadlag
+  refine ⟨M + C, A - C, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
+  · ext t ω
+    rw [hXA]
+    simp only [Pi.add_apply, Pi.sub_apply, C]
+    ring
+  · -- Simultaneous localization makes the initial-value shift a local martingale.
+    exact hM.add_initial_of_hasLocallyIntegrableSup hA_prog hA_int
+  · intro ω
+    exact (hM_cadlag ω).add (hC_cadlag ω)
+  · simpa only [Pi.sub_apply] using hA_pred.sub hC_pred
+  · simpa only [Pi.sub_apply] using hA_prog.sub hC_prog
+  · intro ω
+    have hnegC : IsCadlag fun t : κ => (-1 : ℝ) • C t ω := (hC_cadlag ω).const_smul (-1)
+    have hadd : IsCadlag ((fun t : κ => A t ω) + fun t => (-1 : ℝ) • C t ω) :=
+      (hA_cadlag ω).add hnegC
+    simpa [sub_eq_add_neg, C] using hadd
+  · -- The locally integrable running supremum is stable under the normalization shift.
+    exact hA_int.sub_initial hA_prog
+  · intro ω i j hij
+    exact sub_le_sub_right (hA_mono ω hij) (A ⊥ ω)
+  · intro ω
+    simp [C]
+
+/-- The local martingale part of the Doob-Meyer decomposition of the local submartingale. -/
+noncomputable
+def normalizedMartingalePart (X : κ → Ω' → ℝ)
+    (hX : IsLocalSubmartingale X 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
+    κ → Ω' → ℝ :=
+  (hX.doob_meyer_normalized hX_cadlag).choose
+
+/-- The predictable part of the Doob-Meyer decomposition of the local submartingale. -/
+noncomputable
+def normalizedPredictablePart (X : κ → Ω' → ℝ)
+    (hX : IsLocalSubmartingale X 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
+    κ → Ω' → ℝ :=
+  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose
+
+lemma normalizedMartingalePart_add_normalizedPredictablePart
+    (hX : IsLocalSubmartingale X' 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
+    X' = hX.normalizedMartingalePart X' hX_cadlag
+      + hX.normalizedPredictablePart X' hX_cadlag :=
+  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose_spec.1
+
+lemma isLocalMartingale_normalizedMartingalePart
+    (hX : IsLocalSubmartingale X' 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
+    IsLocalMartingale (hX.normalizedMartingalePart X' hX_cadlag) 𝓕' P' :=
+  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose_spec.2.1
+
+lemma cadlag_normalizedMartingalePart
+    (hX : IsLocalSubmartingale X' 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
+    ∀ ω, IsCadlag (hX.normalizedMartingalePart X' hX_cadlag · ω) :=
+  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose_spec.2.2.1
+
+lemma isStronglyPredictable_normalizedPredictablePart
+    (hX : IsLocalSubmartingale X' 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
+    IsStronglyPredictable 𝓕' (hX.normalizedPredictablePart X' hX_cadlag) :=
+  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose_spec.2.2.2.1
+
+lemma isStronglyProgressive_normalizedPredictablePart
+    (hX : IsLocalSubmartingale X' 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
+    IsStronglyProgressive 𝓕' (hX.normalizedPredictablePart X' hX_cadlag) :=
+  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose_spec.2.2.2.2.1
+
+lemma cadlag_normalizedPredictablePart
+    (hX : IsLocalSubmartingale X' 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
+    ∀ ω, IsCadlag (hX.normalizedPredictablePart X' hX_cadlag · ω) :=
+  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose_spec.2.2.2.2.2.1
+
+lemma hasLocallyIntegrableSup_normalizedPredictablePart
+    (hX : IsLocalSubmartingale X' 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
+    HasLocallyIntegrableSup (hX.normalizedPredictablePart X' hX_cadlag) 𝓕' P' :=
+  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose_spec.2.2.2.2.2.2.1
+
+lemma monotone_normalizedPredictablePart (hX : IsLocalSubmartingale X' 𝓕' P')
+    (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
+    ∀ ω, Monotone (hX.normalizedPredictablePart X' hX_cadlag · ω) :=
+  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose_spec.2.2.2.2.2.2.2.1
+
+lemma normalizedPredictablePart_bot_eq_zero (hX : IsLocalSubmartingale X' 𝓕' P')
+    (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
+    ∀ ω, hX.normalizedPredictablePart X' hX_cadlag ⊥ ω = 0 :=
+  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose_spec.2.2.2.2.2.2.2.2
+
+/-- Any normalized Doob-Meyer decomposition has the same predictable part as the choice-based
+normalized decomposition, at each deterministic time and almost surely. -/
+lemma normalizedPredictablePart_eq_of_normalized_decomposition
+    (hX : IsLocalSubmartingale X' 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X' · ω))
+    {M A : κ → Ω' → ℝ} (hXA : X' = M + A)
+    (hM : IsLocalMartingale M 𝓕' P') (hM_cadlag : ∀ ω, IsCadlag (M · ω))
+    (hA_pred : IsStronglyPredictable 𝓕' A) (hA_prog : IsStronglyProgressive 𝓕' A)
+    (hA_cadlag : ∀ ω, IsCadlag (A · ω))
+    (hA_int : HasLocallyIntegrableSup A 𝓕' P') (hA_mono : ∀ ω, Monotone (A · ω))
+    (hA_zero : ∀ ω, A ⊥ ω = 0) (t : κ) :
+    hX.normalizedPredictablePart X' hX_cadlag t =ᵐ[P'] A t := by
+  let M0 : κ → Ω' → ℝ := hX.normalizedMartingalePart X' hX_cadlag
+  let A0 : κ → Ω' → ℝ := hX.normalizedPredictablePart X' hX_cadlag
+  have _hM_cadlag_used := hM_cadlag
+  have _hA_prog_used := hA_prog
+  have _hA_int_used := hA_int
+  have hchosen : X' = M0 + A0 := by
+    simpa [M0, A0] using hX.normalizedMartingalePart_add_normalizedPredictablePart
+      hX_cadlag
+  have hA0_eq : A0 - A = M - M0 := by
+    ext s ω
+    have hsum := congr_fun (congr_fun (hchosen.symm.trans hXA) s) ω
+    simp only [Pi.add_apply] at hsum
+    simp only [Pi.sub_apply]
+    linarith
+  have hN_mart : IsLocalMartingale (A0 - A) 𝓕' P' := by
+    rw [hA0_eq]
+    have hM0 : IsLocalMartingale M0 𝓕' P' := by
+      simpa [M0] using hX.isLocalMartingale_normalizedMartingalePart hX_cadlag
+    exact hM.sub hM0
+  have hN_cadlag : ∀ ω, IsCadlag ((A0 - A) · ω) := by
+    intro ω
+    have hA0_cad : IsCadlag (A0 · ω) := by
+      simpa [A0] using hX.cadlag_normalizedPredictablePart hX_cadlag ω
+    have hneg : IsCadlag (fun s : κ => (-1 : ℝ) • A s ω) :=
+      (hA_cadlag ω).const_smul (-1)
+    have hadd :
+        IsCadlag ((fun s : κ => A0 s ω) + fun s => (-1 : ℝ) • A s ω) :=
+      hA0_cad.add hneg
+    simpa [Pi.sub_apply, sub_eq_add_neg] using hadd
+  have hN_zero : ∀ ω, (A0 - A) ⊥ ω = 0 := by
+    intro ω
+    simp [A0, hX.normalizedPredictablePart_bot_eq_zero hX_cadlag ω, hA_zero ω]
+  have hN_pred : IsStronglyPredictable 𝓕' (A0 - A) := by
+    have hA0_pred : IsStronglyPredictable 𝓕' A0 := by
+      simpa [A0] using hX.isStronglyPredictable_normalizedPredictablePart hX_cadlag
+    exact hA0_pred.sub hA_pred
+  have hN_var : ∀ ω, LocallyBoundedVariationOn ((A0 - A) · ω) Set.univ := by
+    intro ω
+    have hA0_mono : Monotone (A0 · ω) := by
+      simpa [A0] using hX.monotone_normalizedPredictablePart hX_cadlag ω
+    have hA0_monoOn : MonotoneOn (A0 · ω) Set.univ :=
+      fun _ _ _ _ hst => hA0_mono hst
+    have hA_monoOn : MonotoneOn (A · ω) Set.univ :=
+      fun _ _ _ _ hst => hA_mono ω hst
+    exact hA0_monoOn.locallyBoundedVariationOn.sub
+      hA_monoOn.locallyBoundedVariationOn
+  have hzero :=
+    hN_mart.eq_zero_of_predictable_finiteVariation hN_cadlag hN_zero hN_pred hN_var t
+  filter_upwards [hzero] with ω hω
+  have hdiff : A0 t ω - A t ω = 0 := by
+    simpa [A0, Pi.sub_apply] using hω
+  change A0 t ω = A t ω
+  linarith
+
+end Normalized
 
 end IsLocalSubmartingale
 

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -6,10 +6,15 @@ Authors: Rémy Degenne
 module
 
 public import BrownianMotion.StochasticIntegral.ClassD
+public import BrownianMotion.StochasticIntegral.Komlos
+public import BrownianMotion.StochasticIntegral.Predictable
 public import Mathlib.MeasureTheory.Integral.DominatedConvergence
 public import Mathlib.MeasureTheory.PiSystem
 public import Mathlib.Topology.EMetricSpace.BoundedVariation
 public import Mathlib.Topology.Order.DenselyOrdered
+public import Mathlib.Topology.Order.LiminfLimsup
+
+import Mathlib.Order.CompleteLattice.Group
 
 /-! # Doob-Meyer decomposition theorem
 
@@ -17,8 +22,8 @@ public import Mathlib.Topology.Order.DenselyOrdered
 
 @[expose] public section
 
-open MeasureTheory Filter TopologicalSpace
-open scoped ENNReal Uniformity
+open MeasureTheory Filter Order ProbabilityTheory Convexity TopologicalSpace
+open scoped NNReal ENNReal Topology Uniformity
 
 namespace ProbabilityTheory
 
@@ -3737,13 +3742,1231 @@ lemma IsLocalMartingale.eq_zero_of_predictable_finiteVariation
     rw [stoppedProcess_eq_of_le htτ.le, Set.indicator_of_mem hmem]
   exact hstop_eq ▸ hzeros n
 
+end ProbabilityTheory
+
+
+section DenseMesh
+
+/-- The fixed countable dense set used instead of dyadics, with both endpoints adjoined. -/
+noncomputable def denseSet (ι : Type*) [LE ι] [OrderBot ι] [OrderTop ι]
+    [TopologicalSpace ι] [SecondCountableTopology ι] : Set ι :=
+  (TopologicalSpace.exists_countable_dense ι).choose ∪ ({⊥, ⊤} : Set ι)
+
+lemma denseSet_countable (ι : Type*) [LE ι] [OrderBot ι] [OrderTop ι]
+    [TopologicalSpace ι] [SecondCountableTopology ι] : (denseSet ι).Countable := by
+  have h_dense_countable := (TopologicalSpace.exists_countable_dense ι).choose_spec.1
+  simpa [denseSet] using h_dense_countable.union (by simp : ({⊥, ⊤} : Set ι).Countable)
+
+lemma denseSet_dense (ι : Type*) [LE ι] [OrderBot ι] [OrderTop ι]
+    [TopologicalSpace ι] [SecondCountableTopology ι] : Dense (denseSet ι) :=
+  (TopologicalSpace.exists_countable_dense ι).choose_spec.2.mono (Set.subset_union_left)
+
+/-- A choice of enumeration of the countable dense set used to construct finite meshes. -/
+noncomputable def denseEnum (ι : Type*) [LE ι] [OrderBot ι] [OrderTop ι]
+    [TopologicalSpace ι] [SecondCountableTopology ι] : ℕ → ι :=
+  have : Nonempty (denseSet ι) := ⟨⟨⊥, by simp [denseSet]⟩⟩
+  Subtype.val ∘ (countable_iff_exists_surjective.mp (denseSet_countable ι)).choose
+
+/-- The `n`-th finite mesh: the first `n` points of the dense enumeration, plus endpoints. -/
+noncomputable def mesh (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : Finset ι :=
+  insert ⊥ <| insert ⊤ <| (Finset.range n).image (denseEnum ι)
+
+lemma bot_mem_mesh (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : (⊥ : ι) ∈ mesh ι n := by simp [mesh]
+
+lemma top_mem_mesh (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : (⊤ : ι) ∈ mesh ι n := by simp [mesh]
+
+instance (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : OrderBot (mesh ι n) where
+  bot := ⟨⊥, bot_mem_mesh ι n⟩
+  bot_le _ := bot_le
+
+instance (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : OrderTop (mesh ι n) where
+  top := ⟨⊤, top_mem_mesh ι n⟩
+  le_top _ := le_top
+
+@[simp]
+lemma top_eq_top (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : (⊤ : mesh ι n) = (⊤ : ι) := by rfl
+
+@[simp]
+lemma bot_eq_bot (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : (⊥ : mesh ι n) = (⊥ : ι) := by rfl
+
+noncomputable instance (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : LocallyFiniteOrder (mesh ι n) :=
+  Fintype.toLocallyFiniteOrder
+
+noncomputable instance (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : SuccOrder (mesh ι n) :=
+  LinearLocallyFiniteOrder.succOrder (mesh ι n)
+
+noncomputable instance (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : PredOrder (mesh ι n) :=
+  LinearLocallyFiniteOrder.predOrder (mesh ι n)
+
+noncomputable instance (ι : Type*) [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    [TopologicalSpace ι] [SecondCountableTopology ι] (n : ℕ) : CompleteLinearOrder (mesh ι n) :=
+  Fintype.toCompleteLinearOrder (mesh ι n)
+
+end DenseMesh
+
+section Estimate
+
+/-- The filtration obtained by restricting `𝓕` to a finite dense mesh. -/
+def meshFiltration {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι] [LinearOrder ι]
+    [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (𝓕 : Filtration ι mΩ) (n : ℕ) :
+    Filtration (mesh ι n) mΩ :=
+  𝓕.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
+
+instance sigmaFiniteFiltration_meshFiltration {ι Ω : Type*} [TopologicalSpace ι]
+    [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} {𝓕 : Filtration ι mΩ} [SigmaFiniteFiltration P 𝓕]
+    (n : ℕ) : SigmaFiniteFiltration P (meshFiltration 𝓕 n) := by
+  unfold meshFiltration
+  infer_instance
+
+/-- Predictable part of a discrete process. -/
+noncomputable def predictablePart {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
+    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) :
+    ι → Ω → E :=
+  fun n ↦ ∑ i ∈ Finset.Iio n, P[S (succ i) - S i | 𝓕 i]
+
+/-- The predictable part is additive for integrable processes. -/
+lemma predictablePart_add {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
+    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [CompleteSpace E] {P : Measure Ω} {S₁ S₂ : ι → Ω → E} (𝓕 : Filtration ι mΩ)
+    (hS₁ : ∀ t, Integrable (S₁ t) P) (hS₂ : ∀ t, Integrable (S₂ t) P) (t : ι) :
+    predictablePart (S₁ + S₂) 𝓕 P t =ᵐ[P] predictablePart S₁ 𝓕 P t + predictablePart S₂ 𝓕 P t := by
+  simp only [_root_.predictablePart, ← Finset.sum_add_distrib]
+  refine eventuallyEq_sum fun i _ => ?_
+  rw [show (S₁ + S₂) (succ i) - (S₁ + S₂) i =
+    (S₁ (succ i) - S₁ i) + (S₂ (succ i) - S₂ i) by simp; abel]
+  exact condExp_add ((hS₁ (succ i)).sub (hS₁ i)) ((hS₂ (succ i)).sub (hS₂ i)) (𝓕 i)
+
+/-- The predictable part of a martingale is zero at every time. -/
+lemma predictablePart_eq_zero_of_martingale {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
+    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [CompleteSpace E] {P : Measure Ω} {S : ι → Ω → E} {𝓕 : Filtration ι mΩ} (hS : Martingale S 𝓕 P)
+    (t : ι) :
+    predictablePart S 𝓕 P t =ᵐ[P] 0 := by
+  rw [_root_.predictablePart, ← Finset.sum_const_zero]
+  refine eventuallyEq_sum fun i _ => ?_
+  grw [condExp_sub (hS.integrable (succ i)) (hS.integrable i) (𝓕 i),
+    (hS.condExp_ae_eq (le_succ i)).sub (hS.condExp_ae_eq le_rfl), sub_self]
+
+@[simp]
+lemma predictablePart_bot {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrder ι] [OrderBot ι]
+    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [CompleteSpace E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) :
+    predictablePart S 𝓕 P ⊥ = 0 := by
+  simp [_root_.predictablePart]
+
+/-- The predictable part at a fixed point of a discrete mesh is integrable. -/
+lemma integrable_predictablePart {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
+    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [CompleteSpace E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω)
+    (t : ι) :
+    Integrable (predictablePart S 𝓕 P t) P := by
+  simp only [_root_.predictablePart]
+  exact integrable_finsetSum' (Finset.Iio t) fun _ _ => integrable_condExp
+
+/-- For a submartingale indexed by a countable type, the predictable part is monotone a.e. -/
+lemma MeasureTheory.Submartingale.monotone_predictablePart_ae {ι Ω E : Type*} [LinearOrder ι]
+    [LocallyFiniteOrderBot ι] [SuccOrder ι] [Countable ι] {mΩ : MeasurableSpace Ω} {P : Measure Ω}
+    [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E] [PartialOrder E]
+    [IsOrderedAddMonoid E] {S : ι → Ω → E} {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P) :
+    ∀ᵐ ω ∂P, Monotone (_root_.predictablePart S 𝓕 P · ω) := by
+  have hnonneg : ∀ᵐ ω ∂P, ∀ i : ι, 0 ≤ P[S (succ i) - S i | 𝓕 i] ω :=
+    ae_all_iff.2 fun i ↦ hs.condExp_sub_nonneg (le_succ i)
+  filter_upwards [hnonneg] with ω hω a b hab
+  simp only [_root_.predictablePart, Finset.sum_apply]
+  exact Finset.sum_le_sum_of_subset_of_nonneg (Finset.Iio_subset_Iio hab) fun i _ _ ↦ hω i
+
+/-- For a submartingale indexed by a countable type, the predictable part is nonnegative a.e. -/
+lemma MeasureTheory.Submartingale.predictablePart_nonneg' {ι Ω E : Type*} [LinearOrder ι]
+    [LocallyFiniteOrder ι] [OrderBot ι] [SuccOrder ι] [Countable ι] {mΩ : MeasurableSpace Ω}
+    {P : Measure Ω} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E] [PartialOrder E]
+    [IsOrderedAddMonoid E] {S : ι → Ω → E} {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P) :
+    ∀ᵐ ω ∂P, ∀ n, 0 ≤ _root_.predictablePart S 𝓕 P n ω := by
+  filter_upwards [hs.monotone_predictablePart_ae] with ω hω n
+  simpa [predictablePart_bot] using hω bot_le
+
+/-- Martingale part of a discrete process. -/
+noncomputable def martingalePart {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
+    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) :
+    ι → Ω → E :=
+  S - predictablePart S 𝓕 P
+
+/-- The martingale part is additive for integrable processes. -/
+lemma martingalePart_add {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
+    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [CompleteSpace E] {P : Measure Ω} {S₁ S₂ : ι → Ω → E} {𝓕 : Filtration ι mΩ}
+    (hS₁ : ∀ t, Integrable (S₁ t) P) (hS₂ : ∀ t, Integrable (S₂ t) P) (t : ι) :
+    martingalePart (S₁ + S₂) 𝓕 P t =ᵐ[P] martingalePart S₁ 𝓕 P t + martingalePart S₂ 𝓕 P t := by
+  filter_upwards [predictablePart_add 𝓕 hS₁ hS₂ t] with ω hω
+  simp [_root_.martingalePart, hω]
+  abel
+
+/-- The martingale part of a martingale is the martingale itself. -/
+lemma martingalePart_eq_self_of_martingale {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
+    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [CompleteSpace E] {P : Measure Ω} {S : ι → Ω → E} {𝓕 : Filtration ι mΩ}
+    (hS : Martingale S 𝓕 P) (t : ι) :
+    martingalePart S 𝓕 P t =ᵐ[P] S t := by
+  filter_upwards [predictablePart_eq_zero_of_martingale hS t] with ω hω
+  simp [_root_.martingalePart, hω]
+
+/-- The martingale part of a process is a martingale. -/
+lemma martingale_martingalePart {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
+    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [CompleteSpace E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) :
+    Martingale (martingalePart S 𝓕 P) 𝓕 P := by
+  sorry
+
+@[simp]
+lemma martingalePart_add_predictablePart {ι Ω E : Type*} [Preorder ι] [LocallyFiniteOrderBot ι]
+    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [CompleteSpace E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) :
+    martingalePart S 𝓕 P + predictablePart S 𝓕 P = S := by
+  simp [_root_.martingalePart]
+
+/-- Sequence of terminal values of the predictable part. -/
+noncomputable def predictableSeqTop {ι Ω E : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
+    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E]
+    [NormedSpace ℝ E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω)
+    (n : ℕ) : Ω → E :=
+  predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P ⊤
+
+/-- The terminal values of the predictable parts on each mesh are integrable. -/
+lemma integrable_predictableSeqTop {ι Ω E : Type*} [TopologicalSpace ι]
+    [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+    (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) :
+    Integrable (predictableSeqTop S 𝓕 P n) P :=
+  integrable_predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P ⊤
+
+/-- The terminal values of the predictable parts of a martingale vanish on every mesh. -/
+lemma predictableSeqTop_eq_zero_of_martingale {ι Ω E : Type*} [TopologicalSpace ι]
+    [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+    {P : Measure Ω} {S : ι → Ω → E} {𝓕 : Filtration ι mΩ} (hS : Martingale S 𝓕 P)
+    (n : ℕ) :
+    predictableSeqTop S 𝓕 P n =ᵐ[P] 0 := by
+  simp only [predictableSeqTop, meshFiltration]
+  apply predictablePart_eq_zero_of_martingale _ ⊤
+  exact (hS.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n))))
+
+/-- Sequence of terminal values of the martingale part. -/
+noncomputable def martingaleSeqTop {ι Ω E : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
+    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E]
+    [NormedSpace ℝ E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) : Ω → E :=
+  martingalePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P ⊤
+
+/-- The terminal values of the discrete martingale parts are additive. -/
+lemma martingaleSeqTop_add {ι Ω E : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
+    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
+    [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E] {P : Measure Ω}
+    {S₁ S₂ : ι → Ω → E} (𝓕 : Filtration ι mΩ) (hS₁ : ∀ t, Integrable (S₁ t) P)
+    (hS₂ : ∀ t, Integrable (S₂ t) P) (n : ℕ) :
+    martingaleSeqTop (S₁ + S₂) 𝓕 P n =ᵐ[P]
+      martingaleSeqTop S₁ 𝓕 P n + martingaleSeqTop S₂ 𝓕 P n := by
+  simpa [martingaleSeqTop] using martingalePart_add (fun t : mesh ι n ↦ hS₁ t) (fun t ↦ hS₂ t) ⊤
+
+/-- The terminal values of the martingale parts of a martingale are its terminal value on every
+mesh. -/
+lemma martingaleSeqTop_eq_self_of_martingale {ι Ω E : Type*} [TopologicalSpace ι]
+    [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E]
+    {P : Measure Ω} {S : ι → Ω → E} {𝓕 : Filtration ι mΩ} (hS : Martingale S 𝓕 P)
+    (n : ℕ) :
+    martingaleSeqTop S 𝓕 P n =ᵐ[P] S ⊤ := by
+  simp only [martingaleSeqTop, meshFiltration]
+  apply martingalePart_eq_self_of_martingale _ ⊤
+  exact (hS.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n))))
+
+/-- If `S = 0` a.e., then the martingale part’s terminal value equals the negative of the
+predictable part’s terminal value. -/
+lemma martingaleSeqTop_eq_neg_predictableSeqTop {ι Ω E : Type*} [TopologicalSpace ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [CompleteSpace E] {S : ι → Ω → E} (𝓕 : Filtration ι mΩ) (hstop : S ⊤ =ᶠ[ae P] 0)
+    (n : ℕ) :
+    martingaleSeqTop S 𝓕 P n =ᶠ[ae P] -predictableSeqTop S 𝓕 P n := by
+  simp only [martingaleSeqTop, _root_.martingalePart, Pi.sub_apply, Function.comp_apply, top_eq_top,
+    predictableSeqTop]
+  grw [neg_eq_zero_sub, hstop]
+
+/-- Apply the optional stopping theorem to get equation 4. Note that `T1 Space` is needed to make
+sure that `mesh ι n` has order topology. -/
+lemma equation4 {ι Ω E : Type*} [TopologicalSpace ι] [T1Space ι] [SecondCountableTopology ι]
+    [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
+    {P : Measure Ω} [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E] {S : ι → Ω → E}
+    {𝓕 : Filtration ι mΩ} {n : ℕ} [SigmaFiniteFiltration P 𝓕] (hstop : S ⊤ =ᶠ[ae P] 0)
+    {τ : Ω → WithTop (mesh ι n)} (hτ : ∀ ω, τ ω ≤ WithTop.some (⊤ : mesh ι n))
+    (hτs : IsStoppingTime (meshFiltration 𝓕 n) τ) :
+    stoppedValue (S ∘ Subtype.val) τ =ᵐ[P]
+      -P[(predictableSeqTop S 𝓕 P n) | hτs.measurableSpace] +
+        stoppedValue (predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P) τ := by
+  grw [← condExp_neg, ← martingaleSeqTop_eq_neg_predictableSeqTop 𝓕 hstop]
+  simp only [martingaleSeqTop]
+  grw [← (martingale_martingalePart (S ∘ Subtype.val)
+    (meshFiltration 𝓕 n) P).stoppedValue_ae_eq_condExp_of_le_const hτs hτ,
+    ← stoppedValue.add, _root_.martingalePart_add_predictablePart]
+
+section equation5
+
+/-- The mesh stopping time `τₙ(c)` associated with the predictable part on the `n`-th mesh. -/
+noncomputable def tauMesh {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
+    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ)
+    (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) (c : ℝ) :
+    Ω → WithTop (mesh ι n) :=
+  fun ω ↦ (((hittingBtwn (fun (t : mesh ι n) ω ↦
+    (predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P) (succ t) ω) (Set.Ioi c)
+    ⊥ ⊤ ω) : mesh ι n) : WithTop (mesh ι n))
+
+lemma tauMesh_le_top {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
+    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ)
+    (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) (c : ℝ) (ω : Ω) :
+    tauMesh S 𝓕 P n c ω ≤ (⊤ : mesh ι n) :=
+  WithTop.coe_le_coe.2 (hittingBtwn_le ω)
+
+/-- The stopped valued of the predictable part with respect to `τₙ(c)` is less than or equal to
+`c`. -/
+lemma stoppedValue_predictablePart_tauMesh_le {ι Ω : Type*} [TopologicalSpace ι]
+    [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
+    (S : ι → Ω → ℝ) (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) {c : ℝ} (hc : 0 ≤ c) :
+    stoppedValue (predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P)
+      (tauMesh S 𝓕 P n c) ≤ fun _ ↦ c := by
+  intro ω
+  let A := predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P
+  let τ := hittingBtwn (fun t ω ↦ A (succ t) ω) (Set.Ioi c) ⊥ ⊤ ω
+  change A τ ω ≤ c
+  by_cases hτ_bot : τ = ⊥
+  · simpa [A, hτ_bot] using hc
+  · have hpred_lt : pred τ < τ := (pred_lt_iff_ne_bot).2 hτ_bot
+    have hnot_min : ¬ IsMin τ := by simpa [isMin_iff_eq_bot] using hτ_bot
+    simpa [succ_pred_of_not_isMin hnot_min] using notMem_of_lt_hittingBtwn hpred_lt bot_le
+
+/-- The predictable part is predictable. -/
+lemma isPredictable_predictablePart {ι Ω E : Type*} [LinearOrder ι] [LocallyFiniteOrder ι]
+    [OrderBot ι] [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [CompleteSpace E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) :
+    IsStronglyPredictable 𝓕 (predictablePart S 𝓕 P) := by
+  sorry
+
+/-- At time `t`, the predictable part is strongly measurable with respect to the previous
+σ-algebra. -/
+lemma stronglyMeasurable_pred_predictablePart {ι Ω E : Type*} [LinearOrder ι]
+    [LocallyFiniteOrderBot ι] [PredOrder ι] [SuccOrder ι] {mΩ : MeasurableSpace Ω}
+    [NormedAddCommGroup E] [NormedSpace ℝ E] [CompleteSpace E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ)
+    (P : Measure Ω) (t : ι) :
+    StronglyMeasurable[𝓕 (pred t)] (predictablePart S 𝓕 P t) :=
+  Finset.stronglyMeasurable_sum _ fun _ hi =>
+    stronglyMeasurable_condExp.mono (𝓕.mono (le_pred_of_lt (Finset.mem_Iio.1 hi)))
+
+/-- At time `t`, the predictable part is strongly measurable with respect to the previous
+σ-algebra. -/
+lemma stronglyMeasurable_predictablePart {ι Ω E : Type*} [LinearOrder ι] [LocallyFiniteOrderBot ι]
+    [PredOrder ι] [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E]
+    [NormedSpace ℝ E] [CompleteSpace E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ)
+    (P : Measure Ω) (t : ι) :
+    StronglyMeasurable[𝓕 t] (predictablePart S 𝓕 P t) :=
+  (stronglyMeasurable_pred_predictablePart S 𝓕 P t).mono (𝓕.mono (pred_le _))
+
+/-- The predictable part of a process is strongly adapted. -/
+lemma stronglyAdapted_predictablePart {ι Ω E : Type*} [LinearOrder ι] [LocallyFiniteOrderBot ι]
+    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [CompleteSpace E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) :
+    StronglyAdapted 𝓕 (predictablePart S 𝓕 P) :=
+  fun _ => Finset.stronglyMeasurable_sum _ fun _ hi =>
+    stronglyMeasurable_condExp.mono (𝓕.mono (Finset.mem_Iio.1 hi).le)
+
+/-- The predictable part of a process is strongly adapted. -/
+lemma stronglyAdapted_predictablePart' {ι Ω E : Type*} [LinearOrder ι] [LocallyFiniteOrderBot ι]
+    [SuccOrder ι] {mΩ : MeasurableSpace Ω} [NormedAddCommGroup E] [NormedSpace ℝ E]
+    [CompleteSpace E] (S : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) :
+    StronglyAdapted 𝓕 (fun t ω ↦ predictablePart S 𝓕 P (succ t) ω) :=
+  fun _ => Finset.stronglyMeasurable_sum _ fun _ hi ↦
+    stronglyMeasurable_condExp.mono (𝓕.mono (le_of_lt_succ (Finset.mem_Iio.1 hi)))
+
+/-- `τₙ(c)` is indeed a stopping time. -/
+lemma isStoppingTime_tauMesh {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
+    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ)
+    (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) (c : ℝ) :
+    IsStoppingTime (meshFiltration 𝓕 n) (tauMesh S 𝓕 P n c) :=
+  (stronglyAdapted_predictablePart'
+    (S ∘ Subtype.val) (meshFiltration 𝓕 n) P).adapted.isStoppingTime_hittingBtwn measurableSet_Ioi
+
+/-- Combine equation 4 and `stoppedValue_predictablePart_tauMesh_le` to get this inequality. -/
+lemma stoppedValue_le_neg_condExp_predictableSeqTop_add_const {ι Ω : Type*} [TopologicalSpace ι]
+    [T1Space ι] [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι]
+    [OrderTop ι] {mΩ : MeasurableSpace Ω} {P : Measure Ω} {S : ι → Ω → ℝ} (hstop : S ⊤ =ᶠ[ae P] 0)
+    (𝓕 : Filtration ι mΩ) (n : ℕ) [SigmaFiniteFiltration P 𝓕] {c : ℝ} (hc : 0 ≤ c) :
+    stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n c) ≤ᵐ[P]
+      -P[predictableSeqTop S 𝓕 P n | (isStoppingTime_tauMesh S 𝓕 P n c).measurableSpace] +
+      (fun _ => c) := by
+  filter_upwards [equation4 hstop (tauMesh_le_top S 𝓕 P n c) (isStoppingTime_tauMesh S 𝓕 P n c)]
+    with ω heqω
+  rw [heqω]
+  exact add_le_add_right (stoppedValue_predictablePart_tauMesh_le S 𝓕 P n hc ω) _
+
+/-- `{τₙ(c) < 1} = {c < Aⁿ₁}`. -/
+lemma MeasureTheory.Submartingale.tauMesh_lt_top_eq_lt_predictableSeqTop {ι Ω : Type*}
+    [TopologicalSpace ι] [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} {S : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ}
+    (hs : Submartingale S 𝓕 P) (n : ℕ) {c : ℝ} (hc : 0 ≤ c) :
+    {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)} =ᵐ[P] {ω | c < predictableSeqTop S 𝓕 P n ω} := by
+  refine eventuallyEq_set.2 ?_
+  have hs_mesh : Submartingale (S ∘ Subtype.val) (meshFiltration 𝓕 n) P :=
+    hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
+  filter_upwards [hs_mesh.monotone_predictablePart_ae] with ω hmono
+  let A : mesh ι n → Ω → ℝ := _root_.predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P
+  by_cases htop_bot : (⊤ : mesh ι n) = ⊥
+  · simp [tauMesh, predictableSeqTop, htop_bot, hc]
+  · refine ⟨fun hω => ?_, fun htop_gt => ?_⟩
+    · simp_all only [tauMesh, WithTop.coe_lt_coe, Std.le_refl, hittingBtwn_lt_iff, Set.Ico_bot,
+        Set.mem_Iio, Set.mem_Ioi, predictableSeqTop]
+      obtain ⟨j, _, hj⟩ := hω
+      exact lt_of_lt_of_le hj (hmono le_top)
+    · have hnot_min : ¬ IsMin (⊤ : mesh ι n) := by simpa [isMin_iff_eq_bot] using htop_bot
+      have hmem : A (succ (pred ⊤)) ω ∈ Set.Ioi c := by
+        simpa [A, succ_pred_of_not_isMin hnot_min, predictableSeqTop] using htop_gt
+      have hhit : hittingBtwn (fun (t : mesh ι n) ω ↦ A (succ t) ω) (Set.Ioi c) ⊥ ⊤ ω < ⊤ := by
+        rw [hittingBtwn_lt_iff ⊤ le_rfl]
+        exact ⟨pred ⊤, ⟨bot_le, (pred_lt_iff_ne_bot).2 htop_bot⟩, hmem⟩
+      simpa [tauMesh, A] using hhit
+
+/-- The constant `c` is integrable on the event where `τₙ(c)` hits before the top element. -/
+lemma MeasureTheory.Submartingale.integrableOn_const_tauMesh_lt_top {ι Ω : Type*}
+    [TopologicalSpace ι] [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} {S : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ}
+    (hs : Submartingale S 𝓕 P) (n : ℕ) {c : ℝ} (hc : 0 ≤ c) :
+    IntegrableOn (fun _ : Ω => c) {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)} P := by
+  by_cases! hc0 : c = 0
+  · simp [hc0]
+  · refine integrableOn_const (LT.lt.ne ?_)
+    rw [measure_congr (hs.tauMesh_lt_top_eq_lt_predictableSeqTop n hc)]
+    exact (integrable_predictableSeqTop S 𝓕 P n).measure_gt_lt_top (lt_of_le_of_ne hc hc0.symm)
+
+/-- Stopping `S` at the bounded mesh time `τₙ(c)` preserves integrability. -/
+lemma MeasureTheory.Submartingale.integrable_stoppedValue_tauMesh {ι Ω : Type*} [TopologicalSpace ι]
+    [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
+    {P : Measure Ω} {S : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P) (n : ℕ)
+    (c : ℝ) :
+    Integrable (stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n c)) P :=
+  integrable_stoppedValue (mesh ι n) (isStoppingTime_tauMesh S 𝓕 P n c)
+    (hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))).integrable
+    (tauMesh_le_top S 𝓕 P n c)
+
+/-- The first estimate before equation 5. -/
+lemma first_estimate {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι] [SecondCountableTopology ι]
+    [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
+    {P : Measure Ω} {S : ι → Ω → ℝ} (hstop : S ⊤ =ᶠ[ae P] 0) (𝓕 : Filtration ι mΩ) (n : ℕ)
+    [SigmaFiniteFiltration P 𝓕] {c : ℝ} (hc : 0 ≤ c) (hs : Submartingale S 𝓕 P) :
+    ∫ ω in {ω | c < predictableSeqTop S 𝓕 P n ω}, predictableSeqTop S 𝓕 P n ω ∂P ≤
+      c * P.real {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)} -
+        ∫ ω in {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)},
+          stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n c) ω ∂P :=
+  calc
+    _ = ∫ ω in {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)},
+          P[predictableSeqTop S 𝓕 P n |
+            (isStoppingTime_tauMesh S 𝓕 P n c).measurableSpace] ω ∂P := by
+      rw [setIntegral_condExp,
+        setIntegral_congr_set (hs.tauMesh_lt_top_eq_lt_predictableSeqTop n hc)]
+      · exact integrable_predictableSeqTop S 𝓕 P n
+      · exact (isStoppingTime_tauMesh S 𝓕 P n c).measurableSet_lt' ⊤
+    _ ≤ ∫ ω in {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)},
+        (c - stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n c) ω) ∂P := by
+      refine setIntegral_mono_ae integrable_condExp.integrableOn
+        ((hs.integrableOn_const_tauMesh_lt_top n hc).sub
+          (hs.integrable_stoppedValue_tauMesh n c).integrableOn) ?_
+      filter_upwards [stoppedValue_le_neg_condExp_predictableSeqTop_add_const hstop 𝓕 n hc]
+        with ω hω
+      simp at hω
+      linarith [hω]
+    _ = _ := by
+      rw [integral_sub (hs.integrableOn_const_tauMesh_lt_top n hc)
+        (hs.integrable_stoppedValue_tauMesh n c).integrableOn, setIntegral_const]
+      ring
+
+/-- If `a ≤ b`, then `{τₙ(b) < 1} ⊆ {τₙ(a) < 1}`. -/
+lemma tauMesh_lt_top_subset_of_lt {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
+    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ)
+    (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) {a b : ℝ} (hab : a ≤ b) :
+    {ω | tauMesh S 𝓕 P n b ω < (⊤ : mesh ι n)} ⊆ {ω | tauMesh S 𝓕 P n a ω < (⊤ : mesh ι n)} := by
+  simp_all only [tauMesh, WithTop.coe_lt_coe, Set.setOf_subset_setOf]
+  exact fun ω hω => (hittingBtwn_anti ((fun t ω ↦ _root_.predictablePart (S ∘ Subtype.val)
+    (meshFiltration 𝓕 n) P (succ t) ω)) ⊥ ⊤ (antitone_Ioi hab) ω).trans_lt hω
+
+/-- Stopping the predictable part at the bounded mesh time `τₙ(c)` preserves integrability. -/
+lemma integrable_stoppedValue_predictablePart_tauMesh {ι Ω : Type*} [TopologicalSpace ι]
+    [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ) (𝓕 : Filtration ι mΩ)
+    (P : Measure Ω) (n : ℕ) (c : ℝ) :
+    Integrable (stoppedValue (predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P)
+      (tauMesh S 𝓕 P n c)) P :=
+  integrable_stoppedValue (mesh ι n) (isStoppingTime_tauMesh S 𝓕 P n c)
+    (integrable_predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P)
+    (tauMesh_le_top S 𝓕 P n c)
+
+/-- The second estimate before equation 5. -/
+lemma second_estimate {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} {S : ι → Ω → ℝ} (hstop : S ⊤ =ᶠ[ae P] 0)
+    (𝓕 : Filtration ι mΩ) (n : ℕ) [SigmaFiniteFiltration P 𝓕] {c : ℝ} (hc : 0 ≤ c)
+    (hs : Submartingale S 𝓕 P) :
+    c / 2 * P.real {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)} ≤
+      - ∫ ω in {ω | tauMesh S 𝓕 P n (c / 2) ω < (⊤ : mesh ι n)},
+        stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n (c / 2)) ω ∂P :=
+  have hpred_int := integrable_predictableSeqTop S 𝓕 P n
+  have hstopped_pred_int := integrable_stoppedValue_predictablePart_tauMesh S 𝓕 P n (c / 2)
+  calc
+    _ = ∫ ω in {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)}, c / 2 ∂P := by simp [mul_comm]
+    _ ≤ ∫ ω in {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)},
+          (predictableSeqTop S 𝓕 P n ω -
+            stoppedValue (predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P)
+              (tauMesh S 𝓕 P n (c / 2)) ω) ∂P := by
+      refine setIntegral_mono_on_ae ?_ ?_ ?_ ?_
+      · exact (hs.integrableOn_const_tauMesh_lt_top n hc).div_const 2
+      · exact (hpred_int.sub hstopped_pred_int).integrableOn
+      · refine (((isStoppingTime_tauMesh S 𝓕 P n c).measurableSet _).1 ?_).1
+        exact (isStoppingTime_tauMesh S 𝓕 P n c).measurableSet_lt' ⊤
+      · filter_upwards [hs.tauMesh_lt_top_eq_lt_predictableSeqTop n hc] with ω hτ hω
+        have : c < predictableSeqTop S 𝓕 P n ω := hτ.mp hω
+        have := stoppedValue_predictablePart_tauMesh_le S 𝓕 P n (by linarith : 0 ≤ c / 2) ω
+        linarith
+    _ ≤ ∫ ω in {ω | tauMesh S 𝓕 P n (c / 2) ω < (⊤ : mesh ι n)},
+          (predictableSeqTop S 𝓕 P n ω -
+            stoppedValue (predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P)
+              (tauMesh S 𝓕 P n (c / 2)) ω) ∂P := by
+      refine setIntegral_mono_set ?_ ?_ ?_
+      · exact (hpred_int.sub hstopped_pred_int).integrableOn
+      · have hs_mesh : Submartingale (S ∘ Subtype.val) (meshFiltration 𝓕 n) P :=
+          hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
+        filter_upwards [ae_restrict_le hs_mesh.monotone_predictablePart_ae] with ω hmono
+        simpa [predictableSeqTop, stoppedValue] using hmono le_top
+      · exact (tauMesh_lt_top_subset_of_lt S 𝓕 P n (by linarith)).eventuallyLE
+    _ = ∫ ω in {ω | tauMesh S 𝓕 P n (c / 2) ω < (⊤ : mesh ι n)}, predictableSeqTop S 𝓕 P n ω ∂P -
+          ∫ ω in {ω | tauMesh S 𝓕 P n (c / 2) ω < (⊤ : mesh ι n)},
+            stoppedValue (predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P)
+              (tauMesh S 𝓕 P n (c / 2)) ω ∂P := by
+      rw [integral_sub]
+      · exact hpred_int.integrableOn
+      · exact hstopped_pred_int.integrableOn
+    _ = ∫ ω in {ω | tauMesh S 𝓕 P n (c / 2) ω < (⊤ : mesh ι n)},
+          P[predictableSeqTop S 𝓕 P n |
+            (isStoppingTime_tauMesh S 𝓕 P n (c / 2)).measurableSpace] ω ∂P -
+              ∫ ω in {ω | tauMesh S 𝓕 P n (c / 2) ω < (⊤ : mesh ι n)},
+                stoppedValue (predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P)
+                  (tauMesh S 𝓕 P n (c / 2)) ω ∂P := by
+      rw [setIntegral_condExp]
+      · exact hpred_int
+      · exact (isStoppingTime_tauMesh S 𝓕 P n (c / 2)).measurableSet_lt' ⊤
+    _ = _ := by
+      rw [← integral_sub integrable_condExp.restrict hstopped_pred_int.integrableOn, ← integral_neg]
+      · refine setIntegral_congr_ae ?_ ?_
+        · refine (((isStoppingTime_tauMesh S 𝓕 P n (c / 2)).measurableSet _).1 ?_).1
+          exact (isStoppingTime_tauMesh S 𝓕 P n (c / 2)).measurableSet_lt' ⊤
+        · filter_upwards [equation4 hstop (tauMesh_le_top S 𝓕 P n (c / 2))
+            (isStoppingTime_tauMesh S 𝓕 P n (c / 2))] with ω hω _
+          simp at hω
+          linarith [hω]
+
+lemma equation5 {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι] [SecondCountableTopology ι]
+    [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
+    {P : Measure Ω} {S : ι → Ω → ℝ} (hstop : S ⊤ =ᶠ[ae P] 0)
+    (𝓕 : Filtration ι mΩ) (n : ℕ) [SigmaFiniteFiltration P 𝓕] {c : ℝ} (hc : 0 ≤ c)
+    (hs : Submartingale S 𝓕 P) :
+    ∫ ω in {ω | c < predictableSeqTop S 𝓕 P n ω}, predictableSeqTop S 𝓕 P n ω ∂P ≤
+      -2 * ∫ ω in {ω | tauMesh S 𝓕 P n (c / 2) ω < (⊤ : mesh ι n)},
+        stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n (c / 2)) ω ∂P -
+          ∫ ω in {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)},
+            stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n c) ω ∂P := by
+  grw [first_estimate hstop 𝓕 n hc hs]
+  linear_combination 2 * (second_estimate hstop 𝓕 n hc hs)
+
+lemma equation5' {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι] [SecondCountableTopology ι]
+    [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
+    {P : Measure Ω} {S : ι → Ω → ℝ} (hstop : S ⊤ =ᶠ[ae P] 0)
+    (𝓕 : Filtration ι mΩ) (n : ℕ) [SigmaFiniteFiltration P 𝓕] {c : ℝ} (hc : 0 ≤ c)
+    (hs : Submartingale S 𝓕 P) :
+    ∫ ω in {ω | c < predictableSeqTop S 𝓕 P n ω}, predictableSeqTop S 𝓕 P n ω ∂P ≤
+      ∫ ω in {ω | tauMesh S 𝓕 P n (c / 2) ω < (⊤ : mesh ι n)}, (-2) *
+        stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n (c / 2)) ω ∂P +
+          ∫ ω in {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)},
+            -stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n c) ω ∂P := by
+  grw [equation5 hstop 𝓕 n hc hs, ← integral_const_mul_of_integrable, sub_eq_add_neg,
+    ← integral_neg]
+  exact (hs.integrable_stoppedValue_tauMesh n (c / 2)).restrict
+
+end equation5
+
+end Estimate
+
+section UniformIntegrability
+
+/-- Lift the mesh stopping time `τₙ(c)` to a stopping time on the original index set. -/
+noncomputable def tauMeshLift {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
+    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ)
+    (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) (c : ℝ) : Ω → WithTop ι :=
+  fun ω => ((tauMesh S 𝓕 P n c ω).untopA : mesh ι n)
+
+@[simp]
+lemma tauMesh_ne_top {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
+    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ)
+    (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) (c : ℝ) (ω : Ω) :
+    tauMesh S 𝓕 P n c ω ≠ ⊤ := by
+  simp [tauMesh]
+
+@[simp]
+lemma tauMeshLift_ne_top {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
+    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ)
+    (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) (c : ℝ) (ω : Ω) :
+    tauMeshLift S 𝓕 P n c ω ≠ ⊤ := by
+  simp [tauMeshLift]
+
+lemma stoppedValue_tauMeshLift {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
+    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ)
+    (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) (c : ℝ) :
+    stoppedValue S (tauMeshLift S 𝓕 P n c) =
+      stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n c) := by
+  ext; simp [stoppedValue, tauMeshLift]
+
+/-- We still get a stopping time after the lifting. -/
+lemma isStoppingTime_tauMeshLift {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
+    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (S : ι → Ω → ℝ)
+    (𝓕 : Filtration ι mΩ) (P : Measure Ω) (n : ℕ) (c : ℝ) :
+    IsStoppingTime 𝓕 (tauMeshLift S 𝓕 P n c) := by
+  sorry
+
+/-- Used in estimating the size of the set `{τₙ(b) < 1}`. -/
+lemma integral_predictableSeqTop_eq_neg_integral_bot {ι Ω : Type*} [TopologicalSpace ι]
+    [T1Space ι] [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι]
+    [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} {P : Measure Ω} {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} [SigmaFiniteFiltration P 𝓕] (hstop : S ⊤ =ᵐ[P] 0) (n : ℕ) :
+    ∫ ω, predictableSeqTop S 𝓕 P n ω ∂P = - ∫ ω, S ⊥ ω ∂P := calc
+  _ = - ∫ ω, -predictableSeqTop S 𝓕 P n ω ∂P := by simp [integral_neg]
+  _ = - ∫ ω, martingaleSeqTop S 𝓕 P n ω ∂P := by
+    simp [integral_congr_ae (martingaleSeqTop_eq_neg_predictableSeqTop 𝓕 hstop n)]
+  _ = - ∫ ω, S ⊥ ω ∂P := by
+    rw [martingaleSeqTop, ← setIntegral_univ,
+      ← (martingale_martingalePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P).setIntegral_eq
+      (bot_le (a := ⊤)) MeasurableSet.univ]
+    simp [_root_.martingalePart]
+
+/-- Estimate for the hitting event `{τₙ(c) < 1}`. -/
+lemma measure_tauMesh_lt_top_le {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} {S : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ}
+    [SigmaFiniteFiltration P 𝓕] (hs : Submartingale S 𝓕 P) (hstop : S ⊤ =ᵐ[P] 0) (n : ℕ) {c : ℝ}
+    (hc : 0 < c) :
+    P {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)} ≤
+      ENNReal.ofReal (- ∫ ω, S ⊥ ω ∂P) / ENNReal.ofReal c := calc
+  P {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)} = P {ω | c < predictableSeqTop S 𝓕 P n ω} :=
+    measure_congr (hs.tauMesh_lt_top_eq_lt_predictableSeqTop n hc.le)
+  _ ≤ P {ω | ENNReal.ofReal c ≤ ENNReal.ofReal (predictableSeqTop S 𝓕 P n ω)} :=
+    measure_mono fun ω hω => ENNReal.ofReal_le_ofReal hω.le
+  _ ≤ (∫⁻ ω, ENNReal.ofReal (predictableSeqTop S 𝓕 P n ω) ∂P) / ENNReal.ofReal c :=
+    meas_ge_le_lintegral_div
+      ((integrable_predictableSeqTop S 𝓕 P n).aestronglyMeasurable.aemeasurable.ennreal_ofReal)
+      (ENNReal.ofReal_ne_zero_iff.2 hc) ENNReal.ofReal_ne_top
+  _ = ENNReal.ofReal (∫ ω, predictableSeqTop S 𝓕 P n ω ∂P) / ENNReal.ofReal c := by
+    rw [ofReal_integral_eq_lintegral_ofReal (integrable_predictableSeqTop S 𝓕 P n)]
+    have hs_mesh : Submartingale (S ∘ Subtype.val) (meshFiltration 𝓕 n) P :=
+      hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
+    filter_upwards [hs_mesh.predictablePart_nonneg'] with ω hω using hω ⊤
+  _ = ENNReal.ofReal (- ∫ ω, S ⊥ ω ∂P) / ENNReal.ofReal c := by
+    rw [integral_predictableSeqTop_eq_neg_integral_bot hstop n]
+
+/-- The terminal values of the predictable parts are uniformly integrable. -/
+lemma uniformIntegrable_predictableSeqTop {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P)
+    (hd : UniformIntegrable (fun (τ : {T : Ω → WithTop ι | IsStoppingTime 𝓕 T ∧ ∀ ω, T ω ≠ ⊤}) ↦
+      stoppedValue S τ.1) 1 P) (hstop : S ⊤ =ᵐ[P] 0) (ht : ∀ t, S t ≤ᵐ[P] 0) :
+    UniformIntegrable (predictableSeqTop S 𝓕 P) 1 P := by
+  refine (uniformIntegrable_iff_tendsto_nnReal_iSup_setIntegral_of_nonneg (fun n => ?_)
+    (fun n => ?_) (fun n => ?_)).2 ?_
+  · exact (stronglyAdapted_predictablePart
+      (S ∘ Subtype.val) (meshFiltration 𝓕 n) P).stronglyMeasurable.aestronglyMeasurable
+  · have hs_mesh : Submartingale (S ∘ Subtype.val) (meshFiltration 𝓕 n) P :=
+      hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
+    filter_upwards [hs_mesh.predictablePart_nonneg'] with ω hω using hω ⊤
+  · exact integrable_predictableSeqTop S 𝓕 P n
+  · refine tendsto_of_tendsto_of_tendsto_of_le_of_le' (a := 0) (h := fun c : ℝ≥0 ↦
+      (⨆ k, ENNReal.ofReal (∫ ω in {ω | tauMesh S 𝓕 P k (c / 2) ω < (⊤ : mesh ι k)}, (-2) *
+        stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P k (c / 2)) ω ∂P)) +
+          ⨆ k, ENNReal.ofReal (∫ ω in {ω | tauMesh S 𝓕 P k c ω < (⊤ : mesh ι k)},
+            -stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P k c) ω ∂P)) tendsto_const_nhds ?_ ?_ ?_
+    · rw [← zero_add (0 : ℝ≥0∞)]
+      apply Tendsto.add
+      · -- use `hd` to prove the following two sorries
+        sorry
+      · sorry
+    · filter_upwards with c using by positivity
+    · filter_upwards with c
+      calc
+        ⨆ k, ENNReal.ofReal (∫ ω in {ω | c < predictableSeqTop S 𝓕 P k ω},
+          predictableSeqTop S 𝓕 P k ω ∂P) ≤ ⨆ k, ENNReal.ofReal
+            (∫ ω in {ω | tauMesh S 𝓕 P k (c / 2) ω < (⊤ : mesh ι k)}, (-2) *
+              stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P k (c / 2)) ω ∂P +
+                ∫ ω in {ω | tauMesh S 𝓕 P k c ω < (⊤ : mesh ι k)},
+                  -stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P k c) ω ∂P) := by
+          gcongr with k
+          exact equation5' hstop 𝓕 k c.2 hs
+        _ = ⨆ k, ENNReal.ofReal
+            (∫ ω in {ω | tauMesh S 𝓕 P k (c / 2) ω < (⊤ : mesh ι k)}, (-2) *
+              stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P k (c / 2)) ω ∂P) +
+                ENNReal.ofReal (∫ ω in {ω | tauMesh S 𝓕 P k c ω < (⊤ : mesh ι k)},
+                  -stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P k c) ω ∂P) := by
+          congr with k
+          have hmesh : ∀ᵐ ω ∂P, ∀ t : mesh ι k, S t ω ≤ 0 := ae_all_iff.2 fun t => ht t
+          apply ENNReal.ofReal_add
+          all_goals
+            apply integral_nonneg_of_ae
+            simp only [stoppedValue, Function.comp_apply]
+          · filter_upwards [ae_restrict_of_ae hmesh] with ω hω
+            exact mul_nonneg_of_nonpos_of_nonpos (by simp) (hω ((tauMesh S 𝓕 P k (c / 2) ω).untopA))
+          · filter_upwards [ae_restrict_of_ae hmesh] with ω hω
+            exact neg_nonneg.2 (hω ((tauMesh S 𝓕 P k c ω).untopA))
+        _ ≤ _ := iSup_add_le _ _
+
+/-- As the terminal values of predictable parts are uniformly integrable, the terminal values of the
+martingale parts are uniformly integrable. -/
+lemma uniformIntegrable_martingaleSeqTopAux {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P)
+    (hd : UniformIntegrable (fun (τ : {T : Ω → WithTop ι | IsStoppingTime 𝓕 T ∧ ∀ ω, T ω ≠ ⊤}) ↦
+      stoppedValue S τ.1) 1 P) (hstop : S ⊤ =ᵐ[P] 0) (ht : ∀ t, S t ≤ᵐ[P] 0) :
+    UniformIntegrable (martingaleSeqTop S 𝓕 P) 1 P := by
+  rw [uniformIntegrable_congr_ae (martingaleSeqTop_eq_neg_predictableSeqTop 𝓕 hstop)]
+  exact (uniformIntegrable_predictableSeqTop hs hd hstop ht).neg
+
+/-- Prove uniform integrability without the assumption `S ⊤ =ᵐ[P] 0` and `∀ t, S t ≤ᵐ[P] 0`. -/
+lemma uniformIntegrable_martingaleSeqTop {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ}
+    (hd : UniformIntegrable (fun (τ : {T : Ω → WithTop ι | IsStoppingTime 𝓕 T ∧ ∀ ω, T ω ≠ ⊤}) ↦
+      stoppedValue S τ.1) 1 P) (hs : Submartingale S 𝓕 P) :
+    UniformIntegrable (martingaleSeqTop S 𝓕 P) 1 P := by
+  have h0 : S = S - (fun i => P[S ⊤ | 𝓕 i]) + (fun i => P[S ⊤ | 𝓕 i]) := by simp
+  have h1 (i) : Integrable ((S - fun t => P[S ⊤ | 𝓕 t]) i) P :=
+    (hs.integrable i).sub integrable_condExp
+  rw [h0, uniformIntegrable_congr_ae (martingaleSeqTop_add 𝓕 h1 (fun i => integrable_condExp))]
+  refine UniformIntegrable.add (refl 1) ?_ ?_
+  · refine uniformIntegrable_martingaleSeqTopAux ?_ ?_ ?_ fun i => ?_
+    · exact hs.sub_martingale (martingale_condExp _ _ _)
+    · sorry
+    · simp [condExp_of_stronglyMeasurable _ (hs.stronglyMeasurable ⊤) (hs.integrable ⊤)]
+    · filter_upwards [hs.ae_le_condExp (i := i) le_top] with ω
+      simp
+  · rw [uniformIntegrable_congr_ae
+      (martingaleSeqTop_eq_self_of_martingale (martingale_condExp (S ⊤) 𝓕 P))]
+    exact Integrable.uniformIntegrable_condExp (hs.integrable ⊤) (fun _ => 𝓕.le' ⊤)
+
+end UniformIntegrability
+
+-- We define the martingale part in the doob-meyer decomposition.
+section MartingalePartLimDef
+
+/-- Show that the terminals values of some convex combinations of the martingale parts converge. -/
+lemma exists_martingalPart_lim {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) :
+    ∃ M : Ω → ℝ, ∃ a : ℕ → StdSimplex ℝ ℕ,
+      Tendsto (fun n ↦ eLpNorm ((a n).weights.sum (fun m r ↦ r • martingaleSeqTop S 𝓕 P m) - M) 1 P)
+      atTop (𝓝 0) := by
+  sorry
+
+/-- This is the martingalePart in the doob-meyer decomposition of a submartingale. -/
+noncomputable def martingalePartLim {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (i : ι) :=
+  P[(exists_martingalPart_lim hd hs).choose | 𝓕 i]
+
+lemma martingale_martingalePartLim {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) :
+    Martingale (martingalePartLim hd hs) 𝓕 P :=
+  martingale_condExp (exists_martingalPart_lim hd hs).choose 𝓕 P
+
+/-- This is the weight associated with the martingale part. -/
+noncomputable def weight {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) : ℕ → StdSimplex ℝ ℕ :=
+  (exists_martingalPart_lim hd hs).choose_spec.choose
+
+/-- The extension of the discrete martingale part `M^n`. -/
+noncomputable def martingaleSeqStep {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
+    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (P : Measure Ω)
+    (S : ι → Ω → ℝ) (𝓕 : Filtration ι mΩ) (n : ℕ) (i : ι) :=
+  P[martingaleSeqTop S 𝓕 P n | 𝓕 i]
+
+/-- The convexly averaged mesh step-extension `ℳ^n` of the martingale parts. -/
+noncomputable def martingaleConvexStep {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) : ι → Ω → ℝ :=
+  (weight hd hs n).weights.sum fun m r ↦ r • martingaleSeqStep P S 𝓕 m
+
+/-- `L¹` norm convergence of `martingaleConvexStep`, proved by using conditional Jensen. -/
+lemma martingaleConvexStep_eLpNorm_tendsto {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) (t : ι) :
+    Tendsto (fun n ↦ eLpNorm
+      (martingaleConvexStep hd hs n t - martingalePartLim hd hs t) 1 P) atTop (𝓝 0) := by
+  sorry
+
+end MartingalePartLimDef
+
+-- We define the predictable part in the doob-meyer decomposition.
+section PredictablePartLimDef
+
+/-- The half-open mesh interval ending at `t`, with left endpoint the predecessor of `t` in the
+finite mesh. -/
+def meshPredIoc {ι : Type*} [LinearOrder ι] [OrderBot ι] [OrderTop ι] [TopologicalSpace ι]
+    [SecondCountableTopology ι] (n : ℕ) (t : mesh ι n) : Set ι :=
+  Set.Ioc ((pred t : mesh ι n) : ι) (t : ι)
+
+/-- The mesh step-extension of the discrete predictable part `A^n`. -/
+noncomputable def predictableSeqStep {ι Ω : Type*} [TopologicalSpace ι]
+    [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
+    (P : Measure Ω) (S : ι → Ω → ℝ) (𝓕 : Filtration ι mΩ) (n : ℕ) :
+    ι → Ω → ℝ :=
+  fun t ↦ ∑ u : mesh ι n, (meshPredIoc n u).indicator
+    (fun _ : ι ↦ predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P u) t
+
+/-- The convexly averaged mesh step-extension `𝒜^n` of the predictable parts. -/
+noncomputable def predictableConvexStep {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) : ι → Ω → ℝ :=
+  (weight hd hs n).weights.sum fun m r ↦ r • predictableSeqStep P S 𝓕 m
+
+/-- The predictable part `A` in the Doob-Meyer decomposition, defined as `S - M`. -/
+noncomputable def predictablePartLim {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) : ι → Ω → ℝ :=
+  S - martingalePartLim hd hs
+
+/-- `L¹` norm convergence of `predictableConvexStep` for `t` in `denseSet ι`. -/
+lemma predictableConvexStep_eLpNorm_tendsto {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) {t : ι}
+    (ht : t ∈ denseSet ι) :
+    Tendsto (fun n ↦ eLpNorm
+      (predictableConvexStep hd hs n t - predictablePartLim hd hs t) 1 P) atTop (𝓝 0) := by
+  sorry
+
+/-- Almost everywhere convergence of `predictableConvexStep`. -/
+lemma predictableConvexStep_ae_tendsto {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) {t : ι}
+    (ht : t ∈ denseSet ι) :
+    ∃ φ : ℕ → ℕ, StrictMono φ ∧
+      ∀ᵐ ω ∂P, Tendsto (fun n ↦ predictableConvexStep hd hs (φ n) t ω)
+        atTop (𝓝 (predictablePartLim hd hs t ω)) := by
+  sorry
+
+end PredictablePartLimDef
+
+-- Helper lemmas about limits of monotone functions.
+section MonotoneLim
+
+/-- The limit of a collection of functions that is frequently monotone is monotone. -/
+lemma monotone_of_frequently_monotone_of_tendsto {ι α β : Type*} [Preorder α] [TopologicalSpace β]
+    [Preorder β] [OrderClosedTopology β] {l : Filter ι} {F : ι → α → β} {f : α → β}
+    (hF : ∃ᶠ i in l, Monotone (F i)) (hlim : ∀ x, Tendsto (fun i ↦ F i x) l (𝓝 (f x))) :
+    Monotone f :=
+  isClosed_monotone.mem_of_frequently_of_tendsto hF ((tendsto_pi_nhds).2 hlim)
+
+/-- The limit of a collection of functions that is frequently antitone is antitone. -/
+lemma antitone_of_frequently_antitone_of_tendsto {ι α β : Type*} [Preorder α] [TopologicalSpace β]
+    [Preorder β] [OrderClosedTopology β] {l : Filter ι} {F : ι → α → β} {f : α → β}
+    (hF : ∃ᶠ i in l, Antitone (F i)) (hlim : ∀ x, Tendsto (fun i ↦ F i x) l (𝓝 (f x))) :
+    Antitone f :=
+  monotone_of_frequently_monotone_of_tendsto (β := βᵒᵈ) hF hlim
+
+/-- The limit of a collection of functions that is eventually monotone is monotone. -/
+lemma monotone_of_eventually_monotone_of_tendsto {ι α β : Type*} [Preorder α] [TopologicalSpace β]
+    [Preorder β] [OrderClosedTopology β] {l : Filter ι} [l.NeBot] {F : ι → α → β} {f : α → β}
+    (hF : ∀ᶠ i in l, Monotone (F i)) (hlim : ∀ x, Tendsto (fun i ↦ F i x) l (𝓝 (f x))) :
+    Monotone f :=
+  monotone_of_frequently_monotone_of_tendsto hF.frequently hlim
+
+/-- The limit of a collection of functions that is eventually antitone is antitone. -/
+lemma antitone_of_eventually_antitone_of_tendsto {ι α β : Type*} [Preorder α] [TopologicalSpace β]
+    [Preorder β] [OrderClosedTopology β] {l : Filter ι} [l.NeBot] {F : ι → α → β} {f : α → β}
+    (hF : ∀ᶠ i in l, Antitone (F i)) (hlim : ∀ x, Tendsto (fun i ↦ F i x) l (𝓝 (f x))) :
+    Antitone f :=
+  monotone_of_eventually_monotone_of_tendsto (β := βᵒᵈ) hF hlim
+
+/-- The limit of a collection of monotone functions is monotone. -/
+lemma monotone_of_monotone_of_tendsto {ι α β : Type*} [Preorder α] [TopologicalSpace β]
+    [Preorder β] [OrderClosedTopology β] {l : Filter ι} [l.NeBot] {F : ι → α → β} {f : α → β}
+    (hF : ∀ i, Monotone (F i)) (hlim : ∀ x, Tendsto (fun i ↦ F i x) l (𝓝 (f x))) :
+    Monotone f :=
+  monotone_of_eventually_monotone_of_tendsto (Eventually.of_forall hF) hlim
+
+/-- The limit of a collection of antitone functions is antitone. -/
+lemma antitone_of_antitone_of_tendsto {ι α β : Type*} [Preorder α] [TopologicalSpace β]
+    [Preorder β] [OrderClosedTopology β] {l : Filter ι} [l.NeBot] {F : ι → α → β} {f : α → β}
+    (hF : ∀ i, Antitone (F i)) (hlim : ∀ x, Tendsto (fun i ↦ F i x) l (𝓝 (f x))) :
+    Antitone f :=
+  monotone_of_monotone_of_tendsto (β := βᵒᵈ) hF hlim
+
+/-- This is an auxillary lemma used to prove `Dense.monotone_of_isRightContinuous`. It is saying
+that if `D` is a dense set and `a, b` are two points such that `a < b`, then the comap of
+`𝓝[Set.Ioi a] a` under the inclusion `D → α` is nontrivial. Note that `a < b` is necessary as
+this is clearly not true if `a` is a top element. -/
+lemma Dense.comap_val_nhdsWithin_Ioi_neBot {α : Type*} [TopologicalSpace α] [LinearOrder α]
+    [OrderTopology α] [DenselyOrdered α] {D : Set α} (hD : Dense D) {a b : α} (hab : a < b) :
+    ((𝓝[Set.Ioi a] a).comap ((↑) : D → α)).NeBot := by
+  refine comap_neBot_iff.2 fun t ht => ?_
+  obtain ⟨c, hc⟩ := (mem_nhdsGT_iff_exists_mem_Ioc_Ioo_subset hab).1 ht
+  obtain ⟨d, hd⟩ := hD.inter_open_nonempty (Set.Ioo a c) isOpen_Ioo (Set.nonempty_Ioo.2 hc.1.1)
+  exact ⟨⟨d, hd.2⟩, hc.2 hd.1⟩
+
+/-- This is the dual of `Dense.comap_val_nhdsWithin_Ioi_neBot`. -/
+lemma Dense.comap_val_nhdsWithin_Iio_neBot {α : Type*} [TopologicalSpace α] [LinearOrder α]
+    [OrderTopology α] [DenselyOrdered α] {D : Set α} (hD : Dense D) {a b : α} (hab : b < a) :
+    ((𝓝[Set.Iio a] a).comap ((↑) : D → α)).NeBot := by
+  refine comap_neBot_iff.2 fun t ht => ?_
+  obtain ⟨c, hc⟩ := (mem_nhdsLT_iff_exists_mem_Ico_Ioo_subset hab).1 ht
+  obtain ⟨d, hd⟩ := hD.inter_open_nonempty (Set.Ioo c a) isOpen_Ioo (Set.nonempty_Ioo.2 hc.1.2)
+  exact ⟨⟨d, hd.2⟩, hc.2 hd.1⟩
+
+/-- If `f` is monotone on a dense set `D` and is right continuous, then `f` is monotone. We prove
+under the assumption that `α` has a top element `⊤` and `⊤ ∈ D`, which is a necessary assumption
+because otherwise it is possible that `⊤` is an isolated point. This theorem should be also true
+when `α` satisfies `NoTopOrder α`. -/
+lemma Dense.monotone_of_isRightContinuous {α β : Type*} [LinearOrder α] [OrderTop α]
+    [TopologicalSpace α] [OrderTopology α] [DenselyOrdered α] [TopologicalSpace β]
+    [Preorder β] [t : OrderClosedTopology β] {f : α → β} {D : Set α} (hD : Dense D) (htop : ⊤ ∈ D)
+    (hm : Monotone (f ∘ (↑) : D → β)) (hf : f.IsRightContinuous) :
+    Monotone f := by
+  refine monotone_iff_forall_lt.2 fun a b hab => ?_
+  by_cases! hbtop : b = ⊤
+  · have : (comap ((↑) : D → α) (𝓝[>] a)).NeBot := hD.comap_val_nhdsWithin_Ioi_neBot hab
+    rw [hbtop]
+    refine (isClosed_Iic (a := f ⊤)).mem_of_tendsto (Tendsto.comp (hf a)
+      (tendsto_comap (f := ((↑) : D → α)))) ?_
+    rw [eventually_comap, eventually_nhdsWithin_iff]
+    filter_upwards with z hz d rfl using hm (Subtype.mk_le_mk.2 le_top : d ≤ ⟨⊤, htop⟩)
+  · -- This part should work when `α` satisfies `NoTopOrder α`.
+    let I : D × D → α × α := Prod.map Subtype.val Subtype.val
+    have : ((𝓝[Set.Ioi a ×ˢ Set.Ioi b] ⟨a, b⟩).comap I).NeBot := by
+      simp only [nhdsWithin_prod_eq, comap_prodMap_prod, I]
+      exact (hD.comap_val_nhdsWithin_Ioi_neBot hab).prod
+        (hD.comap_val_nhdsWithin_Ioi_neBot hbtop.lt_top)
+    have : ∀ᶠ (p : D × D) in (𝓝[Set.Ioi a ×ˢ Set.Ioi b] ⟨a, b⟩).comap I, p.1 ≤ p.2 := by
+      rw [eventually_comap, eventually_nhdsWithin_iff]
+      have := isOpen_lt_prod.mem_nhds_iff.2 (by simp [hab] : ⟨a, b⟩ ∈ {p : α × α | p.1 < p.2})
+      filter_upwards [this] with p hlt _ a rfl using hlt.le
+    exact t.isClosed_le'.mem_of_tendsto (Tendsto.comp ((hf a).prodMap (hf b)) tendsto_comap)
+      (this.mono fun d hd => by simpa using hm hd)
+
+/-- A helper lemma. -/
+lemma Filter.IsCoboundedUnder.trans {ι α : Type*} {r : α → α → Prop} {l : Filter ι} [l.NeBot]
+    [IsTrans α r] {u v : ι → α} (hle : ∀ᶠ i in l, r (u i) (v i)) (h : IsCoboundedUnder r l u) :
+    IsCoboundedUnder r l v := by
+  simp only [IsCoboundedUnder, IsCobounded, eventually_map] at *
+  obtain ⟨b, hb⟩ := h
+  refine ⟨b, fun a ha => hb a ?_⟩
+  filter_upwards [ha, hle] with i hi huv using Trans.trans huv hi
+
+/-- Convergence on a dense set of a collection of monotone function controls the `limsup` at a point
+if `f` is right continuous at `a`. We prove this under the assumption that `α` has both a bottom
+element and a top element. The bottom element is needed because otherwise `limsup` evaluated at the
+bottome element may give a junk value to break the inequality. -/
+lemma limsup_le_of_eventually_monotone_of_tendsto_on_dense {ι α β : Type*} [LinearOrder α]
+    [BoundedOrder α] [TopologicalSpace α] [OrderTopology α] [DenselyOrdered α]
+    [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β] {l : Filter ι}
+    [l.NeBot] {D : Set α} {F : ι → α → β} {f : α → β} (hF : ∀ᶠ i in l, Monotone (F i))
+    (hD : Dense D) (htop : ⊤ ∈ D) (hbot : ⊥ ∈ D) {a : α} (hfa : ContinuousWithinAt f (Set.Ioi a) a)
+    (hlim : ∀ t ∈ D, Tendsto (F · t) l (𝓝 (f t))) :
+    limsup (F · a) l ≤ f a := by
+  by_cases! ha : a = ⊤
+  · rw [ha, (hlim ⊤ htop).limsup_eq]
+  · have : (comap ((↑) : D → α) (𝓝[>] a)).NeBot := hD.comap_val_nhdsWithin_Ioi_neBot ha.lt_top
+    refine (isClosed_Ici (a := limsup (F · a) l)).mem_of_tendsto (Tendsto.comp hfa
+      (tendsto_comap (f := ((↑) : D → α)))) ?_
+    rw [eventually_comap, eventually_nhdsWithin_iff]
+    filter_upwards with z hz d rfl
+    simp only [Function.comp_apply, Set.mem_Ici, ← (hlim d d.2).limsup_eq]
+    refine limsup_le_limsup ?_ ?_ (hlim d d.2).isBoundedUnder_le
+    · filter_upwards [hF] with i hi using hi hz.le
+    · refine (hlim ⊥ hbot).isCoboundedUnder_le.trans ?_
+      filter_upwards [hF] with i hi using hi bot_le
+
+/-- This is the dual of `limsup_le_of_eventually_monotone_of_tendsto_on_dense`. -/
+lemma le_liminf_of_eventually_monotone_of_tendsto_on_dense {ι α β : Type*} [LinearOrder α]
+    [BoundedOrder α] [TopologicalSpace α] [OrderTopology α] [DenselyOrdered α]
+    [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β] {l : Filter ι}
+    [l.NeBot] {D : Set α} {F : ι → α → β} {f : α → β} (hF : ∀ᶠ i in l, Monotone (F i))
+    (hD : Dense D) (htop : ⊤ ∈ D) (hbot : ⊥ ∈ D) {a : α} (hfa : ContinuousWithinAt f (Set.Iio a) a)
+    (hlim : ∀ t ∈ D, Tendsto (F · t) l (𝓝 (f t))) :
+    f a ≤ liminf (F · a) l := by
+  by_cases! ha : a = ⊥
+  · rw [ha, (hlim ⊥ hbot).liminf_eq]
+  · have : (comap ((↑) : D → α) (𝓝[<] a)).NeBot := hD.comap_val_nhdsWithin_Iio_neBot ha.bot_lt
+    refine (isClosed_Iic (a := liminf (F · a) l)).mem_of_tendsto (Tendsto.comp hfa
+      (tendsto_comap (f := ((↑) : D → α)))) ?_
+    rw [eventually_comap, eventually_nhdsWithin_iff]
+    filter_upwards with z hz d rfl
+    simp only [Function.comp_apply, Set.mem_Iic, ← (hlim d d.2).liminf_eq]
+    refine liminf_le_liminf ?_ (hlim d d.2).isBoundedUnder_ge ?_
+    · filter_upwards [hF] with i hi using hi hz.le
+    · refine (hlim ⊤ htop).isCoboundedUnder_ge.trans ?_
+      filter_upwards [hF] with i hi using hi le_top
+
+/-- We combine `limsup_le_of_eventually_monotone_of_tendsto_on_dense` and
+`le_liminf_of_eventually_monotone_of_tendsto_on_dense` to prove that `F · a` converges to `f a`
+if `f` is continuous at `a`. -/
+lemma tendsto_of_eventually_monotone_of_tendsto_on_dense {ι α β : Type*} [LinearOrder α]
+    [BoundedOrder α] [TopologicalSpace α] [OrderTopology α] [DenselyOrdered α]
+    [ConditionallyCompleteLinearOrder β] [TopologicalSpace β] [OrderTopology β] {l : Filter ι}
+    [l.NeBot] {D : Set α} {F : ι → α → β} {f : α → β} (hF : ∀ᶠ i in l, Monotone (F i))
+    (hD : Dense D) (htop : ⊤ ∈ D) (hbot : ⊥ ∈ D) (a : α) (hfa : ContinuousAt f a)
+    (hlim : ∀ t ∈ D, Tendsto (F · t) l (𝓝 (f t))) :
+    Tendsto (F · a) l (𝓝 (f a)) := by
+  refine tendsto_of_le_liminf_of_limsup_le ?_ ?_ ?_ ?_
+  · exact le_liminf_of_eventually_monotone_of_tendsto_on_dense hF hD htop hbot
+      hfa.continuousWithinAt hlim
+  · exact limsup_le_of_eventually_monotone_of_tendsto_on_dense hF hD htop hbot
+      hfa.continuousWithinAt hlim
+  · -- create an analogue of `Filter.IsCoboundedUnder.trans` for `IsBoundedUnder` to replace
+    -- `isBoundedUnder_le.mono_le`
+    refine (hlim ⊤ htop).isBoundedUnder_le.mono_le ?_
+    filter_upwards [hF] with i hi using hi le_top
+  · refine (hlim ⊥ hbot).isBoundedUnder_ge.mono_ge ?_
+    filter_upwards [hF] with i hi using hi bot_le
+
+end MonotoneLim
+
+section PredictablePartLimMono
+
+lemma predictableSeqStep_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P) (n : ℕ) (t : ι) :
+    ∀ᵐ ω ∂P, Monotone fun t ↦ predictableSeqStep P S 𝓕 n t ω := by
+  sorry
+
+lemma predictableConvexStep_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) (t : ι) :
+    ∀ᵐ ω ∂P, Monotone fun t ↦ predictableConvexStep hd hs n t ω := by
+  sorry
+
+lemma predictablePartLim_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) (t : ι) :
+    ∀ᵐ ω ∂P, Monotone fun t ↦ predictablePartLim hd hs t ω := by
+  sorry
+
+end PredictablePartLimMono
+
+section PredictableConvexStepPredictable
+
+/-- The mesh step-extension of the discrete predictable part is left-continuous in time. -/
+lemma predictableSeqStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (n : ℕ) (ω : Ω) (t : ι) :
+    ContinuousWithinAt (fun s ↦ predictableSeqStep P S 𝓕 n s ω) (Set.Iio t) t := by
+  sorry
+
+/-- `predictableConvexStep` is left-continuous in time. -/
+lemma predictableConvexStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) (ω : Ω) (t : ι) :
+    ContinuousWithinAt (fun s ↦ predictableConvexStep hd hs n s ω) (Set.Iio t) t := by
+  sorry
+
+/-- The mesh step-extension of the discrete predictable part is strongly adapted. -/
+lemma stronglyAdapted_predictableSeqStep {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} (P : Measure Ω) [IsFiniteMeasure P] (S : ι → Ω → ℝ)
+    (𝓕 : Filtration ι mΩ) (n : ℕ) :
+    StronglyAdapted 𝓕 (predictableSeqStep P S 𝓕 n) := by
+  refine fun t => Finset.stronglyMeasurable_sum _ fun u _ => ?_
+  by_cases htu : t ∈ meshPredIoc n u
+  · have : meshFiltration 𝓕 n (pred u) ≤ 𝓕 t := by simpa [meshFiltration] using 𝓕.mono htu.1.le
+    simpa [htu] using (stronglyMeasurable_pred_predictablePart (S ∘ Subtype.val)
+      (meshFiltration 𝓕 n) P u).mono this
+  · simpa [htu] using stronglyMeasurable_zero
+
+/-- The convexly averaged mesh step-extension of the predictable parts is strongly adapted. -/
+lemma stronglyAdapted_predictableConvexStep {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) :
+    StronglyAdapted 𝓕 (predictableConvexStep hd hs n) := by
+  intro t
+  simpa [predictableConvexStep, Finsupp.sum] using
+    Finset.stronglyMeasurable_sum ((weight hd hs n).weights.support) fun m _hm ↦
+      (stronglyAdapted_predictableSeqStep P S 𝓕 m t).const_smul ((weight hd hs n).weights m)
+
+/-- The convexly averaged mesh step-extension of the predictable parts is strongly predictable. -/
+lemma isStronglyPredictable_predictableConvexStep {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    [OrderTopology ι] [DenselyOrdered ι] {mΩ : MeasurableSpace Ω} {P : Measure Ω}
+    [IsFiniteMeasure P] {S : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P)
+    (hs : Submartingale S 𝓕 P) (n : ℕ) :
+    IsStronglyPredictable 𝓕 (predictableConvexStep hd hs n) :=
+  (stronglyAdapted_predictableConvexStep hd hs n).isStronglyPredictable_of_leftContinuous
+    (predictableConvexStep_leftContinuous hd hs n)
+
+end PredictableConvexStepPredictable
+
+section PredictablePartIsStronglyPredictable
+
+/-- The pointwise limsup of strongly predictable processes is strongly predictable. -/
+lemma IsStronglyPredictable.limsup {ι Ω E : Type*} [Preorder ι] [OrderBot ι]
+    {mΩ : MeasurableSpace Ω} {𝓕 : Filtration ι mΩ} [TopologicalSpace E] [MeasurableSpace E]
+    [BorelSpace E] [TopologicalSpace.PseudoMetrizableSpace E] [ConditionallyCompleteLinearOrder E]
+    [OrderTopology E] [SecondCountableTopology E] {X : ℕ → ι → Ω → E}
+    (hX : ∀ n, IsStronglyPredictable 𝓕 (X n)) :
+    IsStronglyPredictable 𝓕 (fun t ω ↦ limsup (fun n ↦ X n t ω) atTop) := by
+  rw [IsStronglyPredictable, stronglyMeasurable_iff_measurable]
+  exact Measurable.limsup fun n => stronglyMeasurable_iff_measurable.1 (hX n)
+
+/-- The limsup of convexly averaged mesh step-extension of the predictable parts is strongly
+predictable. -/
+lemma isStronglyPredictable_limsup_predictableConvexStep {ι Ω : Type*} [TopologicalSpace ι]
+    [T1Space ι] [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι]
+    [OrderTop ι] [OrderTopology ι] [DenselyOrdered ι] {mΩ : MeasurableSpace Ω} {P : Measure Ω}
+    [IsFiniteMeasure P] {S : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P)
+    (hs : Submartingale S 𝓕 P) :
+    IsStronglyPredictable 𝓕 (fun t ω => limsup (predictableConvexStep hd hs · t ω) atTop) :=
+  IsStronglyPredictable.limsup fun n => isStronglyPredictable_predictableConvexStep hd hs n
+
+/-- For each stopping time `τ`, `limsup (fun n => stoppedValue 𝒜^n τ) atTop ≤ stoppedValue A τ`
+almost everywhere. Use `limsup_le_of_eventually_monotone_of_tendsto_on_dense`. -/
+lemma limsup_stoppedValue_predictableConvexStep_ae_le_stoppedValue_predictablePartLim {ι Ω : Type*}
+    [TopologicalSpace ι] [T1Space ι] [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι]
+    [OrderBot ι] [OrderTop ι] [OrderTopology ι] [DenselyOrdered ι] {mΩ : MeasurableSpace Ω}
+    {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P)
+    (hs : Submartingale S 𝓕 P) {τ : Ω → WithTop ι} (hτ : IsStoppingTime 𝓕 τ)
+    (hc : ∀ᵐ ω ∂P, IsCadlag (S · ω)) :
+    limsup (fun n => stoppedValue (predictableConvexStep hd hs n) τ) atTop ≤ᵐ[P]
+      stoppedValue (predictablePartLim hd hs) τ := by
+  sorry
+
+/-- Prove that `∫ ω, stoppedValue 𝒜^n τ ω ∂P` converges to `∫ ω, stoppedValue A τ ω ∂P`. -/
+lemma integral_stoppedValue_predictableConvexStep_tendsto_stoppedValue_predictablePartLim
+    {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι] [SecondCountableTopology ι] [MeasurableSpace ι]
+    [LinearOrder ι] [OrderBot ι] [OrderTop ι] [OrderTopology ι] [DenselyOrdered ι]
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) {τ : Ω → WithTop ι}
+    (hτ : IsStoppingTime 𝓕 τ) :
+    Tendsto (fun n => ∫ ω, stoppedValue (predictableConvexStep hd hs n) τ ω ∂P) atTop
+      (𝓝 <| ∫ ω, stoppedValue (predictablePartLim hd hs) τ ω ∂P) := by
+  sorry
+
+/-- Reverse Fatou's lemma. See also `limsup_lintegral_le`. -/
+lemma limsup_integral_le_integral_limsup_of_tendsto_integral_posPart_sub {Ω : Type*}
+    {mΩ : MeasurableSpace Ω} {P : Measure Ω} {X : ℕ → Ω → ℝ} {Y : Ω → ℝ}
+    (hX_nonneg : ∀ n, 0 ≤ᵐ[P] X n) (hY : Integrable Y P) (hY_nonneg : 0 ≤ᵐ[P] Y)
+    (h_tendsto : Tendsto (fun n => ∫ ω, max (X n ω - Y ω) 0 ∂P) atTop (𝓝 0)) :
+    limsup (fun n => ∫ ω, X n ω ∂P) atTop ≤ ∫ ω, limsup (fun n => X n ω) atTop ∂P := by
+  sorry
+
+/-- For each stopping time `τ`, `limsup (fun n => stoppedValue 𝒜^n τ) atTop = stoppedValue A τ`
+almost everywhere. -/
+lemma limsup_stoppedValue_predictableConvexStep_ae_eq_stoppedValue_predictablePartLim {ι Ω : Type*}
+    [TopologicalSpace ι] [T1Space ι] [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι]
+    [OrderBot ι] [OrderTop ι] [OrderTopology ι] [DenselyOrdered ι] {mΩ : MeasurableSpace Ω}
+    {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P)
+    (hs : Submartingale S 𝓕 P) {τ : Ω → WithTop ι} (hτ : IsStoppingTime 𝓕 τ)
+    (hc : ∀ᵐ ω ∂P, IsCadlag (S · ω)) :
+    limsup (fun n => stoppedValue (predictableConvexStep hd hs n) τ) atTop =ᵐ[P]
+      stoppedValue (predictablePartLim hd hs) τ := by
+  refine (integral_eq_iff_of_ae_le ?_ ?_ ?_).1 ?_
+  · -- maybe it is better to first prove an analogue of `ae_eq_of_ae_le_of_lintegral_le` that
+    -- asssumes `0 ≤ f` instead of integrability of `f`.
+    sorry
+  · sorry
+  · exact
+      limsup_stoppedValue_predictableConvexStep_ae_le_stoppedValue_predictablePartLim hd hs hτ hc
+  · refine le_antisymm ?_ ?_
+    · refine integral_mono_of_nonneg ?_ ?_ ?_
+      · sorry
+      · sorry
+      · exact (limsup_stoppedValue_predictableConvexStep_ae_le_stoppedValue_predictablePartLim
+          hd hs hτ hc)
+    · calc
+      ∫ ω, stoppedValue (predictablePartLim hd hs) τ ω ∂P =
+        limsup (fun n => ∫ ω, stoppedValue (predictableConvexStep hd hs n) τ ω ∂P) atTop :=
+        ((integral_stoppedValue_predictableConvexStep_tendsto_stoppedValue_predictablePartLim
+          hd hs hτ).limsup_eq).symm
+        -- Use Fatou's lemma for the following sorry
+        -- We use integral instead of lintegral because
+        -- 1. `ae_eq_of_ae_le_of_lintegral_le` is the analogue of `ae_eq_of_ae_le_of_lintegral_le`,
+        -- but it still requires a proof that the lintegral is not equal to infinity.
+        -- 2. these processes are naturally real valued.
+        -- 3. I think it is useful to prove reverse Fatou's lemma for integral as one should be
+        -- able to apply for functions taking negative values.
+      _ ≤ _ := by sorry
+
+/-- Show that `fun t ω => limsup (predictableConvexStep hd hs · t ω` and `predictablePartLim hd hs`
+are indistinguishable. -/
+lemma limsup_predictableConvexStep_eq_predictablePartLim {ι Ω : Type*}
+    [TopologicalSpace ι] [T1Space ι] [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι]
+    [OrderBot ι] [OrderTop ι] [OrderTopology ι] [DenselyOrdered ι] {mΩ : MeasurableSpace Ω}
+    {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P)
+    (hs : Submartingale S 𝓕 P) {τ : Ω → WithTop ι} (hτ : IsStoppingTime 𝓕 τ) :
+    ∀ᵐ ω ∂P, ∀ t, limsup (predictableConvexStep hd hs · t ω) atTop =
+      predictablePartLim hd hs t ω := by
+  sorry
+
+end PredictablePartIsStronglyPredictable
+
+section DoobMeyer
+
+theorem ClassD.doob_meyer {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
+    [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    [SuccOrder ι] {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
+    {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P) :
+    ∃ (M A : ι → Ω → ℝ), S = M + A ∧ Martingale M 𝓕 P ∧ (∀ ω, IsCadlag (M · ω)) ∧
+      IsStronglyPredictable 𝓕 A ∧ (∀ ω, IsCadlag (A · ω)) ∧ (∀ ω, Monotone (A · ω)) := by
+  sorry
+
+end DoobMeyer
+
+variable {ι Ω : Type*} [LinearOrder ι] [OrderBot ι] [TopologicalSpace ι] [OrderTopology ι]
+  {mΩ : MeasurableSpace Ω} {P : Measure Ω} {X : ι → Ω → ℝ} {𝓕 : Filtration ι mΩ}
+  [MeasurableSpace ι]
+
+namespace ProbabilityTheory
+
 namespace IsLocalSubmartingale
 
 theorem doob_meyer (hX : IsLocalSubmartingale X 𝓕 P) (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
     ∃ (M A : ι → Ω → ℝ), X = M + A ∧ IsLocalMartingale M 𝓕 P ∧ (∀ ω, IsCadlag (M · ω)) ∧
-      IsStronglyPredictable 𝓕 A ∧ IsStronglyProgressive 𝓕 A ∧
-      (∀ ω, IsCadlag (A · ω)) ∧ (HasLocallyIntegrableSup A 𝓕 P) ∧
-      (∀ ω, Monotone (A · ω)) := by
+      IsStronglyProgressive 𝓕 A ∧ (∀ ω, IsCadlag (A · ω)) ∧ (HasLocallyIntegrableSup A 𝓕 P)
+      ∧ (∀ ω, Monotone (A · ω)) := by
   sorry
 
 /-- The local martingale part of the Doob-Meyer decomposition of the local submartingale. -/
@@ -3770,214 +4993,28 @@ lemma isLocalMartingale_martingalePart
     IsLocalMartingale (hX.martingalePart X hX_cadlag) 𝓕 P :=
   (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.1
 
-lemma cadlag_martingalePart (hX : IsLocalSubmartingale X 𝓕 P)
-    (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
+lemma cadlag_martingalePart (hX : IsLocalSubmartingale X 𝓕 P) (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
     ∀ ω, IsCadlag (hX.martingalePart X hX_cadlag · ω) :=
   (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.1
-
-lemma isStronglyPredictable_predictablePart
-    (hX : IsLocalSubmartingale X 𝓕 P) (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
-    IsStronglyPredictable 𝓕 (hX.predictablePart X hX_cadlag) :=
-  (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.2.1
 
 lemma isStronglyProgressive_predictablePart
     (hX : IsLocalSubmartingale X 𝓕 P) (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
     IsStronglyProgressive 𝓕 (hX.predictablePart X hX_cadlag) :=
-  (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.2.2.1
+  (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.2.1
 
-lemma cadlag_predictablePart (hX : IsLocalSubmartingale X 𝓕 P)
-    (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
+lemma cadlag_predictablePart (hX : IsLocalSubmartingale X 𝓕 P) (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
     ∀ ω, IsCadlag (hX.predictablePart X hX_cadlag · ω) :=
-  (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.2.2.2.1
+  (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.2.2.1
 
 lemma hasLocallyIntegrableSup_predictablePart
     (hX : IsLocalSubmartingale X 𝓕 P) (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
     HasLocallyIntegrableSup (hX.predictablePart X hX_cadlag) 𝓕 P :=
-  (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.2.2.2.2.1
+  (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.2.2.2.1
 
 lemma monotone_predictablePart (hX : IsLocalSubmartingale X 𝓕 P)
     (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
     ∀ ω, Monotone (hX.predictablePart X hX_cadlag · ω) :=
-  (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.2.2.2.2.2
-
-section Normalized
-
-variable {κ Ω' : Type*} [ConditionallyCompleteLinearOrderBot κ] [TopologicalSpace κ]
-  [OrderTopology κ] [MeasurableSpace κ] [BorelSpace κ] [PolishSpace κ]
-  {mΩ' : MeasurableSpace Ω'} {P' : Measure Ω'} {X' : κ → Ω' → ℝ}
-  {𝓕' : Filtration κ mΩ'} [IsFiniteMeasure P'] [Approximable 𝓕' P']
-  [𝓕'.IsComplete P'] [𝓕'.IsRightContinuous]
-
-/-- A normalized local Doob-Meyer decomposition whose predictable part starts from zero. -/
-theorem doob_meyer_normalized (hX : IsLocalSubmartingale X' 𝓕' P')
-    (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
-    ∃ (M A : κ → Ω' → ℝ), X' = M + A ∧ IsLocalMartingale M 𝓕' P' ∧
-      (∀ ω, IsCadlag (M · ω)) ∧ IsStronglyPredictable 𝓕' A ∧
-      IsStronglyProgressive 𝓕' A ∧ (∀ ω, IsCadlag (A · ω)) ∧
-      HasLocallyIntegrableSup A 𝓕' P' ∧ (∀ ω, Monotone (A · ω)) ∧
-      (∀ ω, A ⊥ ω = 0) := by
-  classical
-  rcases hX.doob_meyer hX_cadlag with
-    ⟨M, A, hXA, hM, hM_cadlag, hA_pred, hA_prog, hA_cadlag, hA_int, hA_mono⟩
-  let C : κ → Ω' → ℝ := fun _ ω => A ⊥ ω
-  have hC_pred : IsStronglyPredictable 𝓕' C := by
-    exact MeasureTheory.IsStronglyPredictable.const_fun (𝓕 := 𝓕')
-      (hA_prog.stronglyAdapted ⊥)
-  have hC_prog : IsStronglyProgressive 𝓕' C := by
-    intro i
-    exact ((hA_prog.stronglyAdapted ⊥).mono (𝓕'.mono bot_le)).comp_measurable measurable_snd
-  have hC_cadlag : ∀ ω, IsCadlag (C · ω) := by
-    intro ω
-    exact (continuous_const : Continuous fun _ : κ => A ⊥ ω).isCadlag
-  refine ⟨M + C, A - C, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_, ?_⟩
-  · ext t ω
-    rw [hXA]
-    simp only [Pi.add_apply, Pi.sub_apply, C]
-    ring
-  · -- Simultaneous localization makes the initial-value shift a local martingale.
-    exact hM.add_initial_of_hasLocallyIntegrableSup hA_prog hA_int
-  · intro ω
-    exact (hM_cadlag ω).add (hC_cadlag ω)
-  · simpa only [Pi.sub_apply] using hA_pred.sub hC_pred
-  · simpa only [Pi.sub_apply] using hA_prog.sub hC_prog
-  · intro ω
-    have hnegC : IsCadlag fun t : κ => (-1 : ℝ) • C t ω := (hC_cadlag ω).const_smul (-1)
-    have hadd : IsCadlag ((fun t : κ => A t ω) + fun t => (-1 : ℝ) • C t ω) :=
-      (hA_cadlag ω).add hnegC
-    simpa [sub_eq_add_neg, C] using hadd
-  · -- The locally integrable running supremum is stable under the normalization shift.
-    exact hA_int.sub_initial hA_prog
-  · intro ω i j hij
-    exact sub_le_sub_right (hA_mono ω hij) (A ⊥ ω)
-  · intro ω
-    simp [C]
-
-/-- The local martingale part of the Doob-Meyer decomposition of the local submartingale. -/
-noncomputable
-def normalizedMartingalePart (X : κ → Ω' → ℝ)
-    (hX : IsLocalSubmartingale X 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
-    κ → Ω' → ℝ :=
-  (hX.doob_meyer_normalized hX_cadlag).choose
-
-/-- The predictable part of the Doob-Meyer decomposition of the local submartingale. -/
-noncomputable
-def normalizedPredictablePart (X : κ → Ω' → ℝ)
-    (hX : IsLocalSubmartingale X 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
-    κ → Ω' → ℝ :=
-  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose
-
-lemma normalizedMartingalePart_add_normalizedPredictablePart
-    (hX : IsLocalSubmartingale X' 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
-    X' = hX.normalizedMartingalePart X' hX_cadlag
-      + hX.normalizedPredictablePart X' hX_cadlag :=
-  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose_spec.1
-
-lemma isLocalMartingale_normalizedMartingalePart
-    (hX : IsLocalSubmartingale X' 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
-    IsLocalMartingale (hX.normalizedMartingalePart X' hX_cadlag) 𝓕' P' :=
-  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose_spec.2.1
-
-lemma cadlag_normalizedMartingalePart
-    (hX : IsLocalSubmartingale X' 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
-    ∀ ω, IsCadlag (hX.normalizedMartingalePart X' hX_cadlag · ω) :=
-  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose_spec.2.2.1
-
-lemma isStronglyPredictable_normalizedPredictablePart
-    (hX : IsLocalSubmartingale X' 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
-    IsStronglyPredictable 𝓕' (hX.normalizedPredictablePart X' hX_cadlag) :=
-  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose_spec.2.2.2.1
-
-lemma isStronglyProgressive_normalizedPredictablePart
-    (hX : IsLocalSubmartingale X' 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
-    IsStronglyProgressive 𝓕' (hX.normalizedPredictablePart X' hX_cadlag) :=
-  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose_spec.2.2.2.2.1
-
-lemma cadlag_normalizedPredictablePart
-    (hX : IsLocalSubmartingale X' 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
-    ∀ ω, IsCadlag (hX.normalizedPredictablePart X' hX_cadlag · ω) :=
-  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose_spec.2.2.2.2.2.1
-
-lemma hasLocallyIntegrableSup_normalizedPredictablePart
-    (hX : IsLocalSubmartingale X' 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
-    HasLocallyIntegrableSup (hX.normalizedPredictablePart X' hX_cadlag) 𝓕' P' :=
-  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose_spec.2.2.2.2.2.2.1
-
-lemma monotone_normalizedPredictablePart (hX : IsLocalSubmartingale X' 𝓕' P')
-    (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
-    ∀ ω, Monotone (hX.normalizedPredictablePart X' hX_cadlag · ω) :=
-  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose_spec.2.2.2.2.2.2.2.1
-
-lemma normalizedPredictablePart_bot_eq_zero (hX : IsLocalSubmartingale X' 𝓕' P')
-    (hX_cadlag : ∀ ω, IsCadlag (X' · ω)) :
-    ∀ ω, hX.normalizedPredictablePart X' hX_cadlag ⊥ ω = 0 :=
-  (hX.doob_meyer_normalized hX_cadlag).choose_spec.choose_spec.2.2.2.2.2.2.2.2
-
-/-- Any normalized Doob-Meyer decomposition has the same predictable part as the choice-based
-normalized decomposition, at each deterministic time and almost surely. -/
-lemma normalizedPredictablePart_eq_of_normalized_decomposition
-    (hX : IsLocalSubmartingale X' 𝓕' P') (hX_cadlag : ∀ ω, IsCadlag (X' · ω))
-    {M A : κ → Ω' → ℝ} (hXA : X' = M + A)
-    (hM : IsLocalMartingale M 𝓕' P') (hM_cadlag : ∀ ω, IsCadlag (M · ω))
-    (hA_pred : IsStronglyPredictable 𝓕' A) (hA_prog : IsStronglyProgressive 𝓕' A)
-    (hA_cadlag : ∀ ω, IsCadlag (A · ω))
-    (hA_int : HasLocallyIntegrableSup A 𝓕' P') (hA_mono : ∀ ω, Monotone (A · ω))
-    (hA_zero : ∀ ω, A ⊥ ω = 0) (t : κ) :
-    hX.normalizedPredictablePart X' hX_cadlag t =ᵐ[P'] A t := by
-  let M0 : κ → Ω' → ℝ := hX.normalizedMartingalePart X' hX_cadlag
-  let A0 : κ → Ω' → ℝ := hX.normalizedPredictablePart X' hX_cadlag
-  have _hM_cadlag_used := hM_cadlag
-  have _hA_prog_used := hA_prog
-  have _hA_int_used := hA_int
-  have hchosen : X' = M0 + A0 := by
-    simpa [M0, A0] using hX.normalizedMartingalePart_add_normalizedPredictablePart
-      hX_cadlag
-  have hA0_eq : A0 - A = M - M0 := by
-    ext s ω
-    have hsum := congr_fun (congr_fun (hchosen.symm.trans hXA) s) ω
-    simp only [Pi.add_apply] at hsum
-    simp only [Pi.sub_apply]
-    linarith
-  have hN_mart : IsLocalMartingale (A0 - A) 𝓕' P' := by
-    rw [hA0_eq]
-    have hM0 : IsLocalMartingale M0 𝓕' P' := by
-      simpa [M0] using hX.isLocalMartingale_normalizedMartingalePart hX_cadlag
-    exact hM.sub hM0
-  have hN_cadlag : ∀ ω, IsCadlag ((A0 - A) · ω) := by
-    intro ω
-    have hA0_cad : IsCadlag (A0 · ω) := by
-      simpa [A0] using hX.cadlag_normalizedPredictablePart hX_cadlag ω
-    have hneg : IsCadlag (fun s : κ => (-1 : ℝ) • A s ω) :=
-      (hA_cadlag ω).const_smul (-1)
-    have hadd :
-        IsCadlag ((fun s : κ => A0 s ω) + fun s => (-1 : ℝ) • A s ω) :=
-      hA0_cad.add hneg
-    simpa [Pi.sub_apply, sub_eq_add_neg] using hadd
-  have hN_zero : ∀ ω, (A0 - A) ⊥ ω = 0 := by
-    intro ω
-    simp [A0, hX.normalizedPredictablePart_bot_eq_zero hX_cadlag ω, hA_zero ω]
-  have hN_pred : IsStronglyPredictable 𝓕' (A0 - A) := by
-    have hA0_pred : IsStronglyPredictable 𝓕' A0 := by
-      simpa [A0] using hX.isStronglyPredictable_normalizedPredictablePart hX_cadlag
-    exact hA0_pred.sub hA_pred
-  have hN_var : ∀ ω, LocallyBoundedVariationOn ((A0 - A) · ω) Set.univ := by
-    intro ω
-    have hA0_mono : Monotone (A0 · ω) := by
-      simpa [A0] using hX.monotone_normalizedPredictablePart hX_cadlag ω
-    have hA0_monoOn : MonotoneOn (A0 · ω) Set.univ :=
-      fun _ _ _ _ hst => hA0_mono hst
-    have hA_monoOn : MonotoneOn (A · ω) Set.univ :=
-      fun _ _ _ _ hst => hA_mono ω hst
-    exact hA0_monoOn.locallyBoundedVariationOn.sub
-      hA_monoOn.locallyBoundedVariationOn
-  have hzero :=
-    hN_mart.eq_zero_of_predictable_finiteVariation hN_cadlag hN_zero hN_pred hN_var t
-  filter_upwards [hzero] with ω hω
-  have hdiff : A0 t ω - A t ω = 0 := by
-    simpa [A0, Pi.sub_apply] using hω
-  change A0 t ω = A t ω
-  linarith
-
-end Normalized
+  (hX.doob_meyer hX_cadlag).choose_spec.choose_spec.2.2.2.2.2.2
 
 end IsLocalSubmartingale
 


### PR DESCRIPTION
## Summary

- Port the snapshot finite-variation uniqueness lane into `DoobMeyer.lean` additively.
- Preserve the existing upstream mesh/convex-step Doob-Meyer construction and public `ClassD` / `IsLocalSubmartingale` APIs.
- Add the martingale/local-martingale zero theorem for strongly predictable finite-variation processes.
- Add two small càdlàg closure lemmas used by the finite-variation normalization arguments.

## Upstreaming Notes

This replaces the earlier whole-file snapshot rewrite. The PR does not delete the upstream `DenseMesh`, `Estimate`, `UniformIntegrability`, `MartingalePartLimDef`, `PredictablePartLimDef`, `MonotoneLim`, `PredictableConvexStepPredictable`, or `PredictablePartIsStronglyPredictable` sections.

The old upstream Doob-Meyer placeholders remain in place. This PR adds the finite-variation uniqueness subgraph beside them, with the remaining new placeholder isolated at the bounded-continuous reduction step.

## Validation

```text
lake build BrownianMotion.StochasticIntegral.DoobMeyer
```
