### PR TITLE
feat: Doob maximal inequality for lower semicontinuous submartingales (separable index)

### DIFF
--- a/BrownianMotion.lean
+++ b/BrownianMotion.lean
@@ -21,6 +21,7 @@ public import BrownianMotion.Auxiliary.Metric
 public import BrownianMotion.Auxiliary.NNReal
 public import BrownianMotion.Auxiliary.Nat
 public import BrownianMotion.Auxiliary.Real
+public import BrownianMotion.Auxiliary.SeparableSpace
 public import BrownianMotion.Auxiliary.SetAlgebra
 public import BrownianMotion.Auxiliary.StandardBorel
 public import BrownianMotion.Auxiliary.StoppedProcess

--- a/BrownianMotion/Auxiliary/SeparableSpace.lean
+++ b/BrownianMotion/Auxiliary/SeparableSpace.lean
@@ -21,7 +21,7 @@ public import Mathlib.Topology.Order.T5
 
 -/
 
-@[expose] public section
+public section
 
 open Filter Set TopologicalSpace
 open scoped Topology
@@ -67,65 +67,51 @@ end OrdConnected
 
 section Separable
 
-/-- In a separable linearly ordered topological space, the points of a subset `s` that are
-isolated in the subspace `s` form a countable set.
+private lemma countable_isolated_inter_Ioi_aux [SeparableSpace α] {s : Set α} {W : s → Set α}
+    (hWo : ∀ x, IsOpen {x} → IsOpen (W x)) (hWc : ∀ x, IsOpen {x} → (W x).OrdConnected)
+    (hWx : ∀ x, IsOpen {x} → {x.1} = W x ∩ s) :
+    {x : s | IsOpen {x} ∧ (W x ∩ Ioi x).Nonempty}.Countable := by
+  refine PairwiseDisjoint.countable_of_isOpen ?_ ?_ fun _ hx ↦ hx.2
+  · rintro x ⟨hx, -⟩ y ⟨hy, -⟩ hxy
+    refine disjoint_left.2 fun z hzx hzy ↦ ?_
+    rcases lt_or_gt_of_ne (Subtype.coe_injective.ne hxy) with h | h
+    · exact h.ne' ((hWx x hx).ge ⟨(hWc x hx).out ((hWx x hx).le rfl).1 hzx.1 ⟨h.le, hzy.2.le⟩, y.2⟩)
+    · exact h.ne' ((hWx y hy).ge ⟨(hWc y hy).out ((hWx y hy).le rfl).1 hzy.1 ⟨h.le, hzx.2.le⟩, x.2⟩)
+  · exact fun x hx ↦ (hWo x hx.1).inter isOpen_Ioi
 
-Each such point `x` has an open order connected neighbourhood `W x` meeting `s` only in `x`. The
-sets `W x ∩ Ioi x` are then pairwise disjoint, as are the sets `W x ∩ Iio x`, so in a separable
-space only countably many of each are nonempty; and if both are empty then `W x = {x}` is open,
-so `x` belongs to any dense set. -/
+/-- In a separable linearly ordered topological space, the points of a subset `s` that are
+isolated in the subspace `s` form a countable set. -/
 theorem countable_setOf_isolated_subtype [SeparableSpace α] (s : Set α) :
     {x : s | IsOpen {x}}.Countable := by
   obtain ⟨D, hDc, hDd⟩ := exists_countable_dense α
-  have key (x : s) (hx : IsOpen {x}) :
-      ∃ W, IsOpen W ∧ W.OrdConnected ∧ x.1 ∈ W ∧ W ∩ s ⊆ {x.1} := by
+  -- Each such point `x` has an open order connected neighbourhood `W x` meeting `s` only in `x`.
+  have key (x : s) (hx : IsOpen {x}) : ∃ W, IsOpen W ∧ W.OrdConnected ∧ {x.1} = W ∩ s := by
     obtain ⟨U, hU, hUx⟩ := Topology.IsInducing.subtypeVal.isOpen_iff.1 hx
