### PR TITLE
Add cadlag norm-square helper & close quadraticVariation sorry

### DIFF
--- a/BrownianMotion/StochasticIntegral/Cadlag.lean
+++ b/BrownianMotion/StochasticIntegral/Cadlag.lean
@@ -5,6 +5,7 @@ Authors: Rémy Degenne
 -/
 module
 
+public import Mathlib.Analysis.Normed.Group.Continuity
 public import Mathlib.Topology.Algebra.MulAction
 public import Mathlib.Topology.Instances.ENNReal.Lemmas
 public import Mathlib.Topology.MetricSpace.Bounded
@@ -143,6 +144,19 @@ lemma IsCadlag.const_smul {E : Type*} [SMul ℝ E] [TopologicalSpace E] [Continu
   refine ⟨fun i ↦ ContinuousWithinAt.const_smul (hf.1 i) r, fun i ↦ ?_⟩
   obtain ⟨l, hl⟩ := hf.2 i
   exact ⟨r • l, hl.const_smul r⟩
+
+lemma IsCadlag.continuous_comp {κ E F : Type*} [TopologicalSpace κ] [TopologicalSpace E]
+    [TopologicalSpace F] [Preorder κ] {g : E → F} {f : κ → E}
+    (hg : Continuous g) (hf : IsCadlag f) : IsCadlag (g ∘ f) where
+  right_continuous := Function.IsRightContinuous.continuous_comp hg hf.right_continuous
+  left_limit i := by
+    obtain ⟨l, hl⟩ := hf.left_limit i
+    exact ⟨g l, (hg.tendsto l).comp hl⟩
+
+lemma IsCadlag.norm_sq {κ F : Type*} [TopologicalSpace κ] [NormedAddCommGroup F] [Preorder κ]
+    {f : κ → F} (hf : IsCadlag f) : IsCadlag (fun i ↦ ‖f i‖ ^ 2) := by
+  change IsCadlag ((fun x : F ↦ ‖x‖ ^ 2) ∘ f)
+  exact IsCadlag.continuous_comp ((continuous_pow 2).comp continuous_norm) hf
 
 /-- A càdlàg function is locally bounded. -/
 lemma isLocallyBounded_of_isCadlag {E : Type*} [LinearOrder ι] [PseudoMetricSpace E]

--- a/BrownianMotion/StochasticIntegral/QuadraticVariation.lean
+++ b/BrownianMotion/StochasticIntegral/QuadraticVariation.lean
@@ -32,7 +32,8 @@ decomposition of its squared norm. -/
 noncomputable
 def quadraticVariation (hX : IsLocalMartingale X 𝓕 P) (hX_cadlag : ∀ ω, IsCadlag (X · ω)) :
     ι → Ω → ℝ :=
-  have hX2_cadlag : ∀ ω, IsCadlag (fun t ↦ ‖X t ω‖ ^ 2) := sorry
+  have hX2_cadlag : ∀ ω, IsCadlag (fun t ↦ ‖X t ω‖ ^ 2) :=
+    fun ω ↦ IsCadlag.norm_sq (hX_cadlag ω)
   (hX.isLocalSubmartingale_sq_norm hX_cadlag).predictablePart (fun t ω ↦ ‖X t ω‖ ^ 2) hX2_cadlag
 
 end ProbabilityTheory


### PR DESCRIPTION
Split out from #469.

Adds two small càdlàg path helpers:

- composition with a continuous function preserves càdlàg paths;
- the squared norm of a càdlàg path is càdlàg.

Uses the squared-norm helper to close the `hX2_cadlag` proof in `quadraticVariation`. 