### PR TITLE
feat: prove left continuity of the predictable step processes

### DIFF
--- a/BrownianMotion/Auxiliary/Algebra.lean
+++ b/BrownianMotion/Auxiliary/Algebra.lean
@@ -1,8 +1,15 @@
 module
 
+public import Mathlib.Algebra.Notation.Indicator
 public import Mathlib.LinearAlgebra.Dimension.Finite
 
 @[expose] public section
+
+-- TODO: remove if https://github.com/leanprover-community/mathlib4/pull/40909 has merged.
+lemma Set.indicator_apply_apply {ι Ω M : Type*} [Zero M] (s : Set ι) (f : ι → Ω → M) (i : ι)
+    (ω : Ω) :
+    s.indicator f i ω = s.indicator (fun j ↦ f j ω) i := by
+  by_cases h : i ∈ s <;> simp [h]
 
 theorem div_left_injective₀ {G₀ : Type*} [CommGroupWithZero G₀] {c : G₀} (hc : c ≠ 0) :
     Function.Injective fun x ↦ x / c := by

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -1064,21 +1064,59 @@ end PredictablePartLimMono
 
 section PredictableConvexStepPredictable
 
+/-- The indicator of a half-open interval `Ioc a b` with constant value `c` is left-continuous:
+when approached from the left it is eventually constant, so it is continuous within `Iio t` at `t`
+for every `t`. -/
+lemma continuousWithinAt_Iio_indicator_Ioc {α M : Type*} [LinearOrder α] [TopologicalSpace α]
+    [OrderTopology α] [Zero M] [TopologicalSpace M] (a b : α) (c : M) (t : α) :
+    ContinuousWithinAt ((Set.Ioc a b).indicator (fun _ ↦ c)) (Set.Iio t) t := by
+  refine (continuousWithinAt_const
+    (b := (Set.Ioc a b).indicator (fun _ ↦ c) t)).congr_of_eventuallyEq ?_ rfl
+  rcases le_or_gt t a with hta | hat
+  · refine eventually_nhdsWithin_of_forall fun x hx ↦ ?_
+    rw [Set.indicator_of_notMem fun h ↦ (not_lt.2 ((Set.mem_Iio.1 hx).le.trans hta)) h.1,
+      Set.indicator_of_notMem fun h ↦ (not_lt.2 hta) h.1]
+  · rcases le_or_gt t b with htb | hbt
+    · filter_upwards [self_mem_nhdsWithin, mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hat)]
+        with x hx_lt hx_gt
+      rw [Set.indicator_of_mem
+          (Set.mem_Ioc.2 ⟨Set.mem_Ioi.1 hx_gt, (Set.mem_Iio.1 hx_lt).le.trans htb⟩),
+        Set.indicator_of_mem (Set.mem_Ioc.2 ⟨hat, htb⟩)]
+    · filter_upwards [mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hbt)] with x hx_gt
+      rw [Set.indicator_of_notMem fun h ↦ (not_le.2 (Set.mem_Ioi.1 hx_gt)) h.2,
+        Set.indicator_of_notMem fun h ↦ (not_le.2 hbt) h.2]
+
 /-- The mesh step-extension of the discrete predictable part is left-continuous in time. -/
 lemma predictableSeqStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    [OrderTopology ι]
     {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
     {𝓕 : Filtration ι mΩ} (n : ℕ) (ω : Ω) (t : ι) :
     ContinuousWithinAt (fun s ↦ predictableSeqStep P S 𝓕 n s ω) (Set.Iio t) t := by
-  sorry
+  have hrw : (fun s ↦ predictableSeqStep P S 𝓕 n s ω)
+      = fun s ↦ ∑ u : mesh ι n, (meshPredIoc n u).indicator
+          (fun _ : ι ↦ predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P u ω) s := by
+    funext s
+    simp only [predictableSeqStep, Finset.sum_apply]
+    refine Finset.sum_congr rfl fun u _ ↦ ?_
+    by_cases hs : s ∈ meshPredIoc n u <;> simp [hs]
+  rw [hrw]
+  exact tendsto_finsetSum _ fun u _ ↦ continuousWithinAt_Iio_indicator_Ioc _ _ _ t
 
 /-- `predictableConvexStep` is left-continuous in time. -/
 lemma predictableConvexStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    [OrderTopology ι]
     {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
     {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) (ω : Ω) (t : ι) :
     ContinuousWithinAt (fun s ↦ predictableConvexStep hd hs n s ω) (Set.Iio t) t := by
-  sorry
+  have hrw : (fun s ↦ predictableConvexStep hd hs n s ω)
+      = fun s ↦ ∑ m ∈ (weight hd hs n).weights.support,
+          (weight hd hs n).weights m • predictableSeqStep P S 𝓕 m s ω := by
+    funext s
+    simp only [predictableConvexStep, Finsupp.sum, Finset.sum_apply, Pi.smul_apply]
+  rw [hrw]
+  exact tendsto_finsetSum _ fun m _ ↦ (predictableSeqStep_leftContinuous m ω t).const_smul _
 
 /-- The mesh step-extension of the discrete predictable part is strongly adapted. -/
 lemma stronglyAdapted_predictableSeqStep {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -1070,21 +1070,16 @@ for every `t`. -/
 lemma continuousWithinAt_Iio_indicator_Ioc {α M : Type*} [LinearOrder α] [TopologicalSpace α]
     [OrderTopology α] [Zero M] [TopologicalSpace M] (a b : α) (c : M) (t : α) :
     ContinuousWithinAt ((Set.Ioc a b).indicator (fun _ ↦ c)) (Set.Iio t) t := by
-  refine (continuousWithinAt_const
-    (b := (Set.Ioc a b).indicator (fun _ ↦ c) t)).congr_of_eventuallyEq ?_ rfl
+  refine continuousWithinAt_const.congr_of_eventuallyEq ?_ rfl
   rcases le_or_gt t a with hta | hat
-  · refine eventually_nhdsWithin_of_forall fun x hx ↦ ?_
-    rw [Set.indicator_of_notMem fun h ↦ (not_lt.2 ((Set.mem_Iio.1 hx).le.trans hta)) h.1,
-      Set.indicator_of_notMem fun h ↦ (not_lt.2 hta) h.1]
+  · filter_upwards [self_mem_nhdsWithin] with x hx
+    simp_all [hx.le.trans hta]
   · rcases le_or_gt t b with htb | hbt
     · filter_upwards [self_mem_nhdsWithin, mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hat)]
         with x hx_lt hx_gt
-      rw [Set.indicator_of_mem
-          (Set.mem_Ioc.2 ⟨Set.mem_Ioi.1 hx_gt, (Set.mem_Iio.1 hx_lt).le.trans htb⟩),
-        Set.indicator_of_mem (Set.mem_Ioc.2 ⟨hat, htb⟩)]
+      simp_all [hx_lt.le.trans htb]
     · filter_upwards [mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hbt)] with x hx_gt
-      rw [Set.indicator_of_notMem fun h ↦ (not_le.2 (Set.mem_Ioi.1 hx_gt)) h.2,
-        Set.indicator_of_notMem fun h ↦ (not_le.2 hbt) h.2]
+      simp_all
 
 /-- The mesh step-extension of the discrete predictable part is left-continuous in time. -/
 lemma predictableSeqStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -1068,7 +1068,7 @@ section PredictableConvexStepPredictable
 when approached from the left it is eventually constant, so it is continuous within `Iio t` at `t`
 for every `t`. -/
 lemma continuousWithinAt_Iio_indicator_Ioc {α M : Type*} [LinearOrder α] [TopologicalSpace α]
-    [OrderTopology α] [Zero M] [TopologicalSpace M] (a b : α) (c : M) (t : α) :
+    [ClosedIicTopology α] [Zero M] [TopologicalSpace M] (a b : α) (c : M) (t : α) :
     ContinuousWithinAt ((Set.Ioc a b).indicator (fun _ ↦ c)) (Set.Iio t) t := by
   refine continuousWithinAt_const.congr_of_eventuallyEq ?_ rfl
   rcases le_or_gt t a with hta | hat

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -5,6 +5,7 @@ Authors: Rémy Degenne
 -/
 module
 
+public import BrownianMotion.Auxiliary.Algebra
 public import BrownianMotion.StochasticIntegral.ClassD
 public import BrownianMotion.StochasticIntegral.Komlos
 public import BrownianMotion.StochasticIntegral.Predictable
@@ -1039,6 +1040,14 @@ end MonotoneLim
 
 section PredictablePartLimMono
 
+lemma predictableSeqStep_eq_sum_indicator {ι Ω : Type*} [TopologicalSpace ι]
+    [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
+    (P : Measure Ω) (S : ι → Ω → ℝ) (𝓕 : Filtration ι mΩ) (n : ℕ) (ω : Ω) (t : ι) :
+    predictableSeqStep P S 𝓕 n t ω = ∑ v : mesh ι n, (meshPredIoc n v).indicator
+      (fun _ : ι ↦ predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P v ω) t := by
+  simp only [predictableSeqStep, Finset.sum_apply]
+  exact Finset.sum_congr rfl fun v _ ↦ Set.indicator_apply_apply _ _ t ω
+
 lemma predictableSeqStep_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
     {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
@@ -1063,10 +1072,6 @@ lemma predictablePartLim_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Sp
 end PredictablePartLimMono
 
 section PredictableConvexStepPredictable
-
-lemma Set.indicator_eval {ι Ω M : Type*} [Zero M] (s : Set ι) (f : ι → Ω → M) (i : ι) (ω : Ω) :
-    s.indicator f i ω = s.indicator (fun j ↦ f j ω) i := by
-  by_cases h : i ∈ s <;> simp [h]
 
 /-- The indicator of a half-open interval `Ioc a b` with constant value `c` is left-continuous:
 when approached from the left it is eventually constant, so it is continuous within `Iio t` at `t`
@@ -1097,7 +1102,7 @@ lemma predictableSeqStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T
           (fun _ : ι ↦ predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P u ω) s := by
     funext s
     simp only [predictableSeqStep, Finset.sum_apply]
-    exact Finset.sum_congr rfl fun u _ ↦ Set.indicator_eval _ _ s ω
+    exact Finset.sum_congr rfl fun u _ ↦ Set.indicator_apply_apply _ _ s ω
   rw [hrw]
   exact tendsto_finsetSum _ fun u _ ↦ continuousWithinAt_Iio_indicator_Ioc _ _ _ t
 

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -1064,6 +1064,10 @@ end PredictablePartLimMono
 
 section PredictableConvexStepPredictable
 
+lemma Set.indicator_eval {ι Ω M : Type*} [Zero M] (s : Set ι) (f : ι → Ω → M) (i : ι) (ω : Ω) :
+    s.indicator f i ω = s.indicator (fun j ↦ f j ω) i := by
+  by_cases h : i ∈ s <;> simp [h]
+
 /-- The indicator of a half-open interval `Ioc a b` with constant value `c` is left-continuous:
 when approached from the left it is eventually constant, so it is continuous within `Iio t` at `t`
 for every `t`. -/
@@ -1093,8 +1097,7 @@ lemma predictableSeqStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T
           (fun _ : ι ↦ predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P u ω) s := by
     funext s
     simp only [predictableSeqStep, Finset.sum_apply]
-    refine Finset.sum_congr rfl fun u _ ↦ ?_
-    by_cases hs : s ∈ meshPredIoc n u <;> simp [hs]
+    exact Finset.sum_congr rfl fun u _ ↦ Set.indicator_eval _ _ s ω
   rw [hrw]
   exact tendsto_finsetSum _ fun u _ ↦ continuousWithinAt_Iio_indicator_Ioc _ _ _ t
 

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -1084,7 +1084,7 @@ lemma continuousWithinAt_Iio_indicator_Ioc {α M : Type*} [LinearOrder α] [Topo
 /-- The mesh step-extension of the discrete predictable part is left-continuous in time. -/
 lemma predictableSeqStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    [OrderTopology ι]
+    [ClosedIicTopology ι]
     {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
     {𝓕 : Filtration ι mΩ} (n : ℕ) (ω : Ω) (t : ι) :
     ContinuousWithinAt (fun s ↦ predictableSeqStep P S 𝓕 n s ω) (Set.Iio t) t := by
@@ -1101,7 +1101,7 @@ lemma predictableSeqStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T
 /-- `predictableConvexStep` is left-continuous in time. -/
 lemma predictableConvexStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    [OrderTopology ι]
+    [ClosedIicTopology ι]
     {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
     {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) (ω : Ω) (t : ι) :
     ContinuousWithinAt (fun s ↦ predictableConvexStep hd hs n s ω) (Set.Iio t) t := by


### PR DESCRIPTION
Proves the two `sorry`s in `DoobMeyer.lean` for left continuity of the predictable
step processes: `predictableSeqStep_leftContinuous` and
`predictableConvexStep_leftContinuous`. Both follow from a small new lemma,
`continuousWithinAt_Iio_indicator_Ioc`, that the indicator of an `Ioc a b` is left
continuous; the step processes are finite sums / convex combinations of such indicators.

## Statement change: added `[OrderTopology ι]`

Both lemmas lacked any link between the order and the topology on `ι`, but their
conclusion pairs `Iio t` with continuity — without `OrderTopology` an `Ioc`-indicator
need not be left continuous, so I don't think they hold as stated.

Closes #455