-    have hUs : U ∩ s ⊆ {(x : α)} := fun z hz ↦
-      congrArg Subtype.val (hUx.le (show (⟨z, hz.2⟩ : s) ∈ Subtype.val ⁻¹' U from hz.1))
-    obtain ⟨W, hWo, hWc, hWx, hWU⟩ := exists_isOpen_ordConnected_mem_subset hU (hUx.ge rfl)
-    exact ⟨W, hWo, hWc, hWx, (inter_subset_inter_left s hWU).trans hUs⟩
-  choose! W hWo hWc hWx hWs using key
-  -- no isolated point above `x` is caught by `W x`, and none below
-  have hup : ∀ x : s, IsOpen {x} → ∀ y : s, (x : α) < (y : α) →
-      ∀ z ∈ W x, ¬ (y : α) ≤ z := fun x hx y hxy z hz hyz ↦
-    hxy.ne' (hWs x hx ⟨(hWc x hx).out (hWx x hx) hz ⟨hxy.le, hyz⟩, y.2⟩)
-  have hdown : ∀ x : s, IsOpen {x} → ∀ y : s, (y : α) < (x : α) →
-      ∀ z ∈ W x, ¬ z ≤ (y : α) := fun x hx y hyx z hz hzy ↦
-    hyx.ne (hWs x hx ⟨(hWc x hx).out hz (hWx x hx) ⟨hzy, hyx.le⟩, y.2⟩)
-  have hcr : {x : s | IsOpen {x} ∧ (W x ∩ Ioi (x : α)).Nonempty}.Countable := by
-    refine PairwiseDisjoint.countable_of_isOpen (s := fun x : s ↦ W x ∩ Ioi (x : α)) ?_
-      (fun x hx ↦ (hWo x hx.1).inter isOpen_Ioi) fun x hx ↦ hx.2
-    rintro x ⟨hx, -⟩ y ⟨hy, -⟩ hxy
-    refine disjoint_left.2 fun z hzx hzy ↦ ?_
-    rcases lt_or_gt_of_ne (Subtype.coe_injective.ne hxy) with h | h
-    · exact hup x hx y h z hzx.1 hzy.2.le
-    · exact hup y hy x h z hzy.1 hzx.2.le
-  have hcl : {x : s | IsOpen {x} ∧ (W x ∩ Iio x).Nonempty}.Countable := by
-    refine PairwiseDisjoint.countable_of_isOpen (s := fun x : s ↦ W x ∩ Iio (x : α)) ?_
-      (fun x hx ↦ (hWo x hx.1).inter isOpen_Iio) fun x hx ↦ hx.2
-    rintro x ⟨hx, -⟩ y ⟨hy, -⟩ hxy
-    refine disjoint_left.2 fun z hzx hzy ↦ ?_
-    rcases lt_or_gt_of_ne (Subtype.coe_injective.ne hxy) with h | h
-    · exact hdown y hy x h z hzy.1 hzx.2.le
-    · exact hdown x hx y h z hzx.1 hzy.2.le
-  -- an isolated point with nothing of `W x` on either side is isolated in `α`, hence lies in `D`
+    obtain ⟨W, hWo, hWc, hxW, hWU⟩ := exists_isOpen_ordConnected_mem_subset hU (hUx.ge rfl)
+    refine ⟨W, hWo, hWc, Subset.antisymm (fun _ h ↦ h ▸ ⟨hxW, x.2⟩) fun y hy ↦ ?_⟩
+    exact congrArg Subtype.val <| hUx.le (show (⟨y, hy.2⟩ : s) ∈ Subtype.val ⁻¹' U from hWU hy.1)
+  choose! W hWo hWc hWx using key
+  -- The sets `W x ∩ Ioi x` are then pairwise disjoint, as are the sets `W x ∩ Iio x`.
+  have hcr : {x : s | IsOpen {x} ∧ (W x ∩ Ioi x).Nonempty}.Countable :=
+    countable_isolated_inter_Ioi_aux hWo hWc hWx
+  have hcl : {x : s | IsOpen {x} ∧ (W x ∩ Iio x).Nonempty}.Countable :=
+    countable_isolated_inter_Ioi_aux (α := αᵒᵈ) hWo (fun x hx ↦ (hWc x hx).dual) hWx
+  -- An isolated point with nothing of `W x` on either side is isolated in `α`, hence lies in `D`.
   refine ((hcr.union hcl).union (hDc.preimage Subtype.val_injective)).mono fun x hx ↦ ?_
   rcases (W x ∩ Ioi x).eq_empty_or_nonempty with h₁ | h₁
-  swap
-  · exact Or.inl (Or.inl ⟨hx, h₁⟩)
-  rcases (W x ∩ Iio x).eq_empty_or_nonempty with h₂ | h₂
-  swap
-  · exact Or.inl (Or.inr ⟨hx, h₂⟩)
-  have hsing : W x = {x.1} := calc
-    _ = W x ∩ Iio x ∪ W x ∩ {x.1} ∪ W x ∩ Ioi x := by grind
-    _ = {x.1} := by grind
-  exact Or.inr (hDd.mem_of_isOpen_singleton (hsing ▸ hWo x hx))
+  · rcases (W x ∩ Iio x).eq_empty_or_nonempty with h₂ | h₂
+    · have hsing : W x = {x.1} := calc
+        _ = W x ∩ Iio x ∪ W x ∩ {x.1} ∪ W x ∩ Ioi x := by grind
+        _ = {x.1} := by grind
+      exact .inr (hDd.mem_of_isOpen_singleton (hsing ▸ hWo x hx))
+    · exact .inl (.inr ⟨hx, h₂⟩)
+  · exact .inl (.inl ⟨hx, h₁⟩)
 
 /-- A separable linearly ordered topological space is hereditarily separable: every subset,
 equipped with the subspace topology, is a separable space. -/
 instance Set.separableSpace [SeparableSpace α] (s : Set α) : SeparableSpace s := by
   obtain ⟨D, hc, hd⟩ := exists_countable_dense α
-  -- a point of `s` strictly between `p` and `q`, whenever there is one
+  -- A point of `s` strictly between `p` and `q`, whenever there is one.
   have hchoice (p q) : ∃ z : α, (s ∩ Ioo p q).Nonempty → z ∈ s ∩ Ioo p q := by
     by_cases h : (s ∩ Ioo p q).Nonempty
     · exact ⟨h.choose, fun _ ↦ h.choose_spec⟩
@@ -136,31 +122,22 @@ instance Set.separableSpace [SeparableSpace α] (s : Set α) : SeparableSpace s 
     ((hc.image2 hc a).preimage Subtype.val_injective), ?_⟩⟩
   refine dense_iff_inter_open.2 fun O hO ⟨x, hxO⟩ ↦ ?_
   by_cases hxiso : IsOpen {x}
-  · exact ⟨x, hxO, Or.inl hxiso⟩
+  · exact ⟨x, hxO, .inl hxiso⟩
   obtain ⟨U, hU, hUO⟩ := Topology.IsInducing.subtypeVal.isOpen_iff.1 hO
   obtain ⟨W, hWo, hWc, hWx, hWU⟩ := exists_isOpen_ordConnected_mem_subset hU (hUO.ge hxO)
-  -- as `x` is not isolated in `s`, every open set containing it meets `s` in a different point
-  have hnot (G : Set α) (hG : IsOpen G) (hxG : x.1 ∈ G) : ∃ y ∈ s, y ∈ G ∧ y ≠ x := by
-    by_contra! hcon
-    suffices hGx : Subtype.val ⁻¹' G = {x} from hxiso (hGx ▸ hG.preimage continuous_subtype_val)
-    grind
-  -- a point `b` of `s` in `W` with points of `W` strictly on either side of it
-  obtain ⟨b, hbs, hlo, hhi⟩ : ∃ b ∈ s, (W ∩ Iio b).Nonempty ∧ (W ∩ Ioi b).Nonempty := by
-    obtain ⟨y, hys, hyW, hyx⟩ := hnot W hWo hWx
-    rcases hyx.lt_or_gt with hy | hy
-    · obtain ⟨z, hzs, hzW, hzx⟩ := hnot (W ∩ Ioi y) (hWo.inter isOpen_Ioi) ⟨hWx, hy⟩
-      rcases hzx.lt_or_gt with hz | hz
-      · exact ⟨z, hzs, ⟨y, hyW, hzW.2⟩, ⟨x, hWx, hz⟩⟩
-      · exact ⟨x, x.2, ⟨y, hyW, hy⟩, ⟨z, hzW.1, hz⟩⟩
-    · obtain ⟨z, hzs, hzW, hzx⟩ := hnot (W ∩ Iio y) (hWo.inter isOpen_Iio) ⟨hWx, hy⟩
-      rcases hzx.lt_or_gt with hz | hz
-      · exact ⟨x, x.2, ⟨z, hzW.1, hz⟩, ⟨y, hyW, hy⟩⟩
-      · exact ⟨z, hzs, ⟨x, hWx, hz⟩, ⟨y, hyW, hzW.2⟩⟩
+  -- A point `b` of `s` in `W` with points of `W` strictly on either side of it.
+  obtain ⟨b, hbs, hlo, hhi⟩ :∃ b ∈ s, (W ∩ Iio b).Nonempty ∧ (W ∩ Ioi b).Nonempty := by
+    rw [isOpen_singleton_iff_punctured_nhds] at hxiso
+    let : NeBot (𝓝[≠] x) := ⟨hxiso⟩
+    have hWinf : (Subtype.val ⁻¹' W).Infinite :=
+      infinite_of_mem_nhds x ((hWo.preimage continuous_subtype_val).mem_nhds hWx)
+    by_contra! h
+    exact hWinf (finite_of_forall_not_lt_lt fun a ha b hb c hc hab hbc ↦
+      (congrArg ((c : α) ∈ ·) (h b b.2 ⟨a, ha, hab⟩)).mp ⟨hc, hbc⟩)
   obtain ⟨p, hpD, hpW⟩ := hd.exists_mem_open (hWo.inter isOpen_Iio) hlo
   obtain ⟨q, hqD, hqW⟩ := hd.exists_mem_open (hWo.inter isOpen_Ioi) hhi
   obtain ⟨hasq, hapq⟩ := ha p q ⟨b, hbs, hpW.2, hqW.2⟩
-  exact ⟨⟨a p q, hasq⟩,
-    hUO.le (hWU (hWc.out hpW.1 hqW.1 (Ioo_subset_Icc_self hapq))),
-    Or.inr ⟨p, hpD, q, hqD, rfl⟩⟩
+  exact ⟨⟨a p q, hasq⟩, hUO.le (hWU (hWc.out hpW.1 hqW.1 (Ioo_subset_Icc_self hapq))),
+    .inr ⟨p, hpD, q, hqD, rfl⟩⟩
 
 end Separable

--- a/BrownianMotion/Auxiliary/SeparableSpace.lean
+++ b/BrownianMotion/Auxiliary/SeparableSpace.lean
@@ -1,0 +1,166 @@
+/-
+Copyright (c) 2026 Yongxi Lin. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Yongxi Lin
+-/
+module
+
+public import Mathlib.Topology.Order.T5
+
+/-!
+# Hereditary separability of linear orders
+
+## Main results
+
+* `exists_isOpen_ordConnected_mem_subset`: every point of an open set has an open order connected
+  neighbourhood contained in that set.
+* `isTopologicalBasis_isOpen_ordConnected`: the open order connected sets form a topological basis.
+* `countable_setOf_isolated_subtype`: in a separable linearly ordered topological space, the
+  points of a subset that are isolated in the subspace topology form a countable set.
+* `Set.separableSpace`: a separable linearly ordered topological space is hereditarily separable.
+
+-/
+
+@[expose] public section
+
+open Filter Set TopologicalSpace
+open scoped Topology
+
+variable {α : Type*} [LinearOrder α] [TopologicalSpace α] [OrderTopology α]
+
+/-- A dense set contains every point whose singleton is open, that is, every isolated point. -/
+theorem Dense.mem_of_isOpen_singleton {X : Type*} [TopologicalSpace X] {s : Set X} {x : X}
+    (hs : Dense s) (hx : IsOpen {x}) : x ∈ s := by
+  obtain ⟨y, hys, hy⟩ := hs.exists_mem_open hx ⟨x, rfl⟩
+  grind
+
+section OrdConnected
+
+/-- Every point `x` of an open set `U` has an open order connected neighbourhood contained in `U`.
+-/
+theorem exists_isOpen_ordConnected_mem_subset {U : Set α} (hU : IsOpen U) {x : α} (hx : x ∈ U) :
+    ∃ V, IsOpen V ∧ V.OrdConnected ∧ x ∈ V ∧ V ⊆ U := by
+  refine ⟨interior (ordConnectedComponent U x), isOpen_interior, ⟨fun y hy z hz w hw ↦ ?_⟩,
+    mem_interior_iff_mem_nhds.2 (ordConnectedComponent_mem_nhds.2 (hU.mem_nhds hx)),
+    interior_subset.trans ordConnectedComponent_subset⟩
+  rcases hw.1.eq_or_lt with rfl | hyw
+  · exact hy
+  rcases hw.2.eq_or_lt with rfl | hwz
+  · exact hz
+  exact mem_interior.2 ⟨Ioo y z, fun v hv ↦ OrdConnected.out inferInstance
+    (interior_subset hy) (interior_subset hz) ⟨hv.1.le, hv.2.le⟩, isOpen_Ioo, hyw, hwz⟩
+
+/-- The open order connected sets form a topological basis of a linearly ordered topological
+space. -/
+theorem isTopologicalBasis_isOpen_ordConnected :
+    IsTopologicalBasis {V : Set α | IsOpen V ∧ V.OrdConnected} :=
+  isTopologicalBasis_of_isOpen_of_nhds (fun _ hu ↦ hu.1) fun _ _ ha hu ↦
+    let ⟨V, hVo, hVc, haV, hVu⟩ := exists_isOpen_ordConnected_mem_subset hu ha
+    ⟨V, ⟨hVo, hVc⟩, haV, hVu⟩
+
+/-- The open order connected sets containing a point form a basis of its neighbourhood filter. -/
+theorem nhds_basis_isOpen_ordConnected (x : α) :
+    (𝓝 x).HasBasis (fun V : Set α ↦ (IsOpen V ∧ V.OrdConnected) ∧ x ∈ V) id :=
+  isTopologicalBasis_isOpen_ordConnected.nhds_hasBasis
+
+end OrdConnected
+
+section Separable
+
+/-- In a separable linearly ordered topological space, the points of a subset `s` that are
+isolated in the subspace `s` form a countable set.
+
+Each such point `x` has an open order connected neighbourhood `W x` meeting `s` only in `x`. The
+sets `W x ∩ Ioi x` are then pairwise disjoint, as are the sets `W x ∩ Iio x`, so in a separable
+space only countably many of each are nonempty; and if both are empty then `W x = {x}` is open,
+so `x` belongs to any dense set. -/
+theorem countable_setOf_isolated_subtype [SeparableSpace α] (s : Set α) :
+    {x : s | IsOpen {x}}.Countable := by
+  obtain ⟨D, hDc, hDd⟩ := exists_countable_dense α
+  have key (x : s) (hx : IsOpen {x}) :
+      ∃ W, IsOpen W ∧ W.OrdConnected ∧ x.1 ∈ W ∧ W ∩ s ⊆ {x.1} := by
+    obtain ⟨U, hU, hUx⟩ := Topology.IsInducing.subtypeVal.isOpen_iff.1 hx
+    have hUs : U ∩ s ⊆ {(x : α)} := fun z hz ↦
+      congrArg Subtype.val (hUx.le (show (⟨z, hz.2⟩ : s) ∈ Subtype.val ⁻¹' U from hz.1))
+    obtain ⟨W, hWo, hWc, hWx, hWU⟩ := exists_isOpen_ordConnected_mem_subset hU (hUx.ge rfl)
+    exact ⟨W, hWo, hWc, hWx, (inter_subset_inter_left s hWU).trans hUs⟩
+  choose! W hWo hWc hWx hWs using key
+  -- no isolated point above `x` is caught by `W x`, and none below
+  have hup : ∀ x : s, IsOpen {x} → ∀ y : s, (x : α) < (y : α) →
+      ∀ z ∈ W x, ¬ (y : α) ≤ z := fun x hx y hxy z hz hyz ↦
+    hxy.ne' (hWs x hx ⟨(hWc x hx).out (hWx x hx) hz ⟨hxy.le, hyz⟩, y.2⟩)
+  have hdown : ∀ x : s, IsOpen {x} → ∀ y : s, (y : α) < (x : α) →
+      ∀ z ∈ W x, ¬ z ≤ (y : α) := fun x hx y hyx z hz hzy ↦
+    hyx.ne (hWs x hx ⟨(hWc x hx).out hz (hWx x hx) ⟨hzy, hyx.le⟩, y.2⟩)
+  have hcr : {x : s | IsOpen {x} ∧ (W x ∩ Ioi (x : α)).Nonempty}.Countable := by
+    refine PairwiseDisjoint.countable_of_isOpen (s := fun x : s ↦ W x ∩ Ioi (x : α)) ?_
+      (fun x hx ↦ (hWo x hx.1).inter isOpen_Ioi) fun x hx ↦ hx.2
+    rintro x ⟨hx, -⟩ y ⟨hy, -⟩ hxy
+    refine disjoint_left.2 fun z hzx hzy ↦ ?_
+    rcases lt_or_gt_of_ne (Subtype.coe_injective.ne hxy) with h | h
+    · exact hup x hx y h z hzx.1 hzy.2.le
+    · exact hup y hy x h z hzy.1 hzx.2.le
+  have hcl : {x : s | IsOpen {x} ∧ (W x ∩ Iio x).Nonempty}.Countable := by
+    refine PairwiseDisjoint.countable_of_isOpen (s := fun x : s ↦ W x ∩ Iio (x : α)) ?_
+      (fun x hx ↦ (hWo x hx.1).inter isOpen_Iio) fun x hx ↦ hx.2
+    rintro x ⟨hx, -⟩ y ⟨hy, -⟩ hxy
+    refine disjoint_left.2 fun z hzx hzy ↦ ?_
+    rcases lt_or_gt_of_ne (Subtype.coe_injective.ne hxy) with h | h
+    · exact hdown y hy x h z hzy.1 hzx.2.le
+    · exact hdown x hx y h z hzx.1 hzy.2.le
+  -- an isolated point with nothing of `W x` on either side is isolated in `α`, hence lies in `D`
+  refine ((hcr.union hcl).union (hDc.preimage Subtype.val_injective)).mono fun x hx ↦ ?_
+  rcases (W x ∩ Ioi x).eq_empty_or_nonempty with h₁ | h₁
+  swap
+  · exact Or.inl (Or.inl ⟨hx, h₁⟩)
+  rcases (W x ∩ Iio x).eq_empty_or_nonempty with h₂ | h₂
+  swap
+  · exact Or.inl (Or.inr ⟨hx, h₂⟩)
+  have hsing : W x = {x.1} := calc
+    _ = W x ∩ Iio x ∪ W x ∩ {x.1} ∪ W x ∩ Ioi x := by grind
+    _ = {x.1} := by grind
+  exact Or.inr (hDd.mem_of_isOpen_singleton (hsing ▸ hWo x hx))
+
+/-- A separable linearly ordered topological space is hereditarily separable: every subset,
+equipped with the subspace topology, is a separable space. -/
+instance Set.separableSpace [SeparableSpace α] (s : Set α) : SeparableSpace s := by
+  obtain ⟨D, hc, hd⟩ := exists_countable_dense α
+  -- a point of `s` strictly between `p` and `q`, whenever there is one
+  have hchoice (p q) : ∃ z : α, (s ∩ Ioo p q).Nonempty → z ∈ s ∩ Ioo p q := by
+    by_cases h : (s ∩ Ioo p q).Nonempty
+    · exact ⟨h.choose, fun _ ↦ h.choose_spec⟩
+    · exact ⟨p, fun h' ↦ absurd h' h⟩
+  choose a ha using hchoice
+  refine ⟨⟨{x : s | IsOpen {x}} ∪ Subtype.val ⁻¹' image2 a D D,
+    (countable_setOf_isolated_subtype s).union
+    ((hc.image2 hc a).preimage Subtype.val_injective), ?_⟩⟩
+  refine dense_iff_inter_open.2 fun O hO ⟨x, hxO⟩ ↦ ?_
+  by_cases hxiso : IsOpen {x}
+  · exact ⟨x, hxO, Or.inl hxiso⟩
+  obtain ⟨U, hU, hUO⟩ := Topology.IsInducing.subtypeVal.isOpen_iff.1 hO
+  obtain ⟨W, hWo, hWc, hWx, hWU⟩ := exists_isOpen_ordConnected_mem_subset hU (hUO.ge hxO)
+  -- as `x` is not isolated in `s`, every open set containing it meets `s` in a different point
+  have hnot (G : Set α) (hG : IsOpen G) (hxG : x.1 ∈ G) : ∃ y ∈ s, y ∈ G ∧ y ≠ x := by
+    by_contra! hcon
+    suffices hGx : Subtype.val ⁻¹' G = {x} from hxiso (hGx ▸ hG.preimage continuous_subtype_val)
+    grind
+  -- a point `b` of `s` in `W` with points of `W` strictly on either side of it
+  obtain ⟨b, hbs, hlo, hhi⟩ : ∃ b ∈ s, (W ∩ Iio b).Nonempty ∧ (W ∩ Ioi b).Nonempty := by
+    obtain ⟨y, hys, hyW, hyx⟩ := hnot W hWo hWx
+    rcases hyx.lt_or_gt with hy | hy
+    · obtain ⟨z, hzs, hzW, hzx⟩ := hnot (W ∩ Ioi y) (hWo.inter isOpen_Ioi) ⟨hWx, hy⟩
+      rcases hzx.lt_or_gt with hz | hz
+      · exact ⟨z, hzs, ⟨y, hyW, hzW.2⟩, ⟨x, hWx, hz⟩⟩
+      · exact ⟨x, x.2, ⟨y, hyW, hy⟩, ⟨z, hzW.1, hz⟩⟩
+    · obtain ⟨z, hzs, hzW, hzx⟩ := hnot (W ∩ Iio y) (hWo.inter isOpen_Iio) ⟨hWx, hy⟩
+      rcases hzx.lt_or_gt with hz | hz
+      · exact ⟨x, x.2, ⟨z, hzW.1, hz⟩, ⟨y, hyW, hy⟩⟩
+      · exact ⟨z, hzs, ⟨x, hWx, hz⟩, ⟨y, hyW, hzW.2⟩⟩
+  obtain ⟨p, hpD, hpW⟩ := hd.exists_mem_open (hWo.inter isOpen_Iio) hlo
+  obtain ⟨q, hqD, hqW⟩ := hd.exists_mem_open (hWo.inter isOpen_Ioi) hhi
+  obtain ⟨hasq, hapq⟩ := ha p q ⟨b, hbs, hpW.2, hqW.2⟩
+  exact ⟨⟨a p q, hasq⟩,
+    hUO.le (hWU (hWc.out hpW.1 hqW.1 (Ioo_subset_Icc_self hapq))),
+    Or.inr ⟨p, hpD, q, hqD, rfl⟩⟩
+
+end Separable

--- a/BrownianMotion/StochasticIntegral/DoobLp.lean
+++ b/BrownianMotion/StochasticIntegral/DoobLp.lean
@@ -6,6 +6,7 @@ Authors: Rémy Degenne, Thomas Zhu
 module
 
 public import BrownianMotion.Auxiliary.Martingale
+public import BrownianMotion.Auxiliary.SeparableSpace
 public import BrownianMotion.StochasticIntegral.Cadlag
 public import Mathlib.Probability.Martingale.OptionalStopping
 
@@ -331,6 +332,81 @@ theorem preimage_iSup {ι β : Type*} [CompleteLinearOrder β] (f : ι → Ω �
     (b : β) : (⨆ i, f i) ⁻¹' (Set.Ioi b) = ⋃ i, f i ⁻¹' (Set.Ioi b) := by
   ext; simp [lt_iSup_iff]
 
+/-- If the running supremum `⨆ i : Set.Iic n` of a nonnegative submartingale is measurable and
+satisfies Doob's maximal inequality (in `ℝ≥0∞` form), then it is a.e. finite. This is the
+topology-free core of `MeasureTheory.Submartingale.iSup_ofReal_ne_top`. -/
+lemma _root_.MeasureTheory.Submartingale.iSup_ofReal_ne_top_of_measurable
+    (hsub : Submartingale Y 𝓕 P) (hnonneg : 0 ≤ Y) (n : ι)
+    (hmY : Measurable fun ω ↦ ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω))
+    (hmax : ∀ ε : ℝ≥0, ε * P.real {ω | (ε : ℝ≥0∞) ≤ ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω)} ≤
+      ∫ ω in {ω | (ε : ℝ≥0∞) ≤ ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω)}, Y n ω ∂P) :
+    ∀ᵐ ω ∂P, ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω) ≠ ∞ := by
+  let supY (ω : Ω) := ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω)
+  change P {ω | ¬supY ω ≠ ∞} = 0
+  push Not
+  convert Antitone.measure_iInter (s := fun ε : ℝ≥0 ↦ {ω | (ε : ℝ≥0∞) ≤ supY ω}) ?_ ?_ ?_
+  · ext ω
+    simp only [Set.mem_setOf_eq, Set.mem_iInter]
+    constructor
+    · simp +contextual
+    · apply ENNReal.eq_top_of_forall_nnreal_le
+  · symm
+    erw [← le_bot_iff]
+    calc
+      _ ≤ ⨅ ε > (0 : ℝ≥0), ENNReal.ofReal (ε⁻¹ • ∫ ω in {ω | ε ≤ supY ω}, Y n ω ∂P) := by
+        gcongr with ε
+        refine le_iInf fun hε0 ↦ ?_
+        rw [ENNReal.ofReal_smul, le_inv_smul_iff_of_pos hε0, ENNReal.le_ofReal_iff_toReal_le]
+        · simp only [Measure.nnreal_smul_coe_apply, ENNReal.toReal_mul, ENNReal.coe_toReal]
+          exact hmax ε
+        · finiteness
+        · exact setIntegral_nonneg (measurableSet_le measurable_const hmY) fun ω _ ↦ hnonneg n ω
+      _ ≤ ⨅ ε > (0 : ℝ≥0), ENNReal.ofReal (ε⁻¹ • ∫ ω, Y n ω ∂P) := by
+        gcongr with ε hε0
+        · exact .of_forall (hnonneg n)
+        · exact hsub.integrable n
+        · exact P.restrict_le_self
+      _ = 0 := by
+        apply iInf_eq_of_tendsto
+        · intro ε₁ ε₂ h
+          refine le_iInf fun hε₁ ↦ ?_
+          simp only [iInf_pos (hε₁.trans_le h)]
+          gcongr
+          exact integral_nonneg (hnonneg n)
+        · convert (ENNReal.tendsto_ofReal ((tendsto_inv_atTop_zero (𝕜 := ℝ≥0)).smul_const
+            (∫ ω, Y n ω ∂P))).congr' ?_
+          · simp
+          · filter_upwards [eventually_gt_atTop 0] with ε hε0
+            simp [hε0]
+  · exact Set.monotone_preimage.comp_antitone ENNReal.coe_mono.Ici
+  · exact fun r ↦ (measurableSet_le measurable_const hmY).nullMeasurableSet
+  · use 0; finiteness
+
+omit [IsFiniteMeasure P] in
+/-- Doob's maximal inequality in real form, derived from the `ℝ≥0∞` form together with a.e.
+finiteness of the running supremum. This is the topology-free core of `maximal_ineq_nonneg`. -/
+theorem maximal_ineq_nonneg_of_ne_top (hnonneg : 0 ≤ Y) (ε : ℝ≥0) (n : ι)
+    (hfin : ∀ᵐ ω ∂P, ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω) ≠ ∞)
+    (hmax : ε * P.real {ω | (ε : ℝ≥0∞) ≤ ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω)} ≤
+      ∫ ω in {ω | (ε : ℝ≥0∞) ≤ ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω)}, Y n ω ∂P) :
+    ε * P.real {ω | (ε : ℝ) ≤ ⨆ i : Set.Iic n, Y i ω} ≤
+      ∫ ω in {ω | (ε : ℝ) ≤ ⨆ i : Set.Iic n, Y i ω}, Y n ω ∂P := by
+  have hpt (ω : Ω) : ⨆ i : Set.Iic n, Y i ω = (⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω)).toReal := by
+    rw [ENNReal.toReal_iSup]
+    · congr with i
+      rw [ENNReal.toReal_ofReal (hnonneg _ _)]
+    · finiteness
+  have hae : {ω | ε ≤ ⨆ i : Set.Iic n, Y i ω} =ᵐ[P]
+      {ω | ε ≤ ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω)} := by
+    filter_upwards [hfin] with ω htop
+    ext
+    change _ ≤ _ ↔ _ ≤ _
+    rw [← ENNReal.ofReal_coe_nnreal, ENNReal.ofReal_le_iff_le_toReal htop, hpt]
+  rw [measureReal_congr hae, setIntegral_congr_set hae]
+  exact hmax
+
+section SecondCountableTopology
+
 variable [TopologicalSpace ι] [OrderTopology ι] [SecondCountableTopology ι]
 
 theorem measurable_iSup_of_rightContinuous {β : Type*} {f : ι → Ω → β}
