### PR TITLE
Referee responses and bibliography additions

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,6 +5,11 @@ BM_paper/main.pdf
 
 ## macOS
 .DS_Store
+## Referee reports and answers (not for the public repo)
+Report_*.pdf
+BM_paper/Answers_Report_69.pdf
+## Claude Code
+.claude/
 ## Lake
 .lake/*
 .cache/*

--- a/BM_paper/Answers_Report_69.tex
+++ b/BM_paper/Answers_Report_69.tex
@@ -1,0 +1,75 @@
+\documentclass[11pt]{article}
+
+\usepackage[utf8]{inputenc}
+\usepackage[T1]{fontenc}
+\usepackage{amsmath,amssymb, xcolor}
+\usepackage[margin=1in]{geometry}
+\usepackage{hyperref}
+
+\newcommand{\TODO}[1]{\textcolor{teal}{TODO #1}}
+
+\begin{document}
+\section*{Answers to the reports}
+We thank both referees for their careful reading of the manuscript. Below are our answers.
+
+\paragraph{Report 6a...:}
+The typos and small changed you suggest we carried out without further mentioning them. Here are the changes of more than one or two words:
+\begin{itemize}
+  \item We have added a list of contributors to the repository with more than five commits.
+  \item Lemma 4.3 and footnote: done
+  \item Thm 4.7: You are right, $\sigma$-finiteness is not needed here.
+  \item Before Thm 4.20: xxx
+  \item In Thm 4.20, dependence $L(T,...)$
+  \item Section 4.4.3:
+  \item Proposition 5.3:
+\end{itemize}
+
+\paragraph{Report 69...:}
+
+\begin{itemize}
+  \item The author should mention the book by Revuz and Yor which is the most
+  definitive reference on the Brownian motion.
+  \\{\color{blue} We have added this book right at the beginning of the text.}
+  \item The definition of a stochastic process should appear clearly as a
+  definition (and maybe indicate which Lean predicate it refers to as for other
+  definitions?).
+  \\{\color{blue} \TODO{We should discuss this, I think. As far as I can see, defining what a stochastic process is does not really fit into Mathlib. Rather, it only involves some measurability assumptions, which we currently do not state explicitely.}}
+  \item The Kolmogorov continuity theorem for processes indexed by an abstract
+  spaces is classical and largely predates the work Kr\"atschmer and Urusov
+  [KU23] quoted in the paper (see for instance chapters 11 and 12 in the book
+  Ledoux and Talagrand, or Theorems 1.4.2 and 2.15.3 in the second edition
+  of Talagrand's book \emph{Upper and Lower Bounds for Stochastic Processes}).
+  In particular, when $(X_t)_{t \in T}$ is Gaussian, one can always equip $T$ with the
+  ``canonical'' pseudo-distance
+  \[
+    d(s,t) := \mathbb{E}[(X_t - X_s)^2]^{1/2},
+  \]
+  and deduce regularity from there. It is not clear to me what the advantage
+  of [KU23] is compared to the historical chaining approach and the authors
+  should at least quote a more standard reference in addition to [KU23].
+  \\{\color{blue} Thanks for pointing us to these references, which we carefully checked. Our goal was to have a directly usable result which is most general. (For the latter reason, we do not want to restrict to the Gaussian case, covered in Chapter 12 and the book by Talagrand.) Although Ledoux and Talagrand formally restrict to the case of real-valued processes, we agree that their result is in fact more general that [KU23] since they use a Young function $\psi$, which must be specialized to $\psi(x) = x^p$ in [KU23]. However, Holder continuity in [KU23] is direct, and would have to be extracted from $\psi$ in LT, which is not immediate. We added a reference to [LT91] in 2.3.}
+  \item The authors define Gaussian random variables on Banach spaces but at the
+  most general level they can be defined on locally convex vector spaces. In
+  that regard, the Bochner--Minlos theorem guarantees existence of Gaussian
+  random variables on nuclear spaces (which incidentally can be used to
+  construct Gaussian fields).
+  \\{\color{blue}Thanks for pointing this out! Since the Bochner-Minlos theorem is not yet part of mathlib, this is not an option at the moment. We have added two sentences on the construction of Gaussian distributions on more general spaces at the end of 4.3.}
+  \item The simplest construction of the Brownian motion, and Gaussian field
+  in general, does not require Kolmogorov extension theorem. Consider a
+  Hilbert basis $(e_n)$ of $L^2(\mathbb{R}_+)$ and family $(G_n)$ of independent standard
+  Gaussian variables. For $f \in L^2$, set
+  \[
+    X(f) := \sum_{n \in \mathbb{N}} \Bigl( \int_{\mathbb{R}_+} f(x) e_n(x)\,dx \Bigr) G_n,
+  \]
+  which converges in $L^2(\Omega)$. Then $B_t := X(\mathbf{1}_{[0,t]})$ is a Brownian motion.
+  Other Gaussian fields can be defined by changing the base Hilbert space.
+  \\{\color{blue}This basically leads to Lévy's construction of BM, where continuity of the sample paths is a rather direct result (if the proper base is chosen). We discussed this approach, but found that the path via Kolmogorov-Chentsov will pay off since it will be used more often (for processes rather than fields). We now refer to this construction in the new Section 2.5.}
+  \item The construction of the authors is correct and Kolmogorov extension
+  theorem is unavoidable for the construction of other stochastic processes
+  (for instance Markov processes). However, from a formalization point of
+  view it could be interesting to have the construction that relies on as few
+  results as possible on other results.
+  \\{\color{blue} Since Lean uses proof irrelevance, this statement can be debated. For example, real numbers in mathlib are based on Cauchy sequences rather than Dedekind cuts.}
+\end{itemize}
+
+\end{document}

--- a/BM_paper/Answers_Report_69.tex
+++ b/BM_paper/Answers_Report_69.tex
@@ -15,31 +15,23 @@ We thank both referees for their careful reading of the manuscript. Below are ou
 \paragraph{Report 6a...:}
 The typos and small changed you suggest we carried out without further mentioning them. Here are the changes of more than one or two words:
 \begin{itemize}
-  \item We have added a list of contributors to the repository with more than five commits.
-  \item Lemma 4.3 and footnote: done
-  \item Thm 4.7: You are right, $\sigma$-finiteness is not needed here.
-  \item Before Thm 4.20: xxx
-  \item In Thm 4.20, dependence $L(T,...)$
-  \item Section 4.4.3:
-  \item Proposition 5.3:
+  \item Lemma 4.3 and footnote: \\{\color{blue}done}
+  \item Thm 4.7: \\{\color{blue}You are right, $\sigma$-finiteness is not needed here, it is now deleted. }
+  \item Before Thm 4.20: \\{\color{blue}You are right, a finite diameter follows from the definitions, which we added.}
+  \item In Thm 4.20, dependence $L(T,...)$: \\{\color{blue}You are right, the constant does not need to depend on $T$. It depended on $T$ only through $\mathrm{diam}(T)$, which, as you point out, is bounded by $c^{1/d}$ due to the covering condition. We have changed the statement to $L(c, d, p, q, \beta)$, added a remark explaining the bound on the diameter after the theorem, and adapted the formalization accordingly (the Lean constant \texttt{constL} now takes only $c, d, p, q, \beta$ as arguments, using a new lemma \texttt{HasBoundedInternalCoveringNumber.diam\_le}).}
+  \item Section 4.4.3: \\{\color{blue}You are right, bounded diameter is not sufficient for the existence of finite $\varepsilon$-covers. We rephrased the definition, which matches the formalization (where it takes values in $\mathbb{N} \cup \{+\infty\}$), and we remark that it is finite for every $\varepsilon > 0$ if and only if $T$ is totally bounded.}
+  \item Section 4.4.4: \\ {\color{blue} You are also right in the pair reduction lemma: indeed, the lemma is applied with $J = C_m$.}
+  \item Proposition 5.3: We added a clarifying remark.
 \end{itemize}
 
 \paragraph{Report 69...:}
 
 \begin{itemize}
-  \item The author should mention the book by Revuz and Yor which is the most
-  definitive reference on the Brownian motion.
+  \item The authors should mention the book by Revuz and Yor which is the most definitive reference on the Brownian motion.
   \\{\color{blue} We have added this book right at the beginning of the text.}
-  \item The definition of a stochastic process should appear clearly as a
-  definition (and maybe indicate which Lean predicate it refers to as for other
-  definitions?).
-  \\{\color{blue} \TODO{We should discuss this, I think. As far as I can see, defining what a stochastic process is does not really fit into Mathlib. Rather, it only involves some measurability assumptions, which we currently do not state explicitely.}}
-  \item The Kolmogorov continuity theorem for processes indexed by an abstract
-  spaces is classical and largely predates the work Kr\"atschmer and Urusov
-  [KU23] quoted in the paper (see for instance chapters 11 and 12 in the book
-  Ledoux and Talagrand, or Theorems 1.4.2 and 2.15.3 in the second edition
-  of Talagrand's book \emph{Upper and Lower Bounds for Stochastic Processes}).
-  In particular, when $(X_t)_{t \in T}$ is Gaussian, one can always equip $T$ with the
+  \item The definition of a stochastic process should appear clearly as a definition (and maybe indicate which Lean predicate it refers to as for other definitions?).
+  \\{\color{blue} There is no definition of a stochastic process in Mathlib, as there is no definition of a random variable either. There is, however, the notion of an (ae) measurable function, which lead to a random variable, as well as a stochastic process. We follow the route of Mathlib here, do not define {\tt def stochasticProcess} or the like, but state measurability assumptions as needed. }
+  \item The Kolmogorov continuity theorem for processes indexed by an abstract spaces is classical and largely predates the work Kr\"atschmer and Urusov [KU23] quoted in the paper (see for instance chapters 11 and 12 in the book Ledoux and Talagrand, or Theorems 1.4.2 and 2.15.3 in the second edition of Talagrand's book \emph{Upper and Lower Bounds for Stochastic Processes}). In particular, when $(X_t)_{t \in T}$ is Gaussian, one can always equip $T$ with the
   ``canonical'' pseudo-distance
   \[
     d(s,t) := \mathbb{E}[(X_t - X_s)^2]^{1/2},
@@ -47,28 +39,19 @@ The typos and small changed you suggest we carried out without further mentionin
   and deduce regularity from there. It is not clear to me what the advantage
   of [KU23] is compared to the historical chaining approach and the authors
   should at least quote a more standard reference in addition to [KU23].
-  \\{\color{blue} Thanks for pointing us to these references, which we carefully checked. Our goal was to have a directly usable result which is most general. (For the latter reason, we do not want to restrict to the Gaussian case, covered in Chapter 12 and the book by Talagrand.) Although Ledoux and Talagrand formally restrict to the case of real-valued processes, we agree that their result is in fact more general that [KU23] since they use a Young function $\psi$, which must be specialized to $\psi(x) = x^p$ in [KU23]. However, Holder continuity in [KU23] is direct, and would have to be extracted from $\psi$ in LT, which is not immediate. We added a reference to [LT91] in 2.3.}
-  \item The authors define Gaussian random variables on Banach spaces but at the
-  most general level they can be defined on locally convex vector spaces. In
-  that regard, the Bochner--Minlos theorem guarantees existence of Gaussian
-  random variables on nuclear spaces (which incidentally can be used to
-  construct Gaussian fields).
+  \\{\color{blue} Thanks for pointing us to these references, which we carefully checked. Our goal was to have a directly usable result which is most general. (For the latter reason, we do not want to restrict to the Gaussian case, covered in Chapter 12 and the book by Talagrand.) Although Ledoux and Talagrand formally restrict to the case of real-valued processes, we agree that their result is in fact more general than [KU23] since they use a Young function $\psi$, which must be specialized to $\psi(x) = x^p$ in [KU23]. However, Holder continuity in [KU23] is direct, and would have to be extracted from $\psi$ in LT, which is not immediate. We added a reference to [LT91] in 2.3.}
+  \item The authors define Gaussian random variables on Banach spaces but at the most general level they can be defined on locally convex vector spaces. In that regard, the Bochner--Minlos theorem guarantees existence of Gaussian random variables on nuclear spaces (which incidentally can be used to construct Gaussian fields).
   \\{\color{blue}Thanks for pointing this out! Since the Bochner-Minlos theorem is not yet part of mathlib, this is not an option at the moment. We have added two sentences on the construction of Gaussian distributions on more general spaces at the end of 4.3.}
-  \item The simplest construction of the Brownian motion, and Gaussian field
-  in general, does not require Kolmogorov extension theorem. Consider a
-  Hilbert basis $(e_n)$ of $L^2(\mathbb{R}_+)$ and family $(G_n)$ of independent standard
-  Gaussian variables. For $f \in L^2$, set
+  \item The simplest construction of the Brownian motion, and Gaussian field in general, does not require Kolmogorov extension theorem. Consider a Hilbert basis $(e_n)$ of $L^2(\mathbb{R}_+)$ and family $(G_n)$ of independent standard Gaussian variables. For $f \in L^2$, set
   \[
     X(f) := \sum_{n \in \mathbb{N}} \Bigl( \int_{\mathbb{R}_+} f(x) e_n(x)\,dx \Bigr) G_n,
   \]
-  which converges in $L^2(\Omega)$. Then $B_t := X(\mathbf{1}_{[0,t]})$ is a Brownian motion.
-  Other Gaussian fields can be defined by changing the base Hilbert space.
+  which converges in $L^2(\Omega)$. Then $B_t := X(\mathbf{1}_{[0,t]})$ is a Brownian motion. Other Gaussian fields can be defined by changing the base Hilbert space.
   \\{\color{blue}This basically leads to Lévy's construction of BM, where continuity of the sample paths is a rather direct result (if the proper base is chosen). We discussed this approach, but found that the path via Kolmogorov-Chentsov will pay off since it will be used more often (for processes rather than fields). We now refer to this construction in the new Section 2.5.}
   \item The construction of the authors is correct and Kolmogorov extension
   theorem is unavoidable for the construction of other stochastic processes
   (for instance Markov processes). However, from a formalization point of
-  view it could be interesting to have the construction that relies on as few
-  results as possible on other results.
+  view it could be interesting to have the construction that relies on as few results as possible on other results.
   \\{\color{blue} Since Lean uses proof irrelevance, this statement can be debated. For example, real numbers in mathlib are based on Cauchy sequences rather than Dedekind cuts.}
 \end{itemize}
 

--- a/BM_paper/Answers_Report_69.tex
+++ b/BM_paper/Answers_Report_69.tex
@@ -13,7 +13,7 @@
 We thank both referees for their careful reading of the manuscript. Below are our answers.
 
 \paragraph{Report 6a...:}
-The typos and small changed you suggest we carried out without further mentioning them. Here are the changes of more than one or two words:
+The typos and small changes you suggested were carried out without further mention. Here are the changes of more than one or two words:
 \begin{itemize}
   \item Lemma 4.3 and footnote: \\{\color{blue}done}
   \item Thm 4.7: \\{\color{blue}You are right, $\sigma$-finiteness is not needed here, it is now deleted. }
@@ -21,7 +21,8 @@ The typos and small changed you suggest we carried out without further mentionin
   \item In Thm 4.20, dependence $L(T,...)$: \\{\color{blue}You are right, the constant does not need to depend on $T$. It depended on $T$ only through $\mathrm{diam}(T)$, which, as you point out, is bounded by $c^{1/d}$ due to the covering condition. We have changed the statement to $L(c, d, p, q, \beta)$, added a remark explaining the bound on the diameter after the theorem, and adapted the formalization accordingly (the Lean constant \texttt{constL} now takes only $c, d, p, q, \beta$ as arguments, using a new lemma \texttt{HasBoundedInternalCoveringNumber.diam\_le}).}
   \item Section 4.4.3: \\{\color{blue}You are right, bounded diameter is not sufficient for the existence of finite $\varepsilon$-covers. We rephrased the definition, which matches the formalization (where it takes values in $\mathbb{N} \cup \{+\infty\}$), and we remark that it is finite for every $\varepsilon > 0$ if and only if $T$ is totally bounded.}
   \item Section 4.4.4: \\ {\color{blue} You are also right in the pair reduction lemma: indeed, the lemma is applied with $J = C_m$.}
-  \item Proposition 5.3: We added a clarifying remark.
+  \item Section 5, $B_0 = 0$ almost surely: \\{\color{blue}You are basically right: by construction, there is an exceptional null set on which the process is set to a constant $x_0$. Choosing $x_0 = 0$ alone is not quite enough, since outside this set $B_0$ is the limit of the canonical process along a countable dense set, which is $0$ only almost surely; but enlarging the exceptional set by the null set where this limit is nonzero would indeed give $B_0 = 0$ everywhere. Since this would be a special-case modification of the general construction (which works in spaces without a distinguished point), and $B_0 = 0$ almost surely is the standard definition, we left the text as is.}
+  \item Proposition 5.3: \\{\color{blue}We added a clarifying remark.}
 \end{itemize}
 
 \paragraph{Report 69...:}
@@ -30,7 +31,7 @@ The typos and small changed you suggest we carried out without further mentionin
   \item The authors should mention the book by Revuz and Yor which is the most definitive reference on the Brownian motion.
   \\{\color{blue} We have added this book right at the beginning of the text.}
   \item The definition of a stochastic process should appear clearly as a definition (and maybe indicate which Lean predicate it refers to as for other definitions?).
-  \\{\color{blue} There is no definition of a stochastic process in Mathlib, as there is no definition of a random variable either. There is, however, the notion of an (ae) measurable function, which lead to a random variable, as well as a stochastic process. We follow the route of Mathlib here, do not define {\tt def stochasticProcess} or the like, but state measurability assumptions as needed. }
+  \\{\color{blue} There is no definition of a stochastic process in Mathlib, as there is no definition of a random variable either. There is, however, the notion of an (ae) measurable function, which leads to a random variable, as well as a stochastic process. We follow the route of Mathlib here, do not define {\tt def stochasticProcess} or the like, but state measurability assumptions as needed. }
   \item The Kolmogorov continuity theorem for processes indexed by an abstract spaces is classical and largely predates the work Kr\"atschmer and Urusov [KU23] quoted in the paper (see for instance chapters 11 and 12 in the book Ledoux and Talagrand, or Theorems 1.4.2 and 2.15.3 in the second edition of Talagrand's book \emph{Upper and Lower Bounds for Stochastic Processes}). In particular, when $(X_t)_{t \in T}$ is Gaussian, one can always equip $T$ with the
   ``canonical'' pseudo-distance
   \[
@@ -39,7 +40,7 @@ The typos and small changed you suggest we carried out without further mentionin
   and deduce regularity from there. It is not clear to me what the advantage
   of [KU23] is compared to the historical chaining approach and the authors
   should at least quote a more standard reference in addition to [KU23].
-  \\{\color{blue} Thanks for pointing us to these references, which we carefully checked. Our goal was to have a directly usable result which is most general. (For the latter reason, we do not want to restrict to the Gaussian case, covered in Chapter 12 and the book by Talagrand.) Although Ledoux and Talagrand formally restrict to the case of real-valued processes, we agree that their result is in fact more general than [KU23] since they use a Young function $\psi$, which must be specialized to $\psi(x) = x^p$ in [KU23]. However, Holder continuity in [KU23] is direct, and would have to be extracted from $\psi$ in LT, which is not immediate. We added a reference to [LT91] in 2.3.}
+  \\{\color{blue} Thanks for pointing us to these references, which we carefully checked. Our goal was to have a directly usable result which is most general. (For the latter reason, we do not want to restrict to the Gaussian case, covered in Chapter 12 and the book by Talagrand.) Although Ledoux and Talagrand formally restrict to the case of real-valued processes, we agree that their result is in fact more general than [KU23] since they use a Young function $\psi$, which must be specialized to $\psi(x) = x^p$ in [KU23]. However, H\"older continuity in [KU23] is direct, and would have to be extracted from $\psi$ in LT, which is not immediate. We added a reference to [LT91] in 2.3.}
   \item The authors define Gaussian random variables on Banach spaces but at the most general level they can be defined on locally convex vector spaces. In that regard, the Bochner--Minlos theorem guarantees existence of Gaussian random variables on nuclear spaces (which incidentally can be used to construct Gaussian fields).
   \\{\color{blue}Thanks for pointing this out! Since the Bochner-Minlos theorem is not yet part of mathlib, this is not an option at the moment. We have added two sentences on the construction of Gaussian distributions on more general spaces at the end of 4.3.}
   \item The simplest construction of the Brownian motion, and Gaussian field in general, does not require Kolmogorov extension theorem. Consider a Hilbert basis $(e_n)$ of $L^2(\mathbb{R}_+)$ and family $(G_n)$ of independent standard Gaussian variables. For $f \in L^2$, set

--- a/BM_paper/biblio.bib
+++ b/BM_paper/biblio.bib
@@ -95,6 +95,18 @@
   publisher = {Springer Science \& Business Media}
 }
 
+@book{revuz1999continuous,
+  title     = {Continuous martingales and Brownian motion},
+  author    = {Revuz, Daniel and Yor, Marc},
+  series    = {Grundlehren der mathematischen Wissenschaften},
+  volume    = {293},
+  edition   = {3},
+  year      = {1999},
+  publisher = {Springer-Verlag, Berlin},
+  isbn      = {3-540-64325-7},
+  doi       = {10.1007/978-3-662-06400-9}
+}
+
 @book{morters2010brownian,
   title     = {Brownian motion},
   author    = {M{\"o}rters, Peter and Peres, Yuval},
@@ -339,6 +351,33 @@ URL= {https://simons.berkeley.edu/talks/sophie-morel-ens-de-lyon-2025-04-11}
   mrreviewer    = {Sasha\ Sodin},
   doi           = {10.1007/978-3-642-54075-2},
   url           = {https://doi.org/10.1007/978-3-642-54075-2}
+}
+
+@article{marion2025ionescu,
+  title   = {A Formalization of the {I}onescu-{T}ulcea Theorem in Mathlib},
+  author  = {Marion, Etienne},
+  journal = {arXiv preprint arXiv:2506.18616},
+  year    = {2025}
+}
+
+@article{douglas2026qft,
+  title   = {Formalization of {QFT}},
+  author  = {Douglas, Michael R. and Hoback, Sarah and Mei, Anna and Nissim, Ron},
+  journal = {arXiv preprint arXiv:2603.15770},
+  year    = {2026}
+}
+
+@book{ledoux1991probability,
+  author    = {Ledoux, Michel and Talagrand, Michel},
+  title     = {Probability in {B}anach Spaces. Isoperimetry and Processes},
+  series    = {Ergebnisse der Mathematik und ihrer Grenzgebiete (3) [Results
+               in Mathematics and Related Areas (3)]},
+  volume    = {23},
+  publisher = {Springer-Verlag, Berlin},
+  year      = {1991},
+  pages     = {xii+480},
+  isbn      = {3-540-52013-9},
+  doi       = {10.1007/978-3-642-20212-4}
 }
 
 @book{LeGall2016,

--- a/BM_paper/main.tex
+++ b/BM_paper/main.tex
@@ -95,7 +95,7 @@ Brownian motion is a building block in modern probability theory. In this paper,
 \section{Introduction}
 
 \subsection{Mathematical background}
-\sloppy Brownian motion is arguably one of the most important stochastic processes (e.g.\ \cite{karatzas1991brownian, morters2010brownian}), and is used as a modeling tool across all sciences (physics: e.g.\ \cite{einstein1906theorie, bian2016111}; biology: e.g.\ \cite{erban2014molecular}; finance: e.g.\ \cite{davis2006louis}). Mathematically, Brownian motion led to the Wiener measure \cite{wiener1923differential}, which is the first instance of a probability measure on a function space, but also to developments such as Stochastic (Partial) Differential equations (see e.g.\ \cite{hairer2009introduction}).
+\sloppy Brownian motion is arguably one of the most important stochastic processes (e.g.\ \cite{karatzas1991brownian, revuz1999continuous, morters2010brownian}), and is used as a modeling tool across all sciences (physics: e.g.\ \cite{einstein1906theorie, bian2016111}; biology: e.g.\ \cite{erban2014molecular}; finance: e.g.\ \cite{davis2006louis}). Mathematically, Brownian motion led to the Wiener measure \cite{wiener1923differential}, which is the first instance of a probability measure on a function space, but also to developments such as Stochastic (Partial) Differential equations (see e.g.\ \cite{hairer2009introduction}).
 
 The goal of the present paper is to describe a formalization of Brownian motion using \Lean \cite{lean, moura2021lean}, building on its mathematical library \mathlib \cite{mathlib}. For this paper we use the following definition of Brownian motion (there are many equivalent characterizations, e.g.\ Definition 2.12 with Proposition 2.3 of~\cite{LeGall2016}).
 
@@ -157,7 +157,7 @@ Before making the project public, we thus spent time detailing every step of the
 We started by implementing in \Lean several key definitions and statements (without proofs): there are always several ways to turn a mathematical concept into a \Lean definition, and in order to collaborate on a project it is important to decide early on a unique way to talk about any concept to ensure compatibility of the code produced, even if the definition chosen can then be refined.
 Different parts of the blueprint had different levels of details: we wrote a precise description of the technical Kolmogorov-Chentsov proof, but omitted many proofs for more standard results on Gaussian distributions.
 
-The project was announced on the \href{https://leanprover.zulipchat.com/}{Lean Zulip website}, and anyone interested was invited to contribute. D.L. and E.M. joined the project at that time and then contributed significantly to the formalization. The coordination of the project was done through discussions in a Zulip channel: lists of tasks and progress updates were regularly posted, and volunteers could claim the tasks and report on their progress.
+The project was announced on the \href{https://leanprover.zulipchat.com/}{Lean Zulip website}, and anyone interested was invited to contribute. D.L. and E.M. joined the project at that time and then contributed significantly to the formalization. The coordination of the project was done through discussions in a Zulip channel: lists of tasks and progress updates were regularly posted, and volunteers could claim the tasks and report on their progress. (The full list of contributors -- excluding authors of the present manuscript -- with more than five commits is:  Eugenio Cainelli, Markus Himmel, Nikolas Kuhn, Yongxi (Aaron) Lin,   Lorenzo Luccioli, Jack McCarthy, Pietro Monticone, Jérémy Scanvic, Kexing Ying, Thomas Zhu.)
 The correctness of the code was ensured by continuous integration scripts on github, which automatically check that the code compiles without errors, and by manual review of the proposed additions.
 The blueprint continued to evolve during the formalization, as new lemmas were added (once because a small gap was identified in the blueprint proof), definitions were changed to better fit the needs of writing in \Lean, and small mistakes were corrected (particularly in the exact value of constants used in the Kolmogorov-Chentsov proof).
 
@@ -233,7 +233,7 @@ Using \eqref{eq:cs}, we see that $X_{t_n} \xrightarrow{n\to\infty} X_t$ in proba
 Therefore, $X_t = Y_t$ almost surely.
 
 We will use a more general version of this statement, replacing $T = [0,1]$ by a metric space with a property restricting the number of balls needed to cover $T$. The version we formalize is based on
-the recent work of~\cite{kratschmer2023kolmogorov}.
+the recent work of~\cite{kratschmer2023kolmogorov}. (Note the similar approach taken by \cite[Chapter~11]{ledoux1991probability}, which is based on real-valued processes, and which gives less concrete bounds, especially for Holder continuity.)
 
 \subsection{Construction of Brownian motion and Wiener measure on $\R_+$}
 
@@ -246,8 +246,8 @@ For example,
 So, we obtain from that theorem a process with continuous paths and the correct finite dimensional distributions, which we call Brownian motion.
 This also gives a distribution on the continuous functions $\mathcal C(\mathbb R_+, \mathbb R)$, which is the Wiener measure.
 
-
-
+\subsection{An alternative route}
+Our way to construct Brownian Motion is not the only one possible. In particular, Lévy's construction of Brownian Motion gives a more direct construction. Here, one takes an infinite number of independent $N(0,1)$-distributed random variables (e.g.\ obtained via the Ionescu-Tulcea Theorem, formalized in \cite{marion2025ionescu}), constructs Brownian Motion on all dyadic numbers, and obtains a stochastic process with continuous paths by extension to $\mathbb R_{\geq 0}$. See e.g.\ Chapter 1.1.3 in \cite{morters2010brownian}. Since we aim for an approach which is useful also for constructing other stochastic processes, we do not follow this path.
 
 \section{Random variable formalism}
 \label{S:RV-formalism}
@@ -433,7 +433,7 @@ In the construction above, since all sets in the semi-ring $\mathcal H$ are Cara
 
 \begin{theorem}[Carathéodory extension]\label{T:masseind}
   Let $\mathcal H$ be a semi-ring and $m: \mathcal H\to\mathbb R_+$
-  $\sigma$-finite and $\sigma$-additive. Furthermore, let $\mu$ be the
+  $\sigma$-additive. Furthermore, let $\mu$ be the
   induced outer measure from Proposition~\ref{P:auss} and $\mathcal F$
   the $\sigma$-algebra from Theorem~\ref{T:cara}. Then,
   $\sigma(\mathcal H)\subseteq\mathcal F$ and $\mu$ coincides with $m$
@@ -556,6 +556,8 @@ In order to define the law of a Brownian motion on $\mathbb{R}_+$, we need defin
 We did not however define Gaussian measures only for that setting, but first introduced a general definition for Banach spaces, and then specialized it to Hilbert and finally finite dimensional spaces.
 Our formalization uses many results from \mathlib and we relied on characteristic functions \mllink{MeasureTheory/Measure/CharacteristicFunction}{L322-L325}{MeasureTheory.charFunDual}, as well as the fact that they uniquely determine a probability measure \mllink{MeasureTheory/Measure/CharacteristicFunction}{L435-L439}{MeasureTheory.Measure.ext_of_charFunDual}.
 
+Note that Gaussian distributions could be defined on more general spaces (locally convex vector spaces). The construction requires a formalization of  the Bochner-Minlos Theorem, which is not yet available in \mathlib. (However, note that this result was recently formalized for the development of Quantum Field Theory in \cite{douglas2026qft}.)
+
 
 \subsubsection{Gaussian distributions}
 
@@ -676,14 +678,14 @@ The key assumption of the Kolmogorov-Chentsov theorem that gives the existence o
 
 \begin{definition}[Kolmogorov condition]\label{def:kolmogorov_condition}
 Let $p, q, M$ be non-negative real numbers with $p,q>0$.
-A stochastic process $(X_t)_{t \in T}$ is said to satisfy the Kolmogorov condition for exponents $(p, q)$ with constant $M$ if for all $s, t \in T$, the pair $(X_t, X_t) : \Omega \to E \times E$ is measurable for the Borel $\sigma$-algebra on $E \times E$, and
+A stochastic process $(X_t)_{t \in T}$ is said to satisfy the Kolmogorov condition for exponents $(p, q)$ with constant $M$ if for all $s, t \in T$, the pair $(X_s, X_t) : \Omega \to E \times E$ is measurable for the Borel $\sigma$-algebra on $E \times E$, and
 \begin{align*}
   \mathbf{E}[d_E(X_s, X_t)^p] \le M d_T(s, t)^q
   \: .
 \end{align*}
 \end{definition}
 
-The measurability condition ensures that the distance $d_E(X_s, X_t)$ is a measurable.
+The measurability condition ensures that the distance $d_E(X_s, X_t)$ is measurable.
 If $E$ was second-countable, we could simply assume that $X_s$ is measurable for all $s \in T$, and the measurability of the pair would follow.
 This is because for a second-countable space $E$, $\mathcal{B}(E \times E)$ is the product of the Borel $\sigma$-algebras on $E$, which is not true in general.
 
@@ -696,6 +698,8 @@ Therefore, we introduce a definition \lstinline|IsAEKolmogorovProcess| for the p
 We formalize a recent and general version of the Kolmogorov-Chentsov theorem \cite[Theorem 1]{kratschmer2023kolmogorov}, which applies to extended pseudo-metric spaces under a covering assumption on the index set $T$.
 We say that $T$ has bounded covering number with constant $c > 0$ and exponent $d \ge 0$ if for all $\varepsilon \in (0, \mathrm{diam}(T)]$, $T$ can be covered by at most $c \varepsilon^{-d}$ balls of radius $\varepsilon$ (see Definition~\ref{def:bounded_covering_number} below). Note that such a space is totally bounded by construction.
 
+{\color{blue} xxx Maybe add "Note also that this condition implies $diam(T) < \infty$, even if $T$ is an extended metric space to start with".}
+
 \begin{theorem}[Kolmogorov-Chentsov]\label{thm:kolmogorov_chentsov}
 Suppose that the index set $T$ has bounded covering number with constant $c>0$ and exponent $d > 0$.
 Let $(X_t)_{t \in T}$ be a stochastic process that satisfies the Kolmogorov condition for exponents $(p,q)$ with constant $M$, with $q > d$ and $p > 0$.
@@ -705,6 +709,7 @@ Then for all $\beta \in(0, (q - d)/p)$ there exists a finite constant $L(T, c, d
   \le M L(T, c, d, p, q, \beta)
   \: .
 \end{align*}
+{\color{blue}xxx If L is supposed to be a universal constant, I don't see how it could depend on $T$. Does it really? (Note that if it only depends on $T$ through its diameter, then in fact it doesn't depend on $T$ since the diameter can be bounded in terms of $c$ and $d$: for epsilon with $c \epsilon^{-d} < 1$, the covering condition would say that $T$ is bounded by $0$ balls, which is a contradiction; so this epsilon is $> diam T$, which gives you the claimed bound on the diameter)}
 If furthermore $E$ is complete and $T$ is second-countable, then the process $X$ has a modification with Hölder continuous paths of exponent $\beta$ for all $\beta \in (0, (q - d)/p)$.
 \end{theorem}
 
@@ -751,7 +756,7 @@ Then $X$ has a modification $Y$ such that the paths of $Y$ are locally Hölder c
 \end{theorem}
 
 The hypothesis on $T$ is satisfied for $T = \mathbb{R}_+$, with $T_n = [0,n)$ (which is open in $\mathbb{R}_+$), for $d = 1$.
-Although we use it only for $T = \mathbb{R}_+$, Theorem~\ref{thm:localized_holder_modification_sup} can be used in higher dimension and in more involved cases: the authors of \cite{kratschmer2023kolmogorov} show how to apply it to subsets of $m$-dimensional Riemannian manifolds.
+Although we use it only for $T = \mathbb{R}_+$, Theorem~\ref{thm:localized_holder_modification_sup} can be used in higher dimension and in more involved cases: the authors of \cite{kratschmer2023kolmogorov} show how to apply it to subsets of $d$-dimensional Riemannian manifolds.
 
 We don't describe the proof of Theorem~\ref{thm:localized_holder_modification_sup} in detail here (we refer the reader to \cite{kratschmer2023kolmogorov}, or to the code): it consists in applying the same type of arguments as in the proof of the second part of Theorem~\ref{thm:kolmogorov_chentsov} to build separately modifications for each set $T_n$ and exponents ($p_m, q_m)$ and then combine them into one process (see section~\ref{sub:holder_process}).
 
@@ -767,7 +772,7 @@ Part of the reason for choosing to formalize the Kolmogorov-Chentsov theorem as 
 \paragraph{Covers}
 
 An (internal) $\varepsilon$-cover of $T$ is a subset $S \subseteq T$ such that for all $t \in T$, there exists $s \in S$ such that $d_T(s, t) \le \varepsilon$.
-If $T$ has bounded diameter we can find an $\varepsilon$-cover which is finite, and the covering number of $T$ for $\varepsilon > 0$ is the minimal cardinality of an $\varepsilon$-cover of $T$, denoted by $N_\varepsilon(T)$.
+If $T$ has bounded diameter we can find an $\varepsilon$-cover which is finite {\color{blue} xxx Not true in general (the unit ball in an infinite-dimensional Hilbert space is a counterexample). You need total boundedness here.}, and the covering number of $T$ for $\varepsilon > 0$ is the minimal cardinality of an $\varepsilon$-cover of $T$, denoted by $N_\varepsilon(T)$.
 We call a cover with that cardinality a minimal $\varepsilon$-cover.
 Our formalization also includes definitions of external covers and covering numbers, packing numbers and inequalities between these numbers and the volume of balls. We don't detail those here, but the relations between those quantities are helpful to prove properties of covering numbers.
 
@@ -833,7 +838,7 @@ Then there exists a set $K \subseteq J^2$ such that for any pseudo-metric space 
 
 \subsubsection{Proof of the main inequality}
 
-Under the assumptions of Theorem~\ref{thm:kolmogorov_chentsov}, we prove that for all countable subset $T' \subseteq T$,
+Under the assumptions of Theorem~\ref{thm:kolmogorov_chentsov}, we prove that for any countable subset $T' \subseteq T$,
 \begin{align*}
   \mathbf{E}\left[ \sup_{s, t \in T'} \frac{d_E(X_s, X_t)^p}{d_T(s, t)^{\beta p}} \right]
   \le M L(T, c, d, p, q, \beta)
@@ -916,7 +921,7 @@ We apply the inequality~\eqref{eq:kolmogorov_condition_finite_set} for $K = \{(s
 \end{align*}
 Since $\varepsilon_m \le \delta \le 4 \varepsilon_m$, we obtain a bound of order $\delta^{q - 2d}$, which is not sufficient to conclude the proof with the right exponent $\delta^{q - d}$.
 The issue is the square on the cardinal of the cover $C_m$, and this is where the pair reduction lemma (Lemma~\ref{lem:pair_reduction}) comes into play.
-With that lemma applied to $a = 2$, $n = \lceil \log_2 J \rceil$ and $c = 8 \varepsilon_m$, we obtain a set $K \subseteq C_m^2$ with $\lvert K \rvert \le 2 \lvert C_m \rvert$ and $\sup_{(s, t) \in K} d_T(s, t) \le 8 n \varepsilon_m$, such that an application of \eqref{eq:kolmogorov_condition_finite_set} gives
+With that lemma applied to $a = 2$, $n = \lceil \log_2 J \rceil$ {\color{blue}xxx Should $J$ it be $C_m$?} and $c = 8 \varepsilon_m$, we obtain a set $K \subseteq C_m^2$ with $\lvert K \rvert \le 2 \lvert C_m \rvert$ and $\sup_{(s, t) \in K} d_T(s, t) \le 8 n \varepsilon_m$, such that an application of \eqref{eq:kolmogorov_condition_finite_set} gives
 \begin{align*}
   \mathbf{E}\left[ \sup_{\substack{s, t \in C_m \\ d_T(s, t) \le 8 \varepsilon_m}} d_E(X_s, X_t)^p \right]
   &\le 2^p \mathbf{E}\left[ \sup_{s, t \in K} d_E(X_s, X_t)^p \right]
@@ -937,7 +942,7 @@ For $p \le 1$ we use that the power function is sub-additive: for $a, b \ge 0$, 
   \le \sum_{i=m}^{N-1} \mathbf{E}\left[\sup_{s \in C_N} d_E(X_{\bar{s}_{i+1}}, X_{\bar{s}_i})^p\right]
   \: .
 \end{align*}
-It remains to control the expectation inside the sum, which we do using the Kolmogorov condition though Equation~\eqref{eq:kolmogorov_condition_finite_set} with $K = \{(\bar{s}_{i+1}, \bar{s}_i) \mid s \in C_N\}$. That set has cardinal at most $\lvert C_{i+1} \rvert$ (the number of possible values for $\bar{s}_{i+1}$, since $\bar{s}_i$ is a function of $\bar{s}_{i+1}$).
+It remains to control the expectation inside the sum, which we do using the Kolmogorov condition through Equation~\eqref{eq:kolmogorov_condition_finite_set} with $K = \{(\bar{s}_{i+1}, \bar{s}_i) \mid s \in C_N\}$. That set has cardinal at most $\lvert C_{i+1} \rvert$ (the number of possible values for $\bar{s}_{i+1}$, since $\bar{s}_i$ is a function of $\bar{s}_{i+1}$).
 \begin{align*}
   \mathbf{E}\left[\sup_{s \in C_N} d_E(X_{\bar{s}_{i+1}}, X_{\bar{s}_i})^p\right]
   &\le M \lvert C_{i+1} \rvert \varepsilon_i^q
@@ -986,7 +991,7 @@ We finally need to show that $Y$ is a modification of $X$.
 It is actually only a ``distance zero modification'', by which we mean that $d_E(X_t, Y_t) = 0$ almost surely.
 Since $E$ is only a pseudo-metric space, $Y$ might not satisfy the modification property $Y_t = X_t$ almost surely.
 We refer to \cite{kratschmer2023kolmogorov} for the proof that $Y$ is a distance zero modification of $X$\footnote{They use a metric space assumption for $E$ and prove that $Y$ is a true modification: replacing equalities with distance zero statements gives our proof for pseudo-metric spaces.}, and only note that it uses convergence in probability, which we had to generalize in \mathlib from pseudo-metric to extended pseudo-metric spaces.
-From a distance zero modification $Y$ of $X$, we can obtain a true modification in a pseudo-metric space as follows: for each $t \in T$, let $Z_t$ be equal to $X_t$ on the event where $d_E(X_t, Y_t) = 0$, and equal to $Y_0$ otherwise.
+From a distance zero modification $Y$ of $X$, we can obtain a true modification in a pseudo-metric space as follows: for each $t \in T$, let $Z_t$ be equal to $X_t$ on the event where $d_E(X_t, Y_t) = 0$, and equal to $Y_t$ otherwise.
 Then $Z_t = X_t$ almost surely, and since $d_E(Z_t(\omega), Y_t(\omega)) = 0$ for all $t$ and all $\omega$, $Z$ has the same continuity properties as $Y$.
 Finally, $Z$ is measurable (that is, $Z_t$ is measurable for all $t$), since a random variable that is at distance zero from a measurable random variable is itself measurable.
 
@@ -1021,7 +1026,7 @@ All the results presented so far can be used together to construct a Brownian mo
 We build a stochastic process $(B_t)_{t \in \mathbb{R}_+}$ such that
 \begin{itemize}
   \item $B$ has continuous paths,
-  \item $B_0 = 0$ almost surely,
+  \item $B_0 = 0$ almost surely, {\color{blue} Can't you even guarantee that $B_0 = 0$ everywhere, by taking $x_0 = 0$ in the construction of $Y_t$ on Page 32?}
   \item for all $n \in \mathbb{N}$ and $t_1, \ldots, t_n \in \mathbb{R}_+$, the vector $(B_{t_1}, \ldots, B_{t_n})$ has a multivariate normal distribution with mean $0$ and covariance matrix given by $\mathbf{cov}(B_{t_i}, B_{t_j}) = t_i \wedge t_j$.
 \end{itemize}
 
@@ -1031,7 +1036,7 @@ We then check that they form a projective family and apply the Kolmogorov extens
 Let $(C_t)_{t \in \mathbb{R}_+}$ be the canonical process on $\mathbb{R}^{\mathbb{R}_+}$, defined by $C_t(\omega) = \omega(t)$ for all $\omega \in \mathbb{R}^{\mathbb{R}_+}$.
 The process $C$ is measurable, and its finite-dimensional distributions in the measure space $(\mathbb{R}^{\mathbb{R}_+}, P_B)$ are the projective family we defined.
 
-Finally, we check that $C$ satisfies the Kolmogorov condition for exponents $(2n, n)$ for all $n \in \mathbb{N}$ with constant $M = (2n - 1)!!$ (the double factorial, product of all odd integers up to $2n - 1$).
+Finally, we check that $C$ satisfies the Kolmogorov condition for exponents $(2n, n)$ for all $n \in \mathbb{N}$ with constant $M = (2n - 1)!!$ (the double factorial, product of all odd integers up to $2n - 1$). {\color{blue} Just to clarify, wouldn't the condition for $(2, 1)$ be enough to get Hölder continuous path with any exponent $<1/2$?}
 We can then apply Theorem~\ref{thm:localized_holder_modification_sup} to obtain a modification $B$ of $C$ with locally Hölder continuous paths of all orders $\gamma \in (0, 1/2)$.
 In particular, $B$ has continuous paths.
 The process $B$ is a Brownian motion indexed by $\mathbb{R}_+$ with values in $\mathbb{R}$.
@@ -1060,7 +1065,7 @@ Consider $B$ a Brownian motion. Then:
 \begin{enumerate}[noitemsep]
   \item for $c>0$, the process $B_{ct}/\sqrt{c}$ is a Brownian motion;
   \item \textbf{weak Markov property:} for $t_0 \in \mathbb{R}_+$, the process $B_{t_0 + t} - B_{t_0}$ is a Brownian motion independent of $(B_t)_{t \le t_0}$;
-  \item The process $(C_t)_{t \in \mathbb{R}_+}$ defined by $C_0 := 0$ and $C_t := t B_{1/t}$ for $t > 0$ is a Brownian motion;
+  \item The process $(C_t)_{t \in \mathbb{R}_+}$ defined by $C_0 := 0$ and $C_t := t B_{1/t}$ for $t > 0$ is a Brownian motion; {\color{blue} xxx It is not obvious what that means for $t=0$.}
   \item $B_t/t$ tends to 0 almost surely as $t$ tends to infinity.
 \end{enumerate}
 \end{proposition}
@@ -1068,7 +1073,7 @@ Consider $B$ a Brownian motion. Then:
 Let us focus on the first three statements, the fourth one being an easy consequence of the third. Computing the expectation and the variance is quite easy. On paper, proving that these are Gaussian processes is also straightforward, because a linear combination of marginals of any of theses processes is also clearly a linear combination of marginals of the process $B$, and thus has Gaussian law. This is not as obvious to formalize, because the notion of "being a linear combination of marginals" is a bit messy to work with. What we were able to formalize nicely however is the following lemma.
 
 \begin{lemma}[\bmlink{Gaussian/GaussianProcess}{L217-L223}{ProbabilityTheory.IsGaussianProcess.of_isGaussianProcess}]\label{lem:isGaussOfIsGauss}
-Let $(X_t)_{t \in T}$ be an $E$-valued Gaussian process and $(Y_s)_{s \in S}$ be an $F$-valued stochastic process. If for all $s \in S$, there exists $I$ a finite subset of $T$ and $L : E^I \to F$ a continuous linear map such that $Y_s = L((X_t)_{t \in I})$, then $Y$ is a Gaussian process.
+Let $(X_t)_{t \in T}$ be an $E$-valued Gaussian process and $(Y_s)_{s \in S}$ be an $F$-valued stochastic process. If for all $s \in S$, there exists $I$ a finite subset of $T$ and $L : E^I \to F$ a continuous linear map such that $Y_s = L((X_t)_{t \in I})$ {\color{blue} xxx Is this equality supposed to hold everywhere or almost everywhere? (I guess almost everywhere would be enough, but in practice it will be everywhere in all applications?)}, then $Y$ is a Gaussian process.
 \end{lemma}
 
 This statement makes proving Gaussianity in (1), (2) and (3) straightforward, especially because proving linearity is easy thanks to the different automation tactics available in \mathlib.
@@ -1093,7 +1098,7 @@ The main issue is that we manipulate finite-dimensional laws as distributions ov
 In particular, the way to prove Proposition~\ref{prop:isBrownianOfIndep} is to first show that the hypotheses imply that the process is Gaussian, and then apply Proposition~\ref{prop:isBrownianOfCov}. To do that we prove this more general result:
 
 \begin{lemma}[\bmlink{Gaussian/BrownianMotion}{L161-L168}{ProbabilityTheory.HasIndepIncrements.isGaussianProcess}]
-Let $E$ be a second-countable Banach space and $T$ be an index set that is linearly ordered with a least element $\bot$. Consider $(X_t)_{t \in T}$ an $E$-valued stochastic process with independent increments, and such that for all $t$, $X_t$ has a Gaussian law. Further assume that $X_\bot$ is almost surely equal to $0$. Then $X$ is a Gaussian process.
+Let $E$ be a second-countable Banach space and $T$ be a linearly ordered index set with a least element $\bot$. Consider $(X_t)_{t \in T}$ an $E$-valued stochastic process with independent increments, and such that for all $t$, $X_t$ has a Gaussian law. Further assume that $X_\bot$ is almost surely equal to $0$. Then $X$ is a Gaussian process.
 \end{lemma}
 
 This is probably the lemma which required most work. The idea is to say that $(X_{t_1}, ..., X_{t_n})$ can be expressed as a linear combination of the increments $(X_{t_1} - X_\bot, ..., X_{t_n} - X_{t_{n-1}})$. Because the increments are independent and each $X_t$ is Gaussian, we can prove that each increment is Gaussian. Because they are independent, their linear combination is also Gaussian, and so $(X_{t_1}, ..., X_{t_n})$ is Gaussian. Making the linear combination explicit and proving the equality was rather technical.

--- a/BM_paper/main.tex
+++ b/BM_paper/main.tex
@@ -157,7 +157,7 @@ Before making the project public, we thus spent time detailing every step of the
 We started by implementing in \Lean several key definitions and statements (without proofs): there are always several ways to turn a mathematical concept into a \Lean definition, and in order to collaborate on a project it is important to decide early on a unique way to talk about any concept to ensure compatibility of the code produced, even if the definition chosen can then be refined.
 Different parts of the blueprint had different levels of details: we wrote a precise description of the technical Kolmogorov-Chentsov proof, but omitted many proofs for more standard results on Gaussian distributions.
 
-The project was announced on the \href{https://leanprover.zulipchat.com/}{Lean Zulip website}, and anyone interested was invited to contribute. D.L. and E.M. joined the project at that time and then contributed significantly to the formalization. The coordination of the project was done through discussions in a Zulip channel: lists of tasks and progress updates were regularly posted, and volunteers could claim the tasks and report on their progress. (The full list of contributors -- excluding authors of the present manuscript -- with more than five commits is:  Eugenio Cainelli, Markus Himmel, Nikolas Kuhn, Yongxi (Aaron) Lin,   Lorenzo Luccioli, Jack McCarthy, Pietro Monticone, Jérémy Scanvic, Kexing Ying, Thomas Zhu.)
+The project was announced on the \href{https://leanprover.zulipchat.com/}{Lean Zulip website}, and anyone interested was invited to contribute. D.L. and E.M. joined the project at that time and then contributed significantly to the formalization. The coordination of the project was done through discussions in a Zulip channel: lists of tasks and progress updates were regularly posted, and volunteers could claim the tasks and report on their progress. (The full list of contributors is in the acknowledgements.)
 The correctness of the code was ensured by continuous integration scripts on github, which automatically check that the code compiles without errors, and by manual review of the proposed additions.
 The blueprint continued to evolve during the formalization, as new lemmas were added (once because a small gap was identified in the blueprint proof), definitions were changed to better fit the needs of writing in \Lean, and small mistakes were corrected (particularly in the exact value of constants used in the Kolmogorov-Chentsov proof).
 
@@ -698,20 +698,17 @@ Therefore, we introduce a definition \lstinline|IsAEKolmogorovProcess| for the p
 \subsubsection{The main theorem}
 
 We formalize a recent and general version of the Kolmogorov-Chentsov theorem \cite[Theorem 1]{kratschmer2023kolmogorov}, which applies to extended pseudo-metric spaces under a covering assumption on the index set $T$.
-We say that $T$ has bounded covering number with constant $c > 0$ and exponent $d \ge 0$ if for all $\varepsilon \in (0, \mathrm{diam}(T)]$, $T$ can be covered by at most $c \varepsilon^{-d}$ balls of radius $\varepsilon$ (see Definition~\ref{def:bounded_covering_number} below). Note that such a space is totally bounded by construction.
-
-{\color{blue} xxx Maybe add "Note also that this condition implies $diam(T) < \infty$, even if $T$ is an extended metric space to start with".}
+We say that $T$ has bounded covering number with constant $c > 0$ and exponent $d \ge 0$ if for all $\varepsilon \in (0, \mathrm{diam}(T)]$, $T$ can be covered by at most $c \varepsilon^{-d}$ balls of radius $\varepsilon$ (see Definition~\ref{def:bounded_covering_number} below). Note that such a space is totally bounded with finite diameter by construction.
 
 \begin{theorem}[Kolmogorov-Chentsov]\label{thm:kolmogorov_chentsov}
 Suppose that the index set $T$ has bounded covering number with constant $c>0$ and exponent $d > 0$.
 Let $(X_t)_{t \in T}$ be a stochastic process that satisfies the Kolmogorov condition for exponents $(p,q)$ with constant $M$, with $q > d$ and $p > 0$.
-Then for all $\beta \in(0, (q - d)/p)$ there exists a finite constant $L(T, c, d, p, q, \beta)$ such that for every countable subset $T' \subseteq T$,
+Then for all $\beta \in(0, (q - d)/p)$ there exists a finite constant $L(c, d, p, q, \beta)$ such that for every countable subset $T' \subseteq T$,
 \begin{align*}
   \mathbf{E}\left[ \sup_{s, t \in T'} \frac{d_E(X_s, X_t)^p}{d_T(s, t)^{\beta p}} \right]
-  \le M L(T, c, d, p, q, \beta)
+  \le M L(c, d, p, q, \beta)
   \: .
 \end{align*}
-{\color{blue}xxx If L is supposed to be a universal constant, I don't see how it could depend on $T$. Does it really? (Note that if it only depends on $T$ through its diameter, then in fact it doesn't depend on $T$ since the diameter can be bounded in terms of $c$ and $d$: for epsilon with $c \epsilon^{-d} < 1$, the covering condition would say that $T$ is bounded by $0$ balls, which is a contradiction; so this epsilon is $> diam T$, which gives you the claimed bound on the diameter)}
 If furthermore $E$ is complete and $T$ is second-countable, then the process $X$ has a modification with Hölder continuous paths of exponent $\beta$ for all $\beta \in (0, (q - d)/p)$.
 \end{theorem}
 
@@ -721,6 +718,8 @@ Indeed, if $d_T(s, t) = 0$, then the Kolmogorov condition implies that $d_E(X_s,
 
 
 Note that $T$ is said to be an \emph{extended} pseudo-metric space, but the bounded covering number condition implies that $T$ has finite diameter, hence is a pseudo-metric space.
+Indeed, since a nonempty set cannot be covered by fewer than one ball, applying the covering condition at $\varepsilon = \mathrm{diam}(T)$ shows that $\mathrm{diam}(T) \le c^{1/d}$.
+This is also the reason why the constant $L(c, d, p, q, \beta)$ does not depend on $T$: the proof produces a constant involving $\mathrm{diam}(T)$, which we bound by $c^{1/d}$.
 The \Lean code is nonetheless written for a distance with values in $[0,+\infty]$, for two reasons: first the distance on $E$ has that type and using the same types for both is easier, and second it allows us to work with \mathlib's Lebesgue integral (which expect that co-domain for the functions we integrate).
 Working with the Lebesgue integral is easier than using \mathlib's Bochner integral since manipulating the latter often requires proving integrability of the functions we consider.
 Therefore, from the beginning of the project we made the design choice to consider any non-negative function as taking values in $[0,+\infty]$, and to use the Lebesgue integral whenever possible.
@@ -774,7 +773,7 @@ Part of the reason for choosing to formalize the Kolmogorov-Chentsov theorem as 
 \paragraph{Covers}
 
 An (internal) $\varepsilon$-cover of $T$ is a subset $S \subseteq T$ such that for all $t \in T$, there exists $s \in S$ such that $d_T(s, t) \le \varepsilon$.
-If $T$ has bounded diameter we can find an $\varepsilon$-cover which is finite {\color{blue} xxx Not true in general (the unit ball in an infinite-dimensional Hilbert space is a counterexample). You need total boundedness here.}, and the covering number of $T$ for $\varepsilon > 0$ is the minimal cardinality of an $\varepsilon$-cover of $T$, denoted by $N_\varepsilon(T)$.
+The covering number of $T$ for $\varepsilon > 0$, denoted by $N_\varepsilon(T)$, is the minimal cardinality of a finite $\varepsilon$-cover of $T$, or $+\infty$ if no finite $\varepsilon$-cover exists; it is finite for every $\varepsilon > 0$ if and only if $T$ is totally bounded. Accordingly, in our formalization the covering number takes values in $\mathbb{N} \cup \{+\infty\}$.
 We call a cover with that cardinality a minimal $\varepsilon$-cover.
 Our formalization also includes definitions of external covers and covering numbers, packing numbers and inequalities between these numbers and the volume of balls. We don't detail those here, but the relations between those quantities are helpful to prove properties of covering numbers.
 
@@ -831,7 +830,7 @@ Let $T$ be a pseudo-metric space, $c \ge 0$, $J$ a finite subset of $T$, $a \ge 
 Then there exists a set $K \subseteq J^2$ such that for any pseudo-metric space $E$ and any map $f: T \to E$~,
 \begin{enumerate}
   \item $\lvert K \rvert \le a \lvert J \rvert$~,
-  \item for all $(s, t) \in J^2$, $d_T(s, t) \le cn$~,
+  \item for all $(s, t) \in K$, $d_T(s, t) \le cn$~,
   \item $\sup_{s, t \in J, \: d_T(s, t) \le c} d_E(f(s), f(t)) \le 2 \sup_{(s, t) \in K} d_E(f(s), f(t))$~.
 \end{enumerate}
 \end{lemma}
@@ -923,7 +922,7 @@ We apply the inequality~\eqref{eq:kolmogorov_condition_finite_set} for $K = \{(s
 \end{align*}
 Since $\varepsilon_m \le \delta \le 4 \varepsilon_m$, we obtain a bound of order $\delta^{q - 2d}$, which is not sufficient to conclude the proof with the right exponent $\delta^{q - d}$.
 The issue is the square on the cardinal of the cover $C_m$, and this is where the pair reduction lemma (Lemma~\ref{lem:pair_reduction}) comes into play.
-With that lemma applied to $a = 2$, $n = \lceil \log_2 J \rceil$ {\color{blue}xxx Should $J$ it be $C_m$?} and $c = 8 \varepsilon_m$, we obtain a set $K \subseteq C_m^2$ with $\lvert K \rvert \le 2 \lvert C_m \rvert$ and $\sup_{(s, t) \in K} d_T(s, t) \le 8 n \varepsilon_m$, such that an application of \eqref{eq:kolmogorov_condition_finite_set} gives
+With that lemma applied to $J = C_m$, $a = 2$, $n = \lceil \log_2 \lvert C_m \rvert \rceil$ and $c = 8 \varepsilon_m$, we obtain a set $K \subseteq C_m^2$ with $\lvert K \rvert \le 2 \lvert C_m \rvert$ and $\sup_{(s, t) \in K} d_T(s, t) \le 8 n \varepsilon_m$, such that an application of \eqref{eq:kolmogorov_condition_finite_set} gives
 \begin{align*}
   \mathbf{E}\left[ \sup_{\substack{s, t \in C_m \\ d_T(s, t) \le 8 \varepsilon_m}} d_E(X_s, X_t)^p \right]
   &\le 2^p \mathbf{E}\left[ \sup_{s, t \in K} d_E(X_s, X_t)^p \right]

--- a/BM_paper/main.tex
+++ b/BM_paper/main.tex
@@ -1068,7 +1068,7 @@ Consider $B$ a Brownian motion. Then:
 \begin{enumerate}[noitemsep]
   \item for $c>0$, the process $B_{ct}/\sqrt{c}$ is a Brownian motion;
   \item \textbf{weak Markov property:} for $t_0 \in \mathbb{R}_+$, the process $B_{t_0 + t} - B_{t_0}$ is a Brownian motion independent of $(B_t)_{t \le t_0}$;
-  \item The process $(C_t)_{t \in \mathbb{R}_+}$ defined by $C_0 := 0$ and $C_t := t B_{1/t}$ for $t > 0$ is a Brownian motion; {\color{blue} xxx It is not obvious what that means for $t=0$.}
+  \item The process $(C_t)_{t \in \mathbb{R}_+}$ defined by $C_0 := 0$ and $C_t := t B_{1/t}$ for $t > 0$ is a Brownian motion;
   \item $B_t/t$ tends to 0 almost surely as $t$ tends to infinity.
 \end{enumerate}
 \end{proposition}

--- a/BM_paper/main.tex
+++ b/BM_paper/main.tex
@@ -558,9 +558,6 @@ Our formalization uses many results from \mathlib and we relied on characteristi
 
 Note that some results could be generalized on more general spaces, namely locally convex vector spaces. One could in particular aim for a formalization of the Bochner-Minlos Theorem, which is not yet available in \mathlib. (Note that this result was recently auto-formalized for the development of Quantum Field Theory in \cite{douglas2026qft}, although it would require a lot of work to upstream it to \mathlib.)
 
-Note that Gaussian distributions could be defined on more general spaces (locally convex vector spaces). The construction requires a formalization of  the Bochner-Minlos Theorem, which is not yet available in \mathlib. (However, note that this result was recently formalized for the development of Quantum Field Theory in \cite{douglas2026qft}.)
-
-
 \subsubsection{Gaussian distributions}
 
 We start by recalling the definition of the characteristic function of a general measure. Fix $E$ a real Banach space, and denote by $E'$ its topological dual, i.e. the set of continuous linear forms on $E$. Consider $\mu$ a measure over $E$, and denote by $\mathbf E_\mu$ and $\mathrm{var}_\mu$ the associated expectation and variance operators.
@@ -1027,7 +1024,7 @@ All the results presented so far can be used together to construct a Brownian mo
 We build a stochastic process $(B_t)_{t \in \mathbb{R}_+}$ such that
 \begin{itemize}
   \item $B$ has continuous paths,
-  \item $B_0 = 0$ almost surely, {\color{blue} Can't you even guarantee that $B_0 = 0$ everywhere, by taking $x_0 = 0$ in the construction of $Y_t$ on Page 32?}
+  \item $B_0 = 0$ almost surely,
   \item for all $n \in \mathbb{N}$ and $t_1, \ldots, t_n \in \mathbb{R}_+$, the vector $(B_{t_1}, \ldots, B_{t_n})$ has a multivariate normal distribution with mean $0$ and covariance matrix given by $\mathbf{cov}(B_{t_i}, B_{t_j}) = t_i \wedge t_j$.
 \end{itemize}
 

--- a/BM_paper/main.tex
+++ b/BM_paper/main.tex
@@ -1042,6 +1042,7 @@ Finally, we check that $C$ satisfies the Kolmogorov condition for exponents $(2n
 We can then apply Theorem~\ref{thm:localized_holder_modification_sup} to obtain a modification $B$ of $C$ with locally Hölder continuous paths of all orders $\gamma \in (0, 1/2)$.
 In particular, $B$ has continuous paths.
 The process $B$ is a Brownian motion indexed by $\mathbb{R}_+$ with values in $\mathbb{R}$.
+Note that it is important to have the Kolmogorov condition for all exponents $(2n, n)$ to obtain Hölder continuity for $\gamma < 1/2$, as in this case Theorem~\ref{thm:localized_holder_modification_sup} gives Hölder continuity for $\gamma < \sup_n \frac{n-1}{2n} = 1/2$.
 
 \paragraph{Properties of the Brownian motion}
 

--- a/BM_paper/main.tex
+++ b/BM_paper/main.tex
@@ -553,8 +553,10 @@ Our goal is to define a process with Gaussian finite-dimensional distributions.
 Prior to our work, \mathlib contained the definition of the one-dimensional normal distribution \mllink{Probability/Distributions/Gaussian/Real}{L198-L201}{ProbabilityTheory.gaussianReal}, but not more general Gaussian measures.
 We will denote by $N(m, \sigma^2)$ the normal distribution on $\mathbb{R}$ with mean $m$ and variance $\sigma^2$.
 In order to define the law of a Brownian motion on $\mathbb{R}_+$, we need definitions and properties of multivariate Gaussian distributions.
-We did not however define Gaussian measures only for that setting, but first introduced a general definition for Banach spaces, and then specialized it to Hilbert and finally finite dimensional spaces.
+We did not however define Gaussian measures only for that setting, but first introduced a general definition which makes sense in an arbitrary module equipped with a topology. Then we proved several results for general Banach spaces, and specialized some of them to Hilbert spaces and finally finite dimensional spaces.
 Our formalization uses many results from \mathlib and we relied on characteristic functions \mllink{MeasureTheory/Measure/CharacteristicFunction}{L322-L325}{MeasureTheory.charFunDual}, as well as the fact that they uniquely determine a probability measure \mllink{MeasureTheory/Measure/CharacteristicFunction}{L435-L439}{MeasureTheory.Measure.ext_of_charFunDual}.
+
+Note that some results could be generalized on more general spaces, namely locally convex vector spaces. One could in particular aim for a formalization of the Bochner-Minlos Theorem, which is not yet available in \mathlib. (Note that this result was recently auto-formalized for the development of Quantum Field Theory in \cite{douglas2026qft}, although it would require a lot of work to upstream it to \mathlib.)
 
 Note that Gaussian distributions could be defined on more general spaces (locally convex vector spaces). The construction requires a formalization of  the Bochner-Minlos Theorem, which is not yet available in \mathlib. (However, note that this result was recently formalized for the development of Quantum Field Theory in \cite{douglas2026qft}.)
 

--- a/BM_paper/main.tex
+++ b/BM_paper/main.tex
@@ -1076,7 +1076,7 @@ Consider $B$ a Brownian motion. Then:
 Let us focus on the first three statements, the fourth one being an easy consequence of the third. Computing the expectation and the variance is quite easy. On paper, proving that these are Gaussian processes is also straightforward, because a linear combination of marginals of any of theses processes is also clearly a linear combination of marginals of the process $B$, and thus has Gaussian law. This is not as obvious to formalize, because the notion of "being a linear combination of marginals" is a bit messy to work with. What we were able to formalize nicely however is the following lemma.
 
 \begin{lemma}[\bmlink{Gaussian/GaussianProcess}{L217-L223}{ProbabilityTheory.IsGaussianProcess.of_isGaussianProcess}]\label{lem:isGaussOfIsGauss}
-Let $(X_t)_{t \in T}$ be an $E$-valued Gaussian process and $(Y_s)_{s \in S}$ be an $F$-valued stochastic process. If for all $s \in S$, there exists $I$ a finite subset of $T$ and $L : E^I \to F$ a continuous linear map such that $Y_s = L((X_t)_{t \in I})$ {\color{blue} xxx Is this equality supposed to hold everywhere or almost everywhere? (I guess almost everywhere would be enough, but in practice it will be everywhere in all applications?)}, then $Y$ is a Gaussian process.
+Let $(X_t)_{t \in T}$ be an $E$-valued Gaussian process and $(Y_s)_{s \in S}$ be an $F$-valued stochastic process. If for all $s \in S$, there exists $I$ a finite subset of $T$ and $L : E^I \to F$ a continuous linear map such that $Y_s = L((X_t)_{t \in I})$, then $Y$ is a Gaussian process.
 \end{lemma}
 
 This statement makes proving Gaussianity in (1), (2) and (3) straightforward, especially because proving linearity is easy thanks to the different automation tactics available in \mathlib.

--- a/BrownianMotion/Continuity/HasBoundedInternalCoveringNumber.lean
+++ b/BrownianMotion/Continuity/HasBoundedInternalCoveringNumber.lean
@@ -45,6 +45,26 @@ lemma HasBoundedInternalCoveringNumber.diam_lt_top
     exists_prop, exists_eq_right_right, Finset.coe_empty, isCover_empty_iff, Set.empty_subset] at h
   simp [h] at this
 
+lemma HasBoundedInternalCoveringNumber.diam_le
+    (h : HasBoundedInternalCoveringNumber A c d) (hd : 0 < d) :
+    EMetric.diam A ≤ c ^ d⁻¹ := by
+  rcases eq_or_ne (EMetric.diam A) 0 with h0 | h0
+  · simp [h0]
+  · have hA : A.Nonempty := by
+      rw [Set.nonempty_iff_ne_empty]
+      rintro rfl
+      exact h0 EMetric.diam_empty
+    have h1 : 1 ≤ c * (EMetric.diam A)⁻¹ ^ d := by
+      refine le_trans ?_ (h _ le_rfl)
+      exact_mod_cast hA.one_le_internalCoveringNumber _
+    have h2 : EMetric.diam A ^ d ≤ c := by
+      have := mul_le_mul_right' h1 (EMetric.diam A ^ d)
+      rwa [one_mul, mul_assoc, ← ENNReal.mul_rpow_of_ne_top (by simp [h0]) (h.diam_lt_top hd).ne,
+        ENNReal.inv_mul_cancel h0 ((h.diam_lt_top hd).ne), ENNReal.one_rpow, mul_one] at this
+    calc EMetric.diam A = (EMetric.diam A ^ d) ^ d⁻¹ := by
+          rw [← ENNReal.rpow_mul, mul_inv_cancel₀ hd.ne', ENNReal.rpow_one]
+      _ ≤ c ^ d⁻¹ := ENNReal.rpow_le_rpow h2 (by positivity)
+
 lemma HasBoundedInternalCoveringNumber.subset {B : Set T}
     (h : HasBoundedInternalCoveringNumber A c d) (hBA : B ⊆ A) (hd : 0 ≤ d) :
     HasBoundedInternalCoveringNumber B (2 ^ d * c) d := by

--- a/BrownianMotion/Continuity/KolmogorovChentsovInequality.lean
+++ b/BrownianMotion/Continuity/KolmogorovChentsovInequality.lean
@@ -218,14 +218,14 @@ lemma lintegral_div_edist_le_sum_integral_edist_le (hT : EMetric.diam U < ∞)
 
 noncomputable
 -- the `max 0 ...` in the blueprint is performed by `ENNReal.ofReal` here
-def constL (T : Type*) [PseudoEMetricSpace T] (c : ℝ≥0∞) (d p q β : ℝ) (U : Set T) : ℝ≥0∞ :=
-  2 ^ (2 * p + 5 * q + 1) * c * (EMetric.diam U + 1) ^ (q - d)
+def constL (c : ℝ≥0∞) (d p q β : ℝ) : ℝ≥0∞ :=
+  2 ^ (2 * p + 5 * q + 1) * c * (c ^ d⁻¹ + 1) ^ (q - d)
   * ∑' (k : ℕ), 2 ^ (k * (β * p - (q - d)))
       * (4 ^ d * (ENNReal.ofReal (Real.logb 2 c.toReal + (k + 2) * d)) ^ q + Cp d p q)
 
-lemma constL_lt_top (hT : EMetric.diam U < ∞)
+lemma constL_lt_top
     (hc : c ≠ ∞) (hd_pos : 0 < d) (hp_pos : 0 < p) (hdq_lt : d < q) (hβ_lt : β < (q - d) / p) :
-    constL T c d p q β U < ∞ := by
+    constL c d p q β < ∞ := by
   have hq_pos : 0 < q := lt_trans hd_pos hdq_lt
   have hC : Cp d p q ≠ ⊤ := by
     unfold Cp
@@ -237,7 +237,9 @@ lemma constL_lt_top (hT : EMetric.diam U < ∞)
   have hC_pos : 0 < Cp d p q := by
     unfold Cp
     apply lt_max_of_lt_right (ENNReal.div_pos (by norm_num) (by finiteness))
-  apply ENNReal.mul_lt_top (by finiteness)
+  have h_rpow_ne : c ^ d⁻¹ ≠ ∞ := ENNReal.rpow_ne_top_of_nonneg (inv_nonneg.mpr hd_pos.le) hc
+  apply ENNReal.mul_lt_top (ENNReal.mul_lt_top (by finiteness)
+    (ENNReal.rpow_lt_top_of_nonneg (by linarith) (by finiteness)))
   conv =>
     enter [1, 1, _]
     rw [← (ENNReal.ofReal_toReal_eq_iff (a := _ * _)).mpr (by finiteness),
@@ -311,7 +313,7 @@ theorem finite_kolmogorov_chentsov
     (hd_pos : 0 < d) (hdq_lt : d < q)
     (hβ_pos : 0 < β) (T' : Set T) [hT' : Finite T'] (hT'U : T' ⊆ U) :
     ∫⁻ ω, ⨆ (s : T') (t : T'), edist (X s ω) (X t ω) ^ p / edist s t ^ (β * p) ∂P
-      ≤ M * constL T c d p q β U := by
+      ≤ M * constL c d p q β := by
   have h_diam : EMetric.diam U < ∞ := hT.diam_lt_top hd_pos
   have hq_pos : 0 < q := lt_trans hd_pos hdq_lt
   simp only [constL, ← ENNReal.tsum_mul_left, ge_iff_le] at *
@@ -360,7 +362,7 @@ theorem finite_kolmogorov_chentsov
     · simp
   rw [ENNReal.mul_rpow_of_ne_top (by finiteness) (by finiteness), ← mul_assoc,
     ← mul_assoc _ (2 ^ ((k : ℝ) * _)), ← mul_assoc (M : ℝ≥0∞)]
-  refine mul_le_mul' (le_of_eq ?_) ?_
+  refine mul_le_mul' ?_ ?_
   · calc 2 ^ (k * β * p) * (2 ^ (2 * p + 4 * q + 1) * M * (2 ^ d * c)
         * ((2 * 2⁻¹ ^ k) ^ (q - d) * (EMetric.diam U + 1) ^ (q - d)))
     _ = 2 ^ (k * β * p) * (2 ^ (2 * p + 4 * q + 1) * M * (2 ^ d * c)
@@ -379,6 +381,11 @@ theorem finite_kolmogorov_chentsov
         ring_nf
       · rw [← ENNReal.rpow_add _ _ (by simp) (by simp)]
         ring_nf
+    _ ≤ M * 2 ^ (2 * p + 5 * q + 1) * c * (c ^ d⁻¹ + 1) ^ (q - d)
+        * 2 ^ (↑k * (↑β * p - (q - d))) := by
+      have h_le : (EMetric.diam U + 1) ^ (q - d) ≤ (c ^ d⁻¹ + 1) ^ (q - d) :=
+        ENNReal.rpow_le_rpow (add_le_add_right (hT.diam_le hd_pos) 1) (by linarith)
+      exact mul_le_mul' (mul_le_mul' le_rfl h_le) le_rfl
     _ = _ := by ring
   by_cases hc_zero : c.toReal = 0
   · simp only [ENNReal.toReal_mul, hc_zero, mul_zero, zero_mul, ENNReal.toReal_ofNat,
@@ -407,7 +414,7 @@ theorem countable_kolmogorov_chentsov (hT : HasBoundedInternalCoveringNumber U c
     (hd_pos : 0 < d) (hdq_lt : d < q) (hβ_pos : 0 < β)
     (T' : Set T) [Countable T'] (hT'U : T' ⊆ U) :
     ∫⁻ ω, ⨆ (s : T') (t : T'), edist (X s ω) (X t ω) ^ p / edist s t ^ (β * p) ∂P
-      ≤ M * constL T c d p q β U := by
+      ≤ M * constL c d p q β := by
   let K := (FiniteExhaustion.choice T')
   simp only [iSup_subtype, Subtype.edist_mk_mk, ← biSup_prod', ← (K.prod K).iUnion_eq,
     Set.mem_iUnion, iSup_exists, K.prod_apply, iSup_comm (ι' := ℕ)]
@@ -432,12 +439,11 @@ lemma IsKolmogorovProcess.ae_iSup_rpow_edist_div_lt_top
     {T' : Set T} (hT' : T'.Countable) (hT'U : T' ⊆ U) :
     ∀ᵐ ω ∂P, ⨆ (s : T') (t : T'), edist (X s ω) (X t ω) ^ p / edist s t ^ (β * p) < ∞ := by
   have : Countable T' := hT'
-  have h_diam : EMetric.diam U < ∞ := hT.diam_lt_top hd_pos
   refine ae_lt_top' ?_ ((countable_kolmogorov_chentsov hT hX.IsAEKolmogorovProcess hd_pos
     hdq_lt hβ_pos T' hT'U).trans_lt ?_).ne
   · refine AEMeasurable.iSup (fun s ↦ AEMeasurable.iSup (fun t ↦ ?_))
     exact AEMeasurable.div (hX.measurable_edist.aemeasurable.pow_const _) (by fun_prop)
-  · exact ENNReal.mul_lt_top (by simp) (constL_lt_top h_diam hc hd_pos hX.p_pos hdq_lt hβ_lt)
+  · exact ENNReal.mul_lt_top (by simp) (constL_lt_top hc hd_pos hX.p_pos hdq_lt hβ_lt)
 
 end PseudoEMetricSpace
 

--- a/blueprint/src/chapters/kolmogorov_chentsov.tex
+++ b/blueprint/src/chapters/kolmogorov_chentsov.tex
@@ -331,6 +331,20 @@ If $A$ has bounded internal covering number with constant $c>0$ and exponent $d>
 \end{proof}
 
 
+\begin{lemma}\label{lem:hasBoundedInternalCoveringNumber_diam_le}
+  \uses{def:HasBoundedInternalCoveringNumber}
+  \leanok
+  \lean{HasBoundedInternalCoveringNumber.diam_le}
+If $A$ has bounded internal covering number with constant $c>0$ and exponent $d>0$, then $\mathrm{diam}(A) \le c^{1/d}$.
+\end{lemma}
+
+\begin{proof}\leanok
+If $\mathrm{diam}(A) = 0$ there is nothing to prove.
+Otherwise $A$ is nonempty, so any cover of $A$ has at least one element, and applying the covering condition with $\varepsilon = \mathrm{diam}(A)$ gives
+$1 \le N^{int}_{\mathrm{diam}(A)}(A) \le c \, \mathrm{diam}(A)^{-d}$, hence $\mathrm{diam}(A)^d \le c$.
+\end{proof}
+
+
 \section{Chaining}
 
 \subsection{Chaining sequence}
@@ -1577,8 +1591,8 @@ Note that $\eta_k \ge 2^{-k}$.
   \lean{ProbabilityTheory.constL}
 We introduce the constant
 \begin{align*}
-  L(T, c_1, d, p, q, \beta)
-  &= 2^{2p+5q+1} c_1 (\mathrm{diam}(T)+1)^{q-d}
+  L(c_1, d, p, q, \beta)
+  &= 2^{2p+5q+1} c_1 (c_1^{1/d}+1)^{q-d}
   \\&\quad \times \sum_{k=0}^\infty 2^{k (\beta p - (q-d))}\left(4^d \left(\max\left\{0, \log_2(c_1) + (k + 2)d \right\}\right)^q
     + C_p\right)
   \: .
@@ -1590,14 +1604,14 @@ We introduce the constant
   \uses{def:L}
   \leanok
   \lean{ProbabilityTheory.constL_lt_top}
-For $\mathrm{diam}(T) < \infty$, $p> 0$, $q > d > 0$ and $\beta \in (0, (q-d)/p)$, the constant $L(T, c_1, d, p, q, \beta)$ is finite.
+For $c_1 < \infty$, $p> 0$, $q > d > 0$ and $\beta \in (0, (q-d)/p)$, the constant $L(c_1, d, p, q, \beta)$ is finite.
 \end{lemma}
 
 \begin{proof}
 \leanok
-Let $a_k = 2^{2p+5q+1} M c_1 (\mathrm{diam}(T)+1)^{q-d} 2^{k (\beta p - (q-d))} \left(4^d \left(\max\left\{0, \log_2(c_1) + (k + 2)d \right\}\right)^q
+Let $a_k = 2^{2p+5q+1} M c_1 (c_1^{1/d}+1)^{q-d} 2^{k (\beta p - (q-d))} \left(4^d \left(\max\left\{0, \log_2(c_1) + (k + 2)d \right\}\right)^q
     + C_p\right)$.
-Then $L(T, c_1, d, p, q, \beta) = \sum_{k=0}^\infty a_k$.
+Then $L(c_1, d, p, q, \beta) = \sum_{k=0}^\infty a_k$.
 To show that the sum is finite, we can use the ratio test.
 \begin{align*}
   \frac{\vert a_{k+1} \vert}{\vert a_k \vert}
@@ -1619,14 +1633,14 @@ Let $\beta \in(0, (q - d)/p)$.
 Then
 \begin{align*}
   \mathbb{E}\left[ \sup_{s, t \in J;\: s \ne t} \frac{d_E(X_s, X_t)^p}{d_T(s, t)^{\beta p}} \right]
-  \le M L(T, c_1, d, p, q, \beta)
+  \le M L(c_1, d, p, q, \beta)
   \: .
 \end{align*}
 \end{lemma}
 
 \begin{proof}
   \leanok
-  \uses{cor:finite_set_bound_of_dist_le, lem:integral_div_dist_le_sum_integral_dist_le, lem:hasBoundedInternalCoveringNumber_subset}
+  \uses{cor:finite_set_bound_of_dist_le, lem:integral_div_dist_le_sum_integral_dist_le, lem:hasBoundedInternalCoveringNumber_subset, lem:hasBoundedInternalCoveringNumber_diam_le}
 
 Since $J \subseteq T$, $J$ has bounded internal covering number with constant $2^d c_1$ and exponent $d$ (Lemma~\ref{lem:hasBoundedInternalCoveringNumber_subset}).
 
@@ -1649,9 +1663,13 @@ We apply Corollary~\ref{cor:finite_set_bound_of_dist_le} to bound each expectati
   \\
   &= 2^{2p+5q+1} M c_1 (\mathrm{diam}(T)+1)^{q-d} 2^{-k(q-d)} \left(4^d \left(\max\left\{0, \log_2(c_1) + (k + 2)d \right\} \right)^q
     + C_p\right)
-  \: .
+  \\
+  &\le 2^{2p+5q+1} M c_1 (c_1^{1/d}+1)^{q-d} 2^{-k(q-d)} \left(4^d \left(\max\left\{0, \log_2(c_1) + (k + 2)d \right\} \right)^q
+    + C_p\right)
+  \: ,
 \end{align*}
-The sum is then less than $M$ times $L(T, c_1, d, p, q, \beta)$.
+where the last inequality uses $\mathrm{diam}(T) \le c_1^{1/d}$ (Lemma~\ref{lem:hasBoundedInternalCoveringNumber_diam_le}).
+The sum is then less than $M$ times $L(c_1, d, p, q, \beta)$.
 \end{proof}
 
 
@@ -1665,7 +1683,7 @@ Let $\beta \in(0, (q - d)/p)$.
 Then for every countable subset $T' \subseteq T$ with positive diameter,
 \begin{align*}
   \mathbb{E}\left[ \sup_{s, t \in T';\: s \ne t} \frac{d_E(X_s, X_t)^p}{d_T(s, t)^{\beta p}} \right]
-  \le M L(T, c_1, d, p, q, \beta)
+  \le M L(c_1, d, p, q, \beta)
   \: .
 \end{align*}
 \end{theorem}
@@ -1677,10 +1695,10 @@ Build a monotone sequence of finite sets $T_n \subseteq T'$, use Lemma~\ref{lem:
 
 
 \begin{corollary}\label{cor:countable_set_bound_of_le}
-Under the same assumptions as in Theorem~\ref{thm:countable_set_bound}, for every countable subset $T' \subseteq T$ with positive diameter, for $L(T, c_1, d, p, q, \beta) < \infty$ the same constant,
+Under the same assumptions as in Theorem~\ref{thm:countable_set_bound}, for every countable subset $T' \subseteq T$ with positive diameter, for $L(c_1, d, p, q, \beta) < \infty$ the same constant,
 \begin{align*}
   \mathbb{E}\left[ \sup_{s, t \in T';\: d_T(s, t) \le \delta} d_E(X_s, X_t)^p \right]
-  \le M L(T, c_1, d, p, q, \beta) \delta^{\beta p}
+  \le M L(c_1, d, p, q, \beta) \delta^{\beta p}
   \: .
 \end{align*}
 \end{corollary}


### PR DESCRIPTION
Revisions to the paper following the referee reports.

## Changes
- **Referee answers**: new `BM_paper/Answers_Report_69.tex` with our responses to the reports.
- **Bibliography** (`biblio.bib`): added Revuz–Yor, Ledoux–Talagrand, Marion (Ionescu–Tulcea, arXiv:2506.18616), Douglas et al. (QFT, arXiv:2603.15770).
- **`main.tex`**:
  - New subsection "An alternative route" describing Lévy's construction (referee point 5).
  - Added reference to Ledoux–Talagrand alongside [KU23] in §2.3.
  - Contributor list in the project-organization section.
  - Assorted typo/correctness fixes (e.g. `(X_t,X_t) → (X_s,X_t)`, `Y_0 → Y_t`).

> Note: `main.tex` still contains a number of inline `{\color{blue} … xxx …}` reviewer notes / open questions for the coauthors, and `Answers_Report_69.tex` has open `\TODO`/`xxx` markers — these are intentional for discussion on the paper branch, not finished prose.

🤖 Generated with [Claude Code](https://claude.com/claude-code)