### PR TITLE
feat: (part of the) monotonicity of the predictable step processes (Issue #454)

### DIFF
--- a/BrownianMotion/Auxiliary/Algebra.lean
+++ b/BrownianMotion/Auxiliary/Algebra.lean
@@ -1,8 +1,15 @@
 module
 
+public import Mathlib.Algebra.Notation.Indicator
 public import Mathlib.LinearAlgebra.Dimension.Finite
 
 @[expose] public section
+
+-- TODO: remove if https://github.com/leanprover-community/mathlib4/pull/40909 has merged.
+lemma Set.indicator_apply_apply {ι Ω M : Type*} [Zero M] (s : Set ι) (f : ι → Ω → M) (i : ι)
+    (ω : Ω) :
+    s.indicator f i ω = s.indicator (fun j ↦ f j ω) i := by
+  by_cases h : i ∈ s <;> simp [h]
 
 theorem div_left_injective₀ {G₀ : Type*} [CommGroupWithZero G₀] {c : G₀} (hc : c ≠ 0) :
     Function.Injective fun x ↦ x / c := by

--- a/BrownianMotion/Auxiliary/Algebra.lean
+++ b/BrownianMotion/Auxiliary/Algebra.lean
@@ -1,8 +1,5 @@
 module
 
-public import Mathlib.Algebra.Notation.Indicator
-public import Mathlib.Algebra.Order.BigOperators.Group.Finset
-public import Mathlib.Algebra.Order.Module.Defs
 public import Mathlib.LinearAlgebra.Dimension.Finite
 
 @[expose] public section

--- a/BrownianMotion/Auxiliary/Algebra.lean
+++ b/BrownianMotion/Auxiliary/Algebra.lean
@@ -1,6 +1,8 @@
 module
 
 public import Mathlib.Algebra.Notation.Indicator
+public import Mathlib.Algebra.Order.BigOperators.Group.Finset
+public import Mathlib.Algebra.Order.Module.Defs
 public import Mathlib.LinearAlgebra.Dimension.Finite
 
 @[expose] public section
@@ -10,6 +12,18 @@ lemma Set.indicator_apply_apply {ι Ω M : Type*} [Zero M] (s : Set ι) (f : ι 
     (ω : Ω) :
     s.indicator f i ω = s.indicator (fun j ↦ f j ω) i := by
   by_cases h : i ∈ s <;> simp [h]
+
+/-- A finite sum of monotone functions is monotone. -/
+lemma Monotone.finset_sum {ι κ M : Type*} [Preorder ι] [AddCommMonoid M] [Preorder M]
+    [AddLeftMono M] {s : Finset κ} {f : κ → ι → M} (hf : ∀ k ∈ s, Monotone (f k)) :
+    Monotone fun i ↦ ∑ k ∈ s, f k i :=
+  fun _ _ hab ↦ Finset.sum_le_sum fun k hk ↦ hf k hk hab
+
+/-- Scalar multiplication by a nonnegative element preserves monotonicity. -/
+lemma Monotone.const_smul_of_nonneg {ι α M : Type*} [Preorder ι] [Preorder α] [Preorder M]
+    [Zero α] [SMul α M] [PosSMulMono α M] {f : ι → M} (hf : Monotone f) {c : α} (hc : 0 ≤ c) :
+    Monotone fun i ↦ c • f i :=
+  fun _ _ hab ↦ smul_le_smul_of_nonneg_left (hf hab) hc
 
 theorem div_left_injective₀ {G₀ : Type*} [CommGroupWithZero G₀] {c : G₀} (hc : c ≠ 0) :
     Function.Injective fun x ↦ x / c := by

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -1064,21 +1064,59 @@ end PredictablePartLimMono
 
 section PredictableConvexStepPredictable
 
+/-- The indicator of a half-open interval `Ioc a b` with constant value `c` is left-continuous:
+when approached from the left it is eventually constant, so it is continuous within `Iio t` at `t`
+for every `t`. -/
+lemma continuousWithinAt_Iio_indicator_Ioc {α M : Type*} [LinearOrder α] [TopologicalSpace α]
+    [OrderTopology α] [Zero M] [TopologicalSpace M] (a b : α) (c : M) (t : α) :
+    ContinuousWithinAt ((Set.Ioc a b).indicator (fun _ ↦ c)) (Set.Iio t) t := by
+  refine (continuousWithinAt_const
+    (b := (Set.Ioc a b).indicator (fun _ ↦ c) t)).congr_of_eventuallyEq ?_ rfl
+  rcases le_or_gt t a with hta | hat
+  · refine eventually_nhdsWithin_of_forall fun x hx ↦ ?_
+    rw [Set.indicator_of_notMem fun h ↦ (not_lt.2 ((Set.mem_Iio.1 hx).le.trans hta)) h.1,
+      Set.indicator_of_notMem fun h ↦ (not_lt.2 hta) h.1]
+  · rcases le_or_gt t b with htb | hbt
+    · filter_upwards [self_mem_nhdsWithin, mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hat)]
+        with x hx_lt hx_gt
+      rw [Set.indicator_of_mem
+          (Set.mem_Ioc.2 ⟨Set.mem_Ioi.1 hx_gt, (Set.mem_Iio.1 hx_lt).le.trans htb⟩),
+        Set.indicator_of_mem (Set.mem_Ioc.2 ⟨hat, htb⟩)]
+    · filter_upwards [mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hbt)] with x hx_gt
+      rw [Set.indicator_of_notMem fun h ↦ (not_le.2 (Set.mem_Ioi.1 hx_gt)) h.2,
+        Set.indicator_of_notMem fun h ↦ (not_le.2 hbt) h.2]
+
 /-- The mesh step-extension of the discrete predictable part is left-continuous in time. -/
 lemma predictableSeqStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    [OrderTopology ι]
     {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
     {𝓕 : Filtration ι mΩ} (n : ℕ) (ω : Ω) (t : ι) :
     ContinuousWithinAt (fun s ↦ predictableSeqStep P S 𝓕 n s ω) (Set.Iio t) t := by
-  sorry
+  have hrw : (fun s ↦ predictableSeqStep P S 𝓕 n s ω)
+      = fun s ↦ ∑ u : mesh ι n, (meshPredIoc n u).indicator
+          (fun _ : ι ↦ predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P u ω) s := by
+    funext s
+    simp only [predictableSeqStep, Finset.sum_apply]
+    refine Finset.sum_congr rfl fun u _ ↦ ?_
+    by_cases hs : s ∈ meshPredIoc n u <;> simp [hs]
+  rw [hrw]
+  exact tendsto_finsetSum _ fun u _ ↦ continuousWithinAt_Iio_indicator_Ioc _ _ _ t
 
 /-- `predictableConvexStep` is left-continuous in time. -/
 lemma predictableConvexStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
+    [OrderTopology ι]
     {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
     {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) (ω : Ω) (t : ι) :
     ContinuousWithinAt (fun s ↦ predictableConvexStep hd hs n s ω) (Set.Iio t) t := by
-  sorry
+  have hrw : (fun s ↦ predictableConvexStep hd hs n s ω)
+      = fun s ↦ ∑ m ∈ (weight hd hs n).weights.support,
+          (weight hd hs n).weights m • predictableSeqStep P S 𝓕 m s ω := by
+    funext s
+    simp only [predictableConvexStep, Finsupp.sum, Finset.sum_apply, Pi.smul_apply]
+  rw [hrw]
+  exact tendsto_finsetSum _ fun m _ ↦ (predictableSeqStep_leftContinuous m ω t).const_smul _
 
 /-- The mesh step-extension of the discrete predictable part is strongly adapted. -/
 lemma stronglyAdapted_predictableSeqStep {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -1070,21 +1070,16 @@ for every `t`. -/
 lemma continuousWithinAt_Iio_indicator_Ioc {α M : Type*} [LinearOrder α] [TopologicalSpace α]
     [OrderTopology α] [Zero M] [TopologicalSpace M] (a b : α) (c : M) (t : α) :
     ContinuousWithinAt ((Set.Ioc a b).indicator (fun _ ↦ c)) (Set.Iio t) t := by
-  refine (continuousWithinAt_const
-    (b := (Set.Ioc a b).indicator (fun _ ↦ c) t)).congr_of_eventuallyEq ?_ rfl
+  refine continuousWithinAt_const.congr_of_eventuallyEq ?_ rfl
   rcases le_or_gt t a with hta | hat
-  · refine eventually_nhdsWithin_of_forall fun x hx ↦ ?_
-    rw [Set.indicator_of_notMem fun h ↦ (not_lt.2 ((Set.mem_Iio.1 hx).le.trans hta)) h.1,
-      Set.indicator_of_notMem fun h ↦ (not_lt.2 hta) h.1]
+  · filter_upwards [self_mem_nhdsWithin] with x hx
+    simp_all [hx.le.trans hta]
   · rcases le_or_gt t b with htb | hbt
     · filter_upwards [self_mem_nhdsWithin, mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hat)]
         with x hx_lt hx_gt
-      rw [Set.indicator_of_mem
-          (Set.mem_Ioc.2 ⟨Set.mem_Ioi.1 hx_gt, (Set.mem_Iio.1 hx_lt).le.trans htb⟩),
-        Set.indicator_of_mem (Set.mem_Ioc.2 ⟨hat, htb⟩)]
+      simp_all [hx_lt.le.trans htb]
     · filter_upwards [mem_nhdsWithin_of_mem_nhds (Ioi_mem_nhds hbt)] with x hx_gt
-      rw [Set.indicator_of_notMem fun h ↦ (not_le.2 (Set.mem_Ioi.1 hx_gt)) h.2,
-        Set.indicator_of_notMem fun h ↦ (not_le.2 hbt) h.2]
+      simp_all
 
 /-- The mesh step-extension of the discrete predictable part is left-continuous in time. -/
 lemma predictableSeqStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -1068,7 +1068,7 @@ section PredictableConvexStepPredictable
 when approached from the left it is eventually constant, so it is continuous within `Iio t` at `t`
 for every `t`. -/
 lemma continuousWithinAt_Iio_indicator_Ioc {α M : Type*} [LinearOrder α] [TopologicalSpace α]
-    [OrderTopology α] [Zero M] [TopologicalSpace M] (a b : α) (c : M) (t : α) :
+    [ClosedIicTopology α] [Zero M] [TopologicalSpace M] (a b : α) (c : M) (t : α) :
     ContinuousWithinAt ((Set.Ioc a b).indicator (fun _ ↦ c)) (Set.Iio t) t := by
   refine continuousWithinAt_const.congr_of_eventuallyEq ?_ rfl
   rcases le_or_gt t a with hta | hat

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -1055,20 +1055,19 @@ lemma predictableSeqStep_apply {ι Ω : Type*} [TopologicalSpace ι] [SecondCoun
     (S : ι → Ω → ℝ) (𝓕 : Filtration ι mΩ) (n : ℕ) (ω : Ω) {t : ι} {u : mesh ι n}
     (ht : t ∈ meshPredIoc n u) :
     predictableSeqStep P S 𝓕 n t ω
-      = _root_.predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P u ω := by
-  have h : predictableSeqStep P S 𝓕 n t ω = ∑ v : mesh ι n, (meshPredIoc n v).indicator
-      (fun _ : ι ↦ _root_.predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P v ω) t := by
-    simp only [predictableSeqStep, Finset.sum_apply]
-    exact Finset.sum_congr rfl fun v _ ↦ by by_cases hv : t ∈ meshPredIoc n v <;> simp [hv]
-  rw [h, Finset.sum_eq_single_of_mem u (Finset.mem_univ _) fun v _ hv ↦
-    Set.indicator_of_notMem (fun hv' ↦ hv (by
-      rcases lt_trichotomy v u with h' | h' | h'
-      · exact absurd (lt_of_le_of_lt hv'.2 (lt_of_le_of_lt
-          (Subtype.coe_le_coe.2 (Order.le_pred_of_lt h')) ht.1)) (lt_irrefl t)
-      · exact h'
-      · exact absurd (lt_of_le_of_lt ht.2 (lt_of_le_of_lt
-          (Subtype.coe_le_coe.2 (Order.le_pred_of_lt h')) hv'.1)) (lt_irrefl t))) _,
-    Set.indicator_of_mem ht]
+      = predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P u ω := by
+  rw [predictableSeqStep_eq_sum_indicator,
+    Finset.sum_eq_single_of_mem u (Finset.mem_univ _) ?_, Set.indicator_of_mem ht]
+  intro v _ hvu
+  apply Set.indicator_of_notMem
+  intro hv
+  apply hvu
+  rcases lt_trichotomy v u with h' | h' | h'
+  · exact absurd (lt_of_le_of_lt hv.2 (lt_of_le_of_lt
+      (Subtype.coe_le_coe.2 (Order.le_pred_of_lt h')) ht.1)) (lt_irrefl t)
+  · exact h'
+  · exact absurd (lt_of_le_of_lt ht.2 (lt_of_le_of_lt
+      (Subtype.coe_le_coe.2 (Order.le_pred_of_lt h')) hv.1)) (lt_irrefl t)
 
 lemma predictableSeqStep_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
@@ -1077,23 +1076,21 @@ lemma predictableSeqStep_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Sp
     ∀ᵐ ω ∂P, Monotone fun t ↦ predictableSeqStep P S 𝓕 n t ω := by
   have hsub : Submartingale (S ∘ Subtype.val) (meshFiltration 𝓕 n) P :=
     hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
-  have hne : ∀ s : ι, (Finset.univ.filter fun u : mesh ι n ↦ s ≤ (u : ι)).Nonempty :=
-    fun s ↦ ⟨⊤, by simp⟩
+  have hne (s : ι) : (Finset.univ.filter fun u : mesh ι n ↦ s ≤ (u : ι)).Nonempty := ⟨⊤, by simp⟩
   set ceil : ι → mesh ι n :=
     fun s ↦ (Finset.univ.filter fun u : mesh ι n ↦ s ≤ (u : ι)).min' (hne s)
-  have hne (s : ι) : (Finset.univ.filter fun u : mesh ι n ↦ s ≤ (u : ι)).Nonempty := ⟨⊤, by simp⟩
-  have hle : ∀ (s : ι) (u : mesh ι n), s ≤ (u : ι) → ceil s ≤ u :=
-    fun s u hu ↦ Finset.min'_le _ u (Finset.mem_filter.2 ⟨Finset.mem_univ u, hu⟩)
+  have hmem (s : ι) : s ≤ (ceil s : ι) := (Finset.mem_filter.1 (Finset.min'_mem _ (hne s))).2
+  have hle (s : ι) (u : mesh ι n) (hu : s ≤ (u : ι)) : ceil s ≤ u :=
+    Finset.min'_le _ u (Finset.mem_filter.2 ⟨Finset.mem_univ u, hu⟩)
   filter_upwards [hsub.monotone_predictablePart_ae] with ω hmono
   have hval : ∀ s : ι, predictableSeqStep P S 𝓕 n s ω
-      = _root_.predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P (ceil s) ω := by
+      = predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P (ceil s) ω := by
     intro s
     rcases eq_or_ne s ⊥ with rfl | hs0
-    · rw [show ceil ⊥ = ⊥ from le_antisymm (hle ⊥ ⊥ (by simp)) bot_le,
-        predictablePart_bot, Pi.zero_apply]
-      simp only [predictableSeqStep, Finset.sum_apply]
-      exact Finset.sum_eq_zero fun u _ ↦ by
-        rw [Set.indicator_of_notMem fun h ↦ absurd h.1 (not_lt.2 bot_le), Pi.zero_apply]
+    · have hceil : ceil ⊥ = ⊥ := le_antisymm (hle ⊥ ⊥ (by simp)) bot_le
+      rw [hceil, predictablePart_bot, Pi.zero_apply, predictableSeqStep_eq_sum_indicator]
+      refine Finset.sum_eq_zero fun u _ ↦ ?_
+      apply Set.indicator_of_notMem fun h ↦ absurd h.1 (not_lt.2 bot_le)
     · refine predictableSeqStep_apply P S 𝓕 n ω (Set.mem_Ioc.2 ⟨?_, hmem s⟩)
       have hcne : ceil s ≠ ⊥ := by
         intro hc
@@ -1113,10 +1110,10 @@ lemma predictableConvexStep_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T
     ∀ᵐ ω ∂P, Monotone fun t ↦ predictableConvexStep hd hs n t ω := by
   have key : ∀ᵐ ω ∂P, ∀ m : ℕ, Monotone fun s ↦ predictableSeqStep P S 𝓕 m s ω :=
     ae_all_iff.2 fun m ↦ predictableSeqStep_monotone_ae hs m
-  filter_upwards [key] with ω hω s₁ s₂ hs12
+  filter_upwards [key] with ω hω
   simp only [predictableConvexStep, Finsupp.sum, Finset.sum_apply, Pi.smul_apply]
-  exact Finset.sum_le_sum fun m _ ↦
-    smul_le_smul_of_nonneg_left (hω m hs12) ((weight hd hs n).weights_nonneg m)
+  exact Monotone.finset_sum fun m _ ↦
+    (hω m).const_smul_of_nonneg ((weight hd hs n).weights_nonneg m)
 
 lemma predictablePartLim_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -5,6 +5,7 @@ Authors: Rémy Degenne
 -/
 module
 
+public import BrownianMotion.Auxiliary.Algebra
 public import BrownianMotion.StochasticIntegral.ClassD
 public import BrownianMotion.StochasticIntegral.Komlos
 public import BrownianMotion.StochasticIntegral.Predictable
@@ -1039,6 +1040,14 @@ end MonotoneLim
 
 section PredictablePartLimMono
 
+lemma predictableSeqStep_eq_sum_indicator {ι Ω : Type*} [TopologicalSpace ι]
+    [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
+    (P : Measure Ω) (S : ι → Ω → ℝ) (𝓕 : Filtration ι mΩ) (n : ℕ) (ω : Ω) (t : ι) :
+    predictableSeqStep P S 𝓕 n t ω = ∑ v : mesh ι n, (meshPredIoc n v).indicator
+      (fun _ : ι ↦ predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P v ω) t := by
+  simp only [predictableSeqStep, Finset.sum_apply]
+  exact Finset.sum_congr rfl fun v _ ↦ Set.indicator_apply_apply _ _ t ω
+
 lemma predictableSeqStep_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
     {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
@@ -1063,10 +1072,6 @@ lemma predictablePartLim_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Sp
 end PredictablePartLimMono
 
 section PredictableConvexStepPredictable
-
-lemma Set.indicator_eval {ι Ω M : Type*} [Zero M] (s : Set ι) (f : ι → Ω → M) (i : ι) (ω : Ω) :
-    s.indicator f i ω = s.indicator (fun j ↦ f j ω) i := by
-  by_cases h : i ∈ s <;> simp [h]
 
 /-- The indicator of a half-open interval `Ioc a b` with constant value `c` is left-continuous:
 when approached from the left it is eventually constant, so it is continuous within `Iio t` at `t`
@@ -1097,7 +1102,7 @@ lemma predictableSeqStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T
           (fun _ : ι ↦ predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P u ω) s := by
     funext s
     simp only [predictableSeqStep, Finset.sum_apply]
-    exact Finset.sum_congr rfl fun u _ ↦ Set.indicator_eval _ _ s ω
+    exact Finset.sum_congr rfl fun u _ ↦ Set.indicator_apply_apply _ _ s ω
   rw [hrw]
   exact tendsto_finsetSum _ fun u _ ↦ continuousWithinAt_Iio_indicator_Ioc _ _ _ t
 

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -1064,6 +1064,10 @@ end PredictablePartLimMono
 
 section PredictableConvexStepPredictable
 
+lemma Set.indicator_eval {ι Ω M : Type*} [Zero M] (s : Set ι) (f : ι → Ω → M) (i : ι) (ω : Ω) :
+    s.indicator f i ω = s.indicator (fun j ↦ f j ω) i := by
+  by_cases h : i ∈ s <;> simp [h]
+
 /-- The indicator of a half-open interval `Ioc a b` with constant value `c` is left-continuous:
 when approached from the left it is eventually constant, so it is continuous within `Iio t` at `t`
 for every `t`. -/
@@ -1093,8 +1097,7 @@ lemma predictableSeqStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T
           (fun _ : ι ↦ predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P u ω) s := by
     funext s
     simp only [predictableSeqStep, Finset.sum_apply]
-    refine Finset.sum_congr rfl fun u _ ↦ ?_
-    by_cases hs : s ∈ meshPredIoc n u <;> simp [hs]
+    exact Finset.sum_congr rfl fun u _ ↦ Set.indicator_eval _ _ s ω
   rw [hrw]
   exact tendsto_finsetSum _ fun u _ ↦ continuousWithinAt_Iio_indicator_Ioc _ _ _ t
 

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -1084,7 +1084,7 @@ lemma continuousWithinAt_Iio_indicator_Ioc {α M : Type*} [LinearOrder α] [Topo
 /-- The mesh step-extension of the discrete predictable part is left-continuous in time. -/
 lemma predictableSeqStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    [OrderTopology ι]
+    [ClosedIicTopology ι]
     {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
     {𝓕 : Filtration ι mΩ} (n : ℕ) (ω : Ω) (t : ι) :
     ContinuousWithinAt (fun s ↦ predictableSeqStep P S 𝓕 n s ω) (Set.Iio t) t := by
@@ -1101,7 +1101,7 @@ lemma predictableSeqStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T
 /-- `predictableConvexStep` is left-continuous in time. -/
 lemma predictableConvexStep_leftContinuous {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
-    [OrderTopology ι]
+    [ClosedIicTopology ι]
     {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
     {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) (ω : Ω) (t : ι) :
     ContinuousWithinAt (fun s ↦ predictableConvexStep hd hs n s ω) (Set.Iio t) t := by

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -1048,19 +1048,79 @@ lemma predictableSeqStep_eq_sum_indicator {ι Ω : Type*} [TopologicalSpace ι]
   simp only [predictableSeqStep, Finset.sum_apply]
   exact Finset.sum_congr rfl fun v _ ↦ Set.indicator_apply_apply _ _ t ω
 
+/-- On the mesh cell `Ioc (pred u) u` containing `t`, the step process `predictableSeqStep` is
+constant, equal to the discrete predictable part at the cell's right endpoint `u`. -/
+lemma predictableSeqStep_apply {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
+    [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (P : Measure Ω)
+    (S : ι → Ω → ℝ) (𝓕 : Filtration ι mΩ) (n : ℕ) (ω : Ω) {t : ι} {u : mesh ι n}
+    (ht : t ∈ meshPredIoc n u) :
+    predictableSeqStep P S 𝓕 n t ω
+      = _root_.predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P u ω := by
+  have h : predictableSeqStep P S 𝓕 n t ω = ∑ v : mesh ι n, (meshPredIoc n v).indicator
+      (fun _ : ι ↦ _root_.predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P v ω) t := by
+    simp only [predictableSeqStep, Finset.sum_apply]
+    exact Finset.sum_congr rfl fun v _ ↦ by by_cases hv : t ∈ meshPredIoc n v <;> simp [hv]
+  rw [h, Finset.sum_eq_single_of_mem u (Finset.mem_univ _) fun v _ hv ↦
+    Set.indicator_of_notMem (fun hv' ↦ hv (by
+      rcases lt_trichotomy v u with h' | h' | h'
+      · exact absurd (lt_of_le_of_lt hv'.2 (lt_of_le_of_lt
+          (Subtype.coe_le_coe.2 (Order.le_pred_of_lt h')) ht.1)) (lt_irrefl t)
+      · exact h'
+      · exact absurd (lt_of_le_of_lt ht.2 (lt_of_le_of_lt
+          (Subtype.coe_le_coe.2 (Order.le_pred_of_lt h')) hv'.1)) (lt_irrefl t))) _,
+    Set.indicator_of_mem ht]
+
 lemma predictableSeqStep_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
     {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P) (n : ℕ) (t : ι) :
+    {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P) (n : ℕ) (_t : ι) :
     ∀ᵐ ω ∂P, Monotone fun t ↦ predictableSeqStep P S 𝓕 n t ω := by
-  sorry
+  have hsub : Submartingale (S ∘ Subtype.val) (meshFiltration 𝓕 n) P :=
+    hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
+  have hne : ∀ s : ι, (Finset.univ.filter fun u : mesh ι n ↦ s ≤ (u : ι)).Nonempty :=
+    fun s ↦ ⟨⊤, by simp⟩
+  set ceil : ι → mesh ι n :=
+    fun s ↦ (Finset.univ.filter fun u : mesh ι n ↦ s ≤ (u : ι)).min' (hne s)
+  have hmem : ∀ s : ι, s ≤ (ceil s : ι) :=
+    fun s ↦ (Finset.mem_filter.1 (Finset.min'_mem _ (hne s))).2
+  have hle : ∀ (s : ι) (u : mesh ι n), s ≤ (u : ι) → ceil s ≤ u :=
+    fun s u hu ↦ Finset.min'_le _ u (Finset.mem_filter.2 ⟨Finset.mem_univ u, hu⟩)
+  filter_upwards [hsub.monotone_predictablePart_ae] with ω hmono
+  have hval : ∀ s : ι, predictableSeqStep P S 𝓕 n s ω
+      = _root_.predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P (ceil s) ω := by
+    intro s
+    rcases eq_or_ne s ⊥ with rfl | hs0
+    · rw [show ceil ⊥ = ⊥ from le_antisymm (hle ⊥ ⊥ (by simp)) bot_le,
+        predictablePart_bot, Pi.zero_apply]
+      simp only [predictableSeqStep, Finset.sum_apply]
+      exact Finset.sum_eq_zero fun u _ ↦ by
+        rw [Set.indicator_of_notMem fun h ↦ absurd h.1 (not_lt.2 bot_le), Pi.zero_apply]
+    · refine predictableSeqStep_apply P S 𝓕 n ω (Set.mem_Ioc.2 ⟨?_, hmem s⟩)
+      have hcne : ceil s ≠ ⊥ := by
+        intro hc
+        have h := hmem s
+        rw [hc, bot_eq_bot] at h
+        exact hs0 (le_bot_iff.1 h)
+      exact not_le.1 fun hcon ↦ absurd (hle s _ hcon) (not_le.2
+        (Order.pred_lt_of_not_isMin fun hmin ↦ hcne (le_bot_iff.1 (hmin bot_le))))
+  intro s₁ s₂ hs12
+  change predictableSeqStep P S 𝓕 n s₁ ω ≤ predictableSeqStep P S 𝓕 n s₂ ω
+  rw [hval s₁, hval s₂]
+  exact hmono (hle s₁ (ceil s₂) (hs12.trans (hmem s₂)))
 
 lemma predictableConvexStep_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
     {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
     {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) (t : ι) :
     ∀ᵐ ω ∂P, Monotone fun t ↦ predictableConvexStep hd hs n t ω := by
-  sorry
+  have key : ∀ᵐ ω ∂P, ∀ m : ℕ, Monotone fun s ↦ predictableSeqStep P S 𝓕 m s ω :=
+    ae_all_iff.2 fun m ↦ predictableSeqStep_monotone_ae hs m t
+  filter_upwards [key] with ω hω
+  intro s₁ s₂ hs12
+  change predictableConvexStep hd hs n s₁ ω ≤ predictableConvexStep hd hs n s₂ ω
+  simp only [predictableConvexStep, Finsupp.sum, Finset.sum_apply, Pi.smul_apply]
+  exact Finset.sum_le_sum fun m _ ↦
+    smul_le_smul_of_nonneg_left (hω m hs12) ((weight hd hs n).weights_nonneg m)
 
 lemma predictablePartLim_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -1058,10 +1058,7 @@ lemma predictableSeqStep_apply {ι Ω : Type*} [TopologicalSpace ι] [SecondCoun
       = predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P u ω := by
   rw [predictableSeqStep_eq_sum_indicator,
     Finset.sum_eq_single_of_mem u (Finset.mem_univ _) ?_, Set.indicator_of_mem ht]
-  intro v _ hvu
-  apply Set.indicator_of_notMem
-  intro hv
-  apply hvu
+  refine fun v _ hvu => Set.indicator_of_notMem (fun hv => hvu ?_) _
   rcases lt_trichotomy v u with h' | h' | h'
   · exact absurd (lt_of_le_of_lt hv.2 (lt_of_le_of_lt
       (Subtype.coe_le_coe.2 (Order.le_pred_of_lt h')) ht.1)) (lt_irrefl t)

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -1073,7 +1073,7 @@ lemma predictableSeqStep_apply {ι Ω : Type*} [TopologicalSpace ι] [SecondCoun
 lemma predictableSeqStep_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
     {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P) (n : ℕ) (_t : ι) :
+    {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P) (n : ℕ) :
     ∀ᵐ ω ∂P, Monotone fun t ↦ predictableSeqStep P S 𝓕 n t ω := by
   have hsub : Submartingale (S ∘ Subtype.val) (meshFiltration 𝓕 n) P :=
     hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
@@ -1081,8 +1081,7 @@ lemma predictableSeqStep_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Sp
     fun s ↦ ⟨⊤, by simp⟩
   set ceil : ι → mesh ι n :=
     fun s ↦ (Finset.univ.filter fun u : mesh ι n ↦ s ≤ (u : ι)).min' (hne s)
-  have hmem : ∀ s : ι, s ≤ (ceil s : ι) :=
-    fun s ↦ (Finset.mem_filter.1 (Finset.min'_mem _ (hne s))).2
+  have hne (s : ι) : (Finset.univ.filter fun u : mesh ι n ↦ s ≤ (u : ι)).Nonempty := ⟨⊤, by simp⟩
   have hle : ∀ (s : ι) (u : mesh ι n), s ≤ (u : ι) → ceil s ≤ u :=
     fun s u hu ↦ Finset.min'_le _ u (Finset.mem_filter.2 ⟨Finset.mem_univ u, hu⟩)
   filter_upwards [hsub.monotone_predictablePart_ae] with ω hmono
@@ -1104,20 +1103,17 @@ lemma predictableSeqStep_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Sp
       exact not_le.1 fun hcon ↦ absurd (hle s _ hcon) (not_le.2
         (Order.pred_lt_of_not_isMin fun hmin ↦ hcne (le_bot_iff.1 (hmin bot_le))))
   intro s₁ s₂ hs12
-  change predictableSeqStep P S 𝓕 n s₁ ω ≤ predictableSeqStep P S 𝓕 n s₂ ω
-  rw [hval s₁, hval s₂]
+  simp only [hval s₁, hval s₂]
   exact hmono (hle s₁ (ceil s₂) (hs12.trans (hmem s₂)))
 
 lemma predictableConvexStep_monotone_ae {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [MeasurableSpace ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
     {mΩ : MeasurableSpace Ω} {P : Measure Ω} [IsFiniteMeasure P] {S : ι → Ω → ℝ}
-    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) (t : ι) :
+    {𝓕 : Filtration ι mΩ} (hd : ClassD S 𝓕 P) (hs : Submartingale S 𝓕 P) (n : ℕ) :
     ∀ᵐ ω ∂P, Monotone fun t ↦ predictableConvexStep hd hs n t ω := by
   have key : ∀ᵐ ω ∂P, ∀ m : ℕ, Monotone fun s ↦ predictableSeqStep P S 𝓕 m s ω :=
-    ae_all_iff.2 fun m ↦ predictableSeqStep_monotone_ae hs m t
-  filter_upwards [key] with ω hω
-  intro s₁ s₂ hs12
-  change predictableConvexStep hd hs n s₁ ω ≤ predictableConvexStep hd hs n s₂ ω
+    ae_all_iff.2 fun m ↦ predictableSeqStep_monotone_ae hs m
+  filter_upwards [key] with ω hω s₁ s₂ hs12
   simp only [predictableConvexStep, Finsupp.sum, Finset.sum_apply, Pi.smul_apply]
   exact Finset.sum_le_sum fun m _ ↦
     smul_le_smul_of_nonneg_left (hω m hs12) ((weight hd hs n).weights_nonneg m)


### PR DESCRIPTION
Part of #454.

- [ ] Depends on #475 

Closes the following  `sorry`s in the `PredictablePartLimMono` section:
- `predictableSeqStep_monotone_ae`
- `predictableConvexStep_monotone_ae`

Adds a helper `predictableSeqStep_apply` giving the value of the step process on
each mesh cell `(pred u, u]`.