@@ -417,74 +493,24 @@ theorem maximal_ineq_ennreal (hsub : Submartingale Y 𝓕 P) (hnonneg : 0 ≤ Y)
 lemma _root_.MeasureTheory.Submartingale.rightCont_iSup_ofReal_ne_top (hsub : Submartingale Y 𝓕 P)
     (hnonneg : 0 ≤ Y) (n : ι) (hY_cont : ∀ ω, IsRightContinuous (Y · ω)) :
     ∀ᵐ ω ∂P, ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω) ≠ ∞ := by
-  let supY (ω : Ω) := ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω)
-  have hmeasY (i : ι) : Measurable (Y i) :=
-    (hsub.stronglyMeasurable i).measurable.mono (𝓕.le _) (le_refl _)
-  have hmY : Measurable supY := by
-    have : supY = ⨆ i : Set.Iic n, (fun ω => ENNReal.ofReal (Y i ω)) := by ext; simp [supY]
-    rw [this]
-    refine measurable_iSup_of_rightContinuous (fun ω => ?_) fun t => ?_
-    · refine fun a => ((hY_cont ω).continuous_comp ENNReal.continuous_ofReal a).comp ?_ ?_
-      · exact continuous_subtype_val.continuousWithinAt
-      · exact fun x => by simp
-    · exact Measurable.ennreal_ofReal (hmeasY t)
-  change P {ω | ¬supY ω ≠ ∞} = 0
-  push Not
-  convert Antitone.measure_iInter (s := fun ε : ℝ≥0 ↦ {ω | (ε : ℝ≥0∞) ≤ supY ω}) ?_ ?_ ?_
-  · ext ω
-    simp only [Set.mem_setOf_eq, Set.mem_iInter]
-    constructor
-    · simp +contextual
-    · apply ENNReal.eq_top_of_forall_nnreal_le
-  · symm
-    erw [← le_bot_iff]
-    calc
-      _ ≤ ⨅ ε > (0 : ℝ≥0), ENNReal.ofReal (ε⁻¹ • ∫ ω in {ω | ε ≤ supY ω}, Y n ω ∂P) := by
-        gcongr with ε
-        refine le_iInf fun hε0 ↦ ?_
-        rw [ENNReal.ofReal_smul, le_inv_smul_iff_of_pos hε0, ENNReal.le_ofReal_iff_toReal_le]
-        · simp only [Measure.nnreal_smul_coe_apply, ENNReal.toReal_mul, ENNReal.coe_toReal]
-          exact maximal_ineq_ennreal hsub hnonneg ε n hY_cont
-        · finiteness
-        · exact setIntegral_nonneg (measurableSet_le measurable_const hmY) fun ω _ ↦ hnonneg n ω
-      _ ≤ ⨅ ε > (0 : ℝ≥0), ENNReal.ofReal (ε⁻¹ • ∫ ω, Y n ω ∂P) := by
-        gcongr with ε hε0
-        · exact .of_forall (hnonneg n)
-        · exact hsub.integrable n
-        · exact P.restrict_le_self
-      _ = 0 := by
-        apply iInf_eq_of_tendsto
-        · intro ε₁ ε₂ h
-          refine le_iInf fun hε₁ ↦ ?_
-          simp only [iInf_pos (hε₁.trans_le h)]
-          gcongr
-          exact integral_nonneg (hnonneg n)
-        · convert (ENNReal.tendsto_ofReal ((tendsto_inv_atTop_zero (𝕜 := ℝ≥0)).smul_const
-            (∫ ω, Y n ω ∂P))).congr' ?_
-          · simp
-          · filter_upwards [eventually_gt_atTop 0] with ε hε0
-            simp [hε0]
-  · exact Set.monotone_preimage.comp_antitone ENNReal.coe_mono.Ici
-  · exact fun r ↦ (measurableSet_le measurable_const hmY).nullMeasurableSet
-  · use 0; finiteness
+  refine hsub.iSup_ofReal_ne_top_of_measurable hnonneg n ?_
+    fun ε ↦ maximal_ineq_ennreal hsub hnonneg ε n hY_cont
+  have heq : (fun ω ↦ ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω))
+      = ⨆ i : Set.Iic n, fun ω ↦ ENNReal.ofReal (Y i ω) := by ext; simp
+  rw [heq]
+  refine measurable_iSup_of_rightContinuous (fun ω => ?_) fun t => ?_
+  · refine fun a => ((hY_cont ω).continuous_comp ENNReal.continuous_ofReal a).comp ?_ ?_
+    · exact continuous_subtype_val.continuousWithinAt
+    · exact fun x => by simp
+  · exact Measurable.ennreal_ofReal
+      ((hsub.stronglyMeasurable t).measurable.mono (𝓕.le _) (le_refl _))
 
 theorem maximal_ineq_nonneg (hsub : Submartingale Y 𝓕 P) (hnonneg : 0 ≤ Y) (ε : ℝ≥0) (n : ι)
     (hY_cont : ∀ ω, IsRightContinuous (Y · ω)) :
     ε * P.real {ω | (ε : ℝ) ≤ ⨆ i : Set.Iic n, Y i ω} ≤
