### PR TITLE
Prove scalar multiplication for square-integrable martingales

### DIFF
--- a/BrownianMotion/StochasticIntegral/SquareIntegrable.lean
+++ b/BrownianMotion/StochasticIntegral/SquareIntegrable.lean
@@ -62,28 +62,15 @@ lemma IsSquareIntegrable.add [CompleteSpace E] (hX : IsSquareIntegrable X 𝓕 P
     _ < ∞ := ENNReal.add_lt_top.mpr ⟨hX_bound, hY_bound⟩
 
 lemma IsSquareIntegrable.smul [CompleteSpace E] (hX : IsSquareIntegrable X 𝓕 P) (r : ℝ) :
-    IsSquareIntegrable (fun i ω ↦ r • X i ω) 𝓕 P := by
-  refine
-    { martingale := ?_
-      cadlag := ?_
-      bounded := ?_ }
-  · simpa [Pi.smul_apply] using hX.martingale.smul r
-  · intro ω
+    IsSquareIntegrable (fun i ω ↦ r • X i ω) 𝓕 P where
+  martingale := by
+    simpa [Pi.smul_apply] using hX.martingale.smul r
+  cadlag ω := by
     simpa [Pi.smul_apply] using (hX.cadlag ω).const_smul r
-  · have h_bound :
-        (⨆ i, eLpNorm (r • X i) 2 P) ≤ ‖r‖ₑ * ⨆ i, eLpNorm (X i) 2 P := by
-      calc
-        ⨆ i, eLpNorm (r • X i) 2 P
-            = ⨆ i, ‖r‖ₑ * eLpNorm (X i) 2 P := by
-              simp_rw [eLpNorm_const_smul]
-        _ ≤ ‖r‖ₑ * ⨆ i, eLpNorm (X i) 2 P := by
-            refine iSup_le fun i ↦ ?_
-            gcongr
-            exact le_iSup (fun j ↦ eLpNorm (X j) 2 P) i
-    calc
-      ⨆ i, eLpNorm (r • X i) 2 P
-      _ ≤ ‖r‖ₑ * ⨆ i, eLpNorm (X i) 2 P := h_bound
-      _ < ∞ := ENNReal.mul_lt_top ENNReal.coe_lt_top hX.bounded
+  bounded := by
+    change (⨆ i, eLpNorm (r • X i) 2 P) < ∞
+    simpa [eLpNorm_const_smul, ENNReal.mul_iSup] using
+      ENNReal.mul_lt_top ENNReal.coe_lt_top hX.bounded
 
 variable [SigmaFiniteFiltration P 𝓕]
 

--- a/BrownianMotion/StochasticIntegral/SquareIntegrable.lean
+++ b/BrownianMotion/StochasticIntegral/SquareIntegrable.lean
@@ -61,9 +61,29 @@ lemma IsSquareIntegrable.add [CompleteSpace E] (hX : IsSquareIntegrable X 𝓕 P
         · exact le_iSup (fun i => eLpNorm (Y i) 2 P) i
     _ < ∞ := ENNReal.add_lt_top.mpr ⟨hX_bound, hY_bound⟩
 
-lemma IsSquareIntegrable.smul (hX : IsSquareIntegrable X 𝓕 P) (r : ℝ) :
+lemma IsSquareIntegrable.smul [CompleteSpace E] (hX : IsSquareIntegrable X 𝓕 P) (r : ℝ) :
     IsSquareIntegrable (fun i ω ↦ r • X i ω) 𝓕 P := by
-  sorry
+  refine
+    { martingale := ?_
+      cadlag := ?_
+      bounded := ?_ }
+  · simpa [Pi.smul_apply] using hX.martingale.smul r
+  · intro ω
+    simpa [Pi.smul_apply] using (hX.cadlag ω).const_smul r
+  · have h_bound :
+        (⨆ i, eLpNorm (r • X i) 2 P) ≤ ‖r‖ₑ * ⨆ i, eLpNorm (X i) 2 P := by
+      calc
+        ⨆ i, eLpNorm (r • X i) 2 P
+            = ⨆ i, ‖r‖ₑ * eLpNorm (X i) 2 P := by
+              simp_rw [eLpNorm_const_smul]
+        _ ≤ ‖r‖ₑ * ⨆ i, eLpNorm (X i) 2 P := by
+            refine iSup_le fun i ↦ ?_
+            gcongr
+            exact le_iSup (fun j ↦ eLpNorm (X j) 2 P) i
+    calc
+      ⨆ i, eLpNorm (r • X i) 2 P
+      _ ≤ ‖r‖ₑ * ⨆ i, eLpNorm (X i) 2 P := h_bound
+      _ < ∞ := ENNReal.mul_lt_top ENNReal.coe_lt_top hX.bounded
 
 variable [SigmaFiniteFiltration P 𝓕]
 


### PR DESCRIPTION
Proves `IsSquareIntegrable.smul`.

The added `[CompleteSpace E]` hypothesis comes from the scalar multiplication theorem for martingales.

Closes #467.