-      ∫ ω in {ω | (ε : ℝ) ≤ ⨆ i : Set.Iic n, Y i ω}, Y n ω ∂P := by
-  have (ω : Ω) : ⨆ i : Set.Iic n, Y i ω = (⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω)).toReal := by
-    rw [ENNReal.toReal_iSup]
-    · congr with i
-      rw [ENNReal.toReal_ofReal (hnonneg _ _)]
-    · finiteness
-  have : {ω | ε ≤ ⨆ i : Set.Iic n, Y i ω} =ᵐ[P]
-    {ω | ε ≤ ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω)} := by
-    filter_upwards [hsub.rightCont_iSup_ofReal_ne_top hnonneg n hY_cont] with ω htop
-    ext
-    change _ ≤ _ ↔ _ ≤ _
-    rw [← ENNReal.ofReal_coe_nnreal, ENNReal.ofReal_le_iff_le_toReal htop, this]
-  rw [measureReal_congr this, setIntegral_congr_set this]
-  exact maximal_ineq_ennreal hsub hnonneg ε n hY_cont
+      ∫ ω in {ω | (ε : ℝ) ≤ ⨆ i : Set.Iic n, Y i ω}, Y n ω ∂P :=
+  maximal_ineq_nonneg_of_ne_top hnonneg ε n (hsub.rightCont_iSup_ofReal_ne_top hnonneg n hY_cont)
+    (maximal_ineq_ennreal hsub hnonneg ε n hY_cont)
 
 -- Remove the nonnegative constraint on `ε`.
 theorem maximal_ineq (hsub : Submartingale Y 𝓕 P) (hnonneg : 0 ≤ Y) (ε : ℝ) (n : ι)
@@ -502,5 +528,104 @@ theorem maximal_ineq_norm (hmar : Martingale X 𝓕 P) (ε : ℝ) (n : ι)
       ∫ ω in {ω | ε ≤ ⨆ i : Set.Iic n, ‖X i ω‖}, ‖X n ω‖ ∂P := by
   refine maximal_ineq hmar.submartingale_norm (fun _ _ ↦ norm_nonneg _) ε n fun ω => ?_
   exact (hX_cont ω).continuous_comp continuous_norm
+
+end SecondCountableTopology
+
+/-! ## Lower semicontinuous submartingales on a separable index set
+
+For processes whose paths are *lower semicontinuous* we can weaken the index assumption from
+`SecondCountableTopology` to `SeparableSpace`. This covers in particular continuous paths. The
+key input is Mathlib's `measurable_iSup_of_lowerSemicontinuous`: a countable dense set of times
+already computes the running supremum, because a lower semicontinuous path pulls `Set.Ioi` back
+to an open set, and separability of `Set.Iic n` follows from hereditary separability of separable
+linearly ordered spaces. -/
+
+section Separable
+
+variable [TopologicalSpace ι] [OrderTopology ι] [SeparableSpace ι]
+
+/-- **Doob's maximal inequality** in `ℝ≥0∞` form for a nonnegative submartingale whose paths are
+lower semicontinuous, indexed by a separable linearly ordered topological space. -/
+theorem maximal_ineq_ennreal_of_lowerSemicontinuous (hsub : Submartingale Y 𝓕 P) (hnonneg : 0 ≤ Y)
+    (ε : ℝ≥0) (n : ι) (hY_lsc : ∀ ω, LowerSemicontinuous (Y · ω)) :
+    ε * P.real {ω | (ε : ℝ≥0∞) ≤ ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω)} ≤
+      ∫ ω in {ω | (ε : ℝ≥0∞) ≤ ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω)}, Y n ω ∂P := by
+  obtain ⟨T, hT_countable, hT_dense⟩ := TopologicalSpace.exists_countable_dense (Set.Iic n)
+  -- add `n` to the countable dense set so that it has a top element
+  let S : Set (Set.Iic n) := insert ⟨n, le_rfl⟩ T
+  have hn : (⟨n, le_rfl⟩ : Set.Iic n) ∈ S := Set.mem_insert _ _
+  have hS : Countable S := by rw [Set.countable_coe_iff]; exact hT_countable.insert _
+  have hSd : Dense S := hT_dense.mono (Set.subset_insert _ _)
+  have h1 (ω : Ω) : ⨆ s : S, ENNReal.ofReal (Y s ω) = ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω) := by
+    refine iSup_eq_of_forall_le_of_forall_lt_exists_gt (fun s => ?_) (fun a ha => ?_)
+    · exact le_iSup (fun i : Set.Iic n => ENNReal.ofReal (Y i ω)) s
+    · obtain ⟨i, hi⟩ := lt_iSup_iff.1 ha
+      -- `x ↦ ENNReal.ofReal (Y x ω)` is lower semicontinuous, so `{x | a < ofReal (Y x ω)}` is open
+      have hlsc : LowerSemicontinuous fun x : Set.Iic n ↦ ENNReal.ofReal (Y x ω) :=
+        ENNReal.continuous_ofReal.comp_lowerSemicontinuous
+          ((hY_lsc ω).comp continuous_subtype_val) ENNReal.ofReal_mono
+      obtain ⟨k, hkS, hk⟩ := hSd.exists_mem_open (hlsc.isOpen_preimage a) ⟨i, hi⟩
+      exact ⟨⟨k, hkS⟩, hk⟩
+  have h2 (ω : Ω) : ⨆ s : S, ENNReal.ofReal (Y s ω) =
+      ⨆ s ≤ (⟨⟨n, le_rfl⟩, hn⟩ : S), ENNReal.ofReal (Y s ω) := by simp_all [iSup_subtype]
+  calc
+  _ = ε * P.real {ω | ε ≤ ⨆ s : S, ENNReal.ofReal (Y s ω)} := by simp [h1]
+  _ = ε * P.real {ω | ε ≤ ⨆ s ≤ (⟨⟨n, le_rfl⟩, hn⟩ : S), ENNReal.ofReal (Y s ω)} := by simp [h2]
+  _ ≤ ∫ ω in {ω | (ε : ℝ≥0∞) ≤ ⨆ s ≤ (⟨⟨n, le_rfl⟩, hn⟩ : S), ENNReal.ofReal (Y s ω)},
+      Y n ω ∂P := by
+    have : Monotone (fun x : S => x.1.1) := Subtype.mono_coe _
+    exact maximal_ineq_countable_ennreal (hsub.indexComap this) (fun x => hnonneg _) ε _
+  _ ≤ ∫ ω in {ω | (ε : ℝ≥0∞) ≤ ⨆ s : S, ENNReal.ofReal (Y s ω)}, Y n ω ∂P := by simp [h2]
+  _ = _ := by simp [h1]
+
+/-- Alternative form of `Submartingale.ae_bddAbove` for lower semicontinuous paths on a separable
+index. -/
+lemma _root_.MeasureTheory.Submartingale.lowerSemicontinuous_iSup_ofReal_ne_top
+    (hsub : Submartingale Y 𝓕 P) (hnonneg : 0 ≤ Y) (n : ι)
+    (hY_lsc : ∀ ω, LowerSemicontinuous (Y · ω)) :
+    ∀ᵐ ω ∂P, ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω) ≠ ∞ := by
+  refine hsub.iSup_ofReal_ne_top_of_measurable hnonneg n ?_
+    fun ε ↦ maximal_ineq_ennreal_of_lowerSemicontinuous hsub hnonneg ε n hY_lsc
+  have heq : (fun ω ↦ ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω))
+      = ⨆ i : Set.Iic n, fun ω ↦ ENNReal.ofReal (Y i ω) := by ext; simp
+  rw [heq]
+  refine measurable_iSup_of_lowerSemicontinuous (fun t => ?_) fun ω => ?_
+  · exact Measurable.ennreal_ofReal
+      ((hsub.stronglyMeasurable t).measurable.mono (𝓕.le _) (le_refl _))
+  · exact ENNReal.continuous_ofReal.comp_lowerSemicontinuous
+      ((hY_lsc ω).comp continuous_subtype_val) ENNReal.ofReal_mono
+
+/-- **Doob's maximal inequality** for a nonnegative submartingale with lower semicontinuous paths,
+indexed by a separable linearly ordered topological space. -/
+theorem maximal_ineq_nonneg_of_lowerSemicontinuous (hsub : Submartingale Y 𝓕 P) (hnonneg : 0 ≤ Y)
+    (ε : ℝ≥0) (n : ι) (hY_lsc : ∀ ω, LowerSemicontinuous (Y · ω)) :
+    ε * P.real {ω | (ε : ℝ) ≤ ⨆ i : Set.Iic n, Y i ω} ≤
+      ∫ ω in {ω | (ε : ℝ) ≤ ⨆ i : Set.Iic n, Y i ω}, Y n ω ∂P :=
+  maximal_ineq_nonneg_of_ne_top hnonneg ε n
+    (hsub.lowerSemicontinuous_iSup_ofReal_ne_top hnonneg n hY_lsc)
+    (maximal_ineq_ennreal_of_lowerSemicontinuous hsub hnonneg ε n hY_lsc)
+
+/-- **Doob's maximal inequality** for a nonnegative submartingale with lower semicontinuous paths,
+indexed by a separable linearly ordered topological space, without the nonnegativity constraint
+on `ε`. -/
+theorem maximal_ineq_of_lowerSemicontinuous (hsub : Submartingale Y 𝓕 P) (hnonneg : 0 ≤ Y) (ε : ℝ)
+    (n : ι) (hY_lsc : ∀ ω, LowerSemicontinuous (Y · ω)) :
+    ε * P.real {ω | ε ≤ ⨆ i : Set.Iic n, Y i ω} ≤
+      ∫ ω in {ω | ε ≤ ⨆ i : Set.Iic n, Y i ω}, Y n ω ∂P := by
+  by_cases! hε : 0 ≤ ε
+  · exact maximal_ineq_nonneg_of_lowerSemicontinuous hsub hnonneg ⟨ε, hε⟩ n hY_lsc
+  · exact (mul_nonpos_of_nonpos_of_nonneg hε.le measureReal_nonneg).trans
+      (integral_nonneg (hnonneg n))
+
+/-- **Doob's maximal inequality** for a martingale with continuous paths, indexed by a separable
+linearly ordered topological space, stated for the norm of the process. -/
+theorem maximal_ineq_norm_of_continuous (hmar : Martingale X 𝓕 P) (ε : ℝ) (n : ι)
+    (hX_cont : ∀ ω, Continuous (X · ω)) :
+    ε • P.real {ω | ε ≤ ⨆ i : Set.Iic n, ‖X i ω‖} ≤
+      ∫ ω in {ω | ε ≤ ⨆ i : Set.Iic n, ‖X i ω‖}, ‖X n ω‖ ∂P :=
+  maximal_ineq_of_lowerSemicontinuous hmar.submartingale_norm (fun _ _ ↦ norm_nonneg _) ε n
+    fun ω ↦ (continuous_norm.comp (hX_cont ω)).lowerSemicontinuous
+
+end Separable
 
 end ProbabilityTheory


### PR DESCRIPTION
Following up on #257 (Doob's maximal inequality for **right-continuous** sub-martingales on a **second-countable** index set), this PR proves the analogous statement for submartingales whose paths are **lower semicontinuous**, on a **separable** index set. This covers continuous paths in particular, and mirrors how `VariationProcess.lean` handles the second-countable and separable regimes for the measurability of the variation process in #494.

### Why a separate version

For general linearly ordered topological spaces, `SeparableSpace` is strictly weaker than `SecondCountableTopology` (a separable LOTS can have uncountably many right-isolated points), so neither result implies the other:
- right-continuous paths ⟹ need `SecondCountableTopology`;
- lower semicontinuous paths ⟹ `SeparableSpace` suffices

The measurability of the running supremum is exactly Mathlib's `measurable_iSup_of_lowerSemicontinuous`; separability of `Set.Iic n` comes from hereditary separability of separable LOTS (`Set.separableSpace`, added in #499).

### Main results (new `section Separable` in `DoobLp.lean`)

- `maximal_ineq_ennreal_of_lowerSemicontinuous`
- `maximal_ineq_nonneg_of_lowerSemicontinuous`, `maximal_ineq_of_lowerSemicontinuous`
- `maximal_ineq_norm_of_continuous` (continuous martingale, norm form)

### Depends on #499

🤖 Generated with [Claude Code](https://claude.com/claude-code)