### PR TITLE
The type of indistinguishable processes

### DIFF
--- a/BrownianMotion/Auxiliary/AEEq.lean
+++ b/BrownianMotion/Auxiliary/AEEq.lean
@@ -128,7 +128,7 @@ protected theorem stronglyAdapted (f : α →ₚ[μ, 𝓕] β) : StronglyAdapted
 protected theorem aestronglyAdapted (f : α →ₚ[μ, 𝓕] β) : AEStronglyAdapted f 𝓕 μ :=
   f.stronglyAdapted.aestronglyAdapted
 
-protected theorem measurable [PseudoMetrizableSpace β] [MeasurableSpace β] [BorelSpace β]
+protected theorem adapted [PseudoMetrizableSpace β] [MeasurableSpace β] [BorelSpace β]
     (f : α →ₚ[μ, 𝓕] β) : Adapted 𝓕 f :=
   f.stronglyAdapted.adapted
 

--- a/BrownianMotion/Auxiliary/AEEq.lean
+++ b/BrownianMotion/Auxiliary/AEEq.lean
@@ -5,138 +5,609 @@ Authors: Etienne Marion
 -/
 module
 
-public import Mathlib.MeasureTheory.Measure.AEMeasurable
+public import BrownianMotion.Auxiliary.Adapted
+public import BrownianMotion.Auxiliary.Indistinguishable
+public import Mathlib.Dynamics.Ergodic.MeasurePreserving
+public import Mathlib.MeasureTheory.Function.StronglyMeasurable.AEStronglyMeasurable
+public import Mathlib.MeasureTheory.Integral.Lebesgue.Add
+public import Mathlib.Order.Filter.Germ.Basic
+public import Mathlib.Probability.Process.Adapted
+public import Mathlib.Topology.ContinuousMap.Algebra
 
 /-!
 
-# Almost everywhere equal functions
+# Indistinguishable processes
 
-This is the same as `AEEqFun` but for `AEMeasurable` functions rather than `AEMeasurable`
-ones.
+We build a space of equivalence classes of processes, where two processes are treated as identical
+if they are `Indistinguishable`. We form the set of equivalence classes under the relation of
+being indistinguishable.
+We consider equivalence classes of strongly adapted processes
+(or, equivalently, of almost everywhere strongly adapted processes.)
+
+## Notation
+
+* `α →ₚ[μ, 𝓕] β`
+
+## Main statements
+
+* The linear structure of `L⁰` :
+  Addition and scalar multiplication are defined on `L⁰` in the natural way, i.e.,
+  `[f] + [g] := [f + g]`, `c • [f] := [c • f]`. So defined, `α →ₚ β` inherits the linear structure
+  of `β`. For example, if `β` is a module, then `α →ₚ β` is a module over the same ring.
+
+  See `mk_add_mk`, `neg_mk`, `mk_sub`, `smul_mk`,
+  `coeFn_add`, `coeFn_neg`, `coeFn_sub`, `coeFn_smul`
+
+* The order structure of `L⁰` :
+  `≤` can be defined in a similar way: `[f] ≤ [g]` if `f a ≤ g a` for almost all `a` in domain.
+  And `α →ₚ β` inherits the preorder and partial order of `β`.
+
+  TODO: Define `sup` and `inf` on `L⁰` so that it forms a lattice. It seems that `β` must be a
+  linear order, since otherwise `f ⊔ g` may not be a measurable function.
+
+## Implementation notes
+
+* `f.cast`:      To find a representative of `f : α →ₚ β`, use the coercion `(f : α → β)`, which
+                 is implemented as `f.toFun`.
+                 For each operation `op` in `L⁰`, there is a lemma called `coe_fn_op`,
+                 characterizing, say, `(f op g : α → β)`.
+* `AEEqProcess.mk`:  To construct an `L⁰` function `α →ₚ β` from an almost everywhere strongly
+                 measurable function `f : α → β`, use `ae_eq_fun.mk`
+* `comp`:        Use `comp g f` to get `[g ∘ f]` from `g : β → γ` and `[f] : α →ₚ γ` when `g` is
+                 continuous. Use `compMeasurable` if `g` is only measurable (this requires the
+                 target space to be second countable).
+* `comp₂`:       Use `comp₂ g f₁ f₂` to get `[fun a ↦ g (f₁ a) (f₂ a)]`.
+                 For example, `[f + g]` is `comp₂ (+)`
 
 -/
 
 @[expose] public section
 
--- Guard against import creep
-assert_not_exists InnerProductSpace
-
 noncomputable section
 
-open Topology Set Filter MeasurableSpace ENNReal EMetric MeasureTheory Function
+open Topology Set Filter TopologicalSpace ENNReal EMetric MeasureTheory Function
 
-variable {α β γ δ : Type*} {mα : MeasurableSpace α} {μ ν : Measure α}
+variable {ι α β γ δ : Type*} {mα : MeasurableSpace α} {μ ν : Measure α}
+  [Preorder ι] {𝓕 : Filtration ι mα}
 
 namespace MeasureTheory
 
 section MeasurableSpace
 
-variable [MeasurableSpace β]
-variable (β)
+variable [TopologicalSpace β]
+variable (𝓕 β)
 
 /-- The equivalence relation of being almost everywhere equal for almost everywhere strongly
 measurable functions. -/
 @[implicit_reducible]
-def Measure.aeEqSetoid' (μ : Measure α) : Setoid { f : α → β // AEMeasurable f μ } :=
-  ⟨fun f g => (f : α → β) =ᵐ[μ] g, fun {f} => ae_eq_refl f.val, fun {_ _} => ae_eq_symm,
-    fun {_ _ _} => ae_eq_trans⟩
+def Measure.aeEqSetoid' (μ : Measure α) :
+    Setoid { X : ι → α → β // AEStronglyAdapted X 𝓕 μ } :=
+  ⟨fun f g => f.1 ≡ᵐ[μ] g, fun {_} => .rfl, fun {_ _} => .symm,
+    fun {_ _ _} => .trans⟩
 
 variable (α)
 
-/-- The space of equivalence classes of almost everywhere measurable functions, where two
-measurable functions are equivalent if they agree almost everywhere, i.e.,
+/-- The space of equivalence classes of almost everywhere strongly measurable functions, where two
+strongly measurable functions are equivalent if they agree almost everywhere, i.e.,
 they differ on a set of measure `0`. -/
-def AEEq (μ : Measure α) : Type _ :=
-  Quotient (μ.aeEqSetoid' β)
+def AEEqProcess (μ : Measure α) : Type _ :=
+  Quotient (μ.aeEqSetoid' β 𝓕)
 
 variable {α β}
 
-@[inherit_doc MeasureTheory.AEEq]
-notation:25 α " →ₐₑ[" μ "] " β => AEEq α β μ
+@[inherit_doc MeasureTheory.AEEqProcess]
+notation:25 α " →ₚ[" μ ", " 𝓕 "] " β => AEEqProcess α β 𝓕 μ
 
 end MeasurableSpace
 
-variable [MeasurableSpace δ]
+variable [TopologicalSpace δ]
 
-namespace AEEq
+namespace AEEqProcess
 
 section
-variable [MeasurableSpace β]
+variable [TopologicalSpace β]
 
 /-- Construct the equivalence class `[f]` of an almost everywhere measurable function `f`, based
 on the equivalence relation of being almost everywhere equal. -/
-def mk {β : Type*} [MeasurableSpace β] (f : α → β) (hf : AEMeasurable f μ) : α →ₐₑ[μ] β :=
+def mk {β : Type*} [TopologicalSpace β] (f : ι → α → β) (hf : AEStronglyAdapted f 𝓕 μ) :
+    α →ₚ[μ, 𝓕] β :=
   Quotient.mk'' ⟨f, hf⟩
 
 open scoped Classical in
-/-- Coercion from a space of equivalence classes of almost everywhere measurable
+/-- Coercion from a space of equivalence classes of almost everywhere strongly measurable
 functions to functions. We ensure that if `f` has a constant representative,
 then we choose that one. -/
 @[coe]
-def cast (f : α →ₐₑ[μ] β) : α → β :=
-  if h : ∃ (b : β), f = mk (const α b) aemeasurable_const then
-    const α <| Classical.choose h else
-    AEMeasurable.mk _ (Quotient.out f : { f : α → β // AEMeasurable f μ }).2
+def cast (X : α →ₚ[μ, 𝓕] β) : ι → α → β :=
+  if h : ∃ (c : β), X = mk (fun _ _ ↦ c) .const then
+    fun _ _ ↦ h.choose else
+    AEStronglyAdapted.mk _ (Quotient.out X : { f : ι → α → β // AEStronglyAdapted f 𝓕 μ }).2
 
-/-- A measurable representative of an `AEEqFun` [f] -/
-instance instCoeFun : CoeFun (α →ₐₑ[μ] β) fun _ => α → β := ⟨cast⟩
+/-- A measurable representative of an `AEEqProcess` [f] -/
+instance instCoeFun : CoeFun (α →ₚ[μ, 𝓕] β) fun _ => ι → α → β := ⟨cast⟩
 
-@[fun_prop]
-protected theorem measurable (f : α →ₐₑ[μ] β) : Measurable f := by
+protected theorem stronglyAdapted (f : α →ₚ[μ, 𝓕] β) : StronglyAdapted 𝓕 f := by
   simp only [cast]
   split_ifs with h
-  · exact measurable_const
-  · apply AEMeasurable.measurable_mk
+  · exact stronglyAdapted_const 𝓕 _
+  · apply AEStronglyAdapted.stronglyAdapted_mk
 
-@[fun_prop]
-protected theorem aemeasurable (f : α →ₐₑ[μ] β) : AEMeasurable f μ :=
-  f.measurable.aemeasurable
+protected theorem aestronglyAdapted (f : α →ₚ[μ, 𝓕] β) : AEStronglyAdapted f 𝓕 μ :=
+  f.stronglyAdapted.aestronglyAdapted
+
+protected theorem measurable [PseudoMetrizableSpace β] [MeasurableSpace β] [BorelSpace β]
+    (f : α →ₚ[μ, 𝓕] β) : Adapted 𝓕 f :=
+  f.stronglyAdapted.adapted
 
 @[simp]
-theorem quot_mk_eq_mk (f : α → β) (hf) :
-    (Quot.mk (@Setoid.r _ <| μ.aeEqSetoid' β) ⟨f, hf⟩ : α →ₐₑ[μ] β) = mk f hf :=
+theorem quot_mk_eq_mk (f : ι → α → β) (hf) :
+    (Quot.mk (@Setoid.r _ <| μ.aeEqSetoid' β 𝓕) ⟨f, hf⟩ : α →ₚ[μ, 𝓕] β) = mk f hf :=
   rfl
 
 @[simp]
-theorem mk_eq_mk {f g : α → β} {hf hg} : (mk f hf : α →ₐₑ[μ] β) = mk g hg ↔ f =ᵐ[μ] g :=
+theorem mk_eq_mk {f g : ι → α → β} {hf hg} : (mk f hf : α →ₚ[μ, 𝓕] β) = mk g hg ↔ f ≡ᵐ[μ] g :=
   Quotient.eq''
 
 @[simp]
-theorem mk_coeFn (f : α →ₐₑ[μ] β) : mk f f.aemeasurable = f := by
+theorem mk_coeFn (f : α →ₚ[μ, 𝓕] β) : mk f f.aestronglyAdapted = f := by
   conv_lhs => simp only [cast]
   split_ifs with h
   · exact Classical.choose_spec h |>.symm
   conv_rhs => rw [← Quotient.out_eq' f]
   rw [← mk, mk_eq_mk]
-  exact (AEMeasurable.ae_eq_mk _).symm
+  exact (AEStronglyAdapted.indist_mk _).symm
 
 @[ext]
-theorem ext {f g : α →ₐₑ[μ] β} (h : f =ᵐ[μ] g) : f = g := by
+theorem ext {f g : α →ₚ[μ, 𝓕] β} (h : f ≡ᵐ[μ] g) : f = g := by
   rwa [← f.mk_coeFn, ← g.mk_coeFn, mk_eq_mk]
 
-theorem coeFn_mk (f : α → β) (hf) : (mk f hf : α →ₐₑ[μ] β) =ᵐ[μ] f := by
-  rw [← mk_eq_mk (hf := AEEq.aemeasurable ..) (hg := hf), mk_coeFn]
+theorem coeFn_mk (f : ι → α → β) (hf) : (mk f hf : α →ₚ[μ, 𝓕] β) ≡ᵐ[μ] f := by
+  rw [← mk_eq_mk (hf := AEEqProcess.aestronglyAdapted ..) (hg := hf), mk_coeFn]
 
 @[elab_as_elim]
-theorem induction_on (f : α →ₐₑ[μ] β) {p : (α →ₐₑ[μ] β) → Prop} (H : ∀ f hf, p (mk f hf)) : p f :=
+theorem induction_on (f : α →ₚ[μ, 𝓕] β) {p : (α →ₚ[μ, 𝓕] β) → Prop} (H : ∀ f hf, p (mk f hf)) :
+    p f :=
   Quotient.inductionOn' f <| Subtype.forall.2 H
 
 @[elab_as_elim]
-theorem induction_on₂ {α' β' : Type*} [MeasurableSpace α'] [MeasurableSpace β'] {μ' : Measure α'}
-    (f : α →ₐₑ[μ] β) (f' : α' →ₐₑ[μ'] β') {p : (α →ₐₑ[μ] β) → (α' →ₐₑ[μ'] β') → Prop}
+theorem induction_on₂ {α' β' ι' : Type*} {mα' : MeasurableSpace α'} [TopologicalSpace β']
+    {μ' : Measure α'} [Preorder ι'] {𝓕' : Filtration ι' mα'}
+    (f : α →ₚ[μ, 𝓕] β) (f' : α' →ₚ[μ', 𝓕'] β') {p : (α →ₚ[μ, 𝓕] β) → (α' →ₚ[μ', 𝓕'] β') → Prop}
     (H : ∀ f hf f' hf', p (mk f hf) (mk f' hf')) : p f f' :=
   induction_on f fun f hf => induction_on f' <| H f hf
 
 @[elab_as_elim]
-theorem induction_on₃ {α' β' : Type*} [MeasurableSpace α'] [MeasurableSpace β'] {μ' : Measure α'}
-    {α'' β'' : Type*} [MeasurableSpace α''] [MeasurableSpace β''] {μ'' : Measure α''}
-    (f : α →ₐₑ[μ] β) (f' : α' →ₐₑ[μ'] β') (f'' : α'' →ₐₑ[μ''] β'')
-    {p : (α →ₐₑ[μ] β) → (α' →ₐₑ[μ'] β') → (α'' →ₐₑ[μ''] β'') → Prop}
+theorem induction_on₃ {α' β' ι' : Type*} {mα' : MeasurableSpace α'} [TopologicalSpace β']
+    {μ' : Measure α'} [Preorder ι'] {𝓕' : Filtration ι' mα'}
+    {α'' β'' ι'' : Type*} {mα'' : MeasurableSpace α''} [TopologicalSpace β''] {μ'' : Measure α''}
+    [Preorder ι''] {𝓕'' : Filtration ι'' mα''}
+    (f : α →ₚ[μ, 𝓕] β) (f' : α' →ₚ[μ', 𝓕'] β') (f'' : α'' →ₚ[μ'', 𝓕''] β'')
+    {p : (α →ₚ[μ, 𝓕] β) → (α' →ₚ[μ', 𝓕'] β') → (α'' →ₚ[μ'', 𝓕''] β'') → Prop}
     (H : ∀ f hf f' hf' f'' hf'', p (mk f hf) (mk f' hf') (mk f'' hf'')) : p f f' f'' :=
   induction_on f fun f hf => induction_on₂ f' f'' <| H f hf
 
 end
 
-end AEEq
+variable [TopologicalSpace β] [TopologicalSpace γ]
+
+/-- Given a continuous function `g : β → γ`, and an almost everywhere equal function `[f] : α →ₚ β`,
+return the equivalence class of `g ∘ f`, i.e., the almost everywhere equal function
+`[g ∘ f] : α →ₚ γ`. -/
+def comp (g : β → γ) (hg : Continuous g) (f : α →ₚ[μ, 𝓕] β) : α →ₚ[μ, 𝓕] γ :=
+  Quotient.liftOn' f (fun f => mk (fun t ↦ g ∘ (f.1 t)) (hg.comp_aestronglyAdapted f.2))
+    fun _ _ H => mk_eq_mk.2 <| H.fun_comp g
+
+@[simp]
+theorem comp_mk (g : β → γ) (hg : Continuous g) (f : ι → α → β) (hf) :
+    comp g hg (mk f hf : α →ₚ[μ, 𝓕] β) = mk (fun t ↦ g ∘ (f t)) (hg.comp_aestronglyAdapted hf) :=
+  rfl
+
+@[simp]
+theorem comp_id (f : α →ₚ[μ, 𝓕] β) : comp id (continuous_id) f = f := by
+  rcases f; rfl
+
+@[simp]
+theorem comp_comp (g : γ → δ) (g' : β → γ) (hg : Continuous g) (hg' : Continuous g')
+    (f : α →ₚ[μ, 𝓕] β) : comp g hg (comp g' hg' f) = comp (g ∘ g') (hg.comp hg') f := by
+  rcases f; rfl
+
+theorem comp_eq_mk (g : β → γ) (hg : Continuous g) (f : α →ₚ[μ, 𝓕] β) :
+    comp g hg f = mk (fun t ↦ g ∘ (f t)) (hg.comp_aestronglyAdapted f.aestronglyAdapted) := by
+  rw [← comp_mk g hg f f.aestronglyAdapted, mk_coeFn]
+
+theorem coeFn_comp (g : β → γ) (hg : Continuous g) (f : α →ₚ[μ, 𝓕] β) :
+    comp g hg f ≡ᵐ[μ] (fun t ↦ g ∘ (f t)) := by
+  rw [comp_eq_mk]
+  apply coeFn_mk
+
+/-- The class of `x ↦ (f x, g x)`. -/
+def pair (f : α →ₚ[μ, 𝓕] β) (g : α →ₚ[μ, 𝓕] γ) : α →ₚ[μ, 𝓕] β × γ :=
+  Quotient.liftOn₂' f g (fun f g => mk (fun t ω => (f.1 t ω, g.1 t ω)) (f.2.prodMk g.2))
+    fun _f _g _f' _g' Hf Hg => mk_eq_mk.2 <| Hf.prodMk Hg
+
+@[simp]
+theorem pair_mk_mk (f : ι → α → β) (hf) (g : ι → α → γ) (hg) :
+    (mk f hf : α →ₚ[μ, 𝓕] β).pair (mk g hg) = mk (fun t ω => (f t ω, g t ω)) (hf.prodMk hg) :=
+  rfl
+
+theorem pair_eq_mk (f : α →ₚ[μ, 𝓕] β) (g : α →ₚ[μ, 𝓕] γ) :
+    f.pair g =
+      mk (fun t ω => (f t ω, g t ω)) (f.aestronglyAdapted.prodMk g.aestronglyAdapted) := by
+  simp only [← pair_mk_mk, mk_coeFn, f.aestronglyAdapted, g.aestronglyAdapted]
+
+theorem coeFn_pair (f : α →ₚ[μ, 𝓕] β) (g : α →ₚ[μ, 𝓕] γ) :
+    f.pair g ≡ᵐ[μ] fun t ω => (f t ω, g t ω) := by
+  rw [pair_eq_mk]
+  apply coeFn_mk
+
+/-- Given a continuous function `g : β → γ → δ`, and almost everywhere equal functions
+`[f₁] : α →ₚ β` and `[f₂] : α →ₚ γ`, return the equivalence class of the function
+`fun a => g (f₁ a) (f₂ a)`, i.e., the almost everywhere equal function
+`[fun a => g (f₁ a) (f₂ a)] : α →ₚ γ` -/
+def comp₂ (g : β → γ → δ) (hg : Continuous (uncurry g)) (f₁ : α →ₚ[μ, 𝓕] β) (f₂ : α →ₚ[μ, 𝓕] γ) :
+    α →ₚ[μ, 𝓕] δ :=
+  comp _ hg (f₁.pair f₂)
+
+@[simp]
+theorem comp₂_mk_mk (g : β → γ → δ) (hg : Continuous (uncurry g)) (f₁ : ι → α → β) (f₂ : ι → α → γ)
+    (hf₁ hf₂) :
+    comp₂ g hg (mk f₁ hf₁ : α →ₚ[μ, 𝓕] β) (mk f₂ hf₂) =
+      mk (fun t ω => g (f₁ t ω) (f₂ t ω)) (hg.comp_aestronglyAdapted (hf₁.prodMk hf₂)) :=
+  rfl
+
+theorem comp₂_eq_pair (g : β → γ → δ) (hg : Continuous (uncurry g)) (f₁ : α →ₚ[μ, 𝓕] β)
+    (f₂ : α →ₚ[μ, 𝓕] γ) : comp₂ g hg f₁ f₂ = comp _ hg (f₁.pair f₂) :=
+  rfl
+
+theorem comp₂_eq_mk (g : β → γ → δ) (hg : Continuous (uncurry g)) (f₁ : α →ₚ[μ, 𝓕] β)
+    (f₂ : α →ₚ[μ, 𝓕] γ) : comp₂ g hg f₁ f₂ = mk (fun t ω => g (f₁ t ω) (f₂ t ω))
+      (hg.comp_aestronglyAdapted (f₁.aestronglyAdapted.prodMk f₂.aestronglyAdapted)) := by
+  rw [comp₂_eq_pair, pair_eq_mk, comp_mk]; rfl
+
+theorem coeFn_comp₂ (g : β → γ → δ) (hg : Continuous (uncurry g)) (f₁ : α →ₚ[μ, 𝓕] β)
+    (f₂ : α →ₚ[μ, 𝓕] γ) : comp₂ g hg f₁ f₂ ≡ᵐ[μ] fun t ω => g (f₁ t ω) (f₂ t ω) := by
+  rw [comp₂_eq_mk]
+  apply coeFn_mk
+
+/-- Interpret `f : α →ₚ[μ, 𝓕] β` as a germ at `ae μ` forgetting that `f` is almost everywhere
+strongly measurable. -/
+def toGerm (f : α →ₚ[μ, 𝓕] β) : Germ (ae μ) (ι → β) :=
+  Quotient.liftOn' f (fun f => (fun ω t ↦ f.1 t ω : Germ (ae μ) (ι → β)))
+  fun _ _ H => Germ.coe_eq.2 H.ae_eq
+
+@[simp]
+theorem mk_toGerm (f : ι → α → β) (hf) : (mk f hf : α →ₚ[μ, 𝓕] β).toGerm = (fun ω t ↦ f t ω) :=
+  rfl
+
+theorem toGerm_eq (f : α →ₚ[μ, 𝓕] β) : f.toGerm = (fun ω t ↦ f t ω) := by
+  rw [← mk_toGerm f f.aestronglyAdapted, mk_coeFn]
+
+theorem toGerm_injective : Injective (toGerm : (α →ₚ[μ, 𝓕] β) → Germ (ae μ) (ι → β)) := fun f g H =>
+  ext <| EventuallyEq.indist <| Germ.coe_eq.1 <| by rwa [← toGerm_eq, ← toGerm_eq]
+
+theorem comp_toGerm (g : β → γ) (hg : Continuous g) (f : α →ₚ[μ, 𝓕] β) :
+    (comp g hg f).toGerm = f.toGerm.map (fun f t ↦ g (f t)) :=
+  induction_on f fun f _ => by
+    simp only [comp_mk, mk_toGerm, comp_apply, Germ.map_coe, Germ.coe_eq]
+    exact ae_of_all _ (by simp)
+
+theorem comp₂_toGerm (g : β → γ → δ) (hg : Continuous (uncurry g)) (f₁ : α →ₚ[μ, 𝓕] β)
+    (f₂ : α →ₚ[μ, 𝓕] γ) :
+    (comp₂ g hg f₁ f₂).toGerm = f₁.toGerm.map₂ (fun f h t ↦ g (f t) (h t)) f₂.toGerm :=
+  induction_on₂ f₁ f₂ fun f₁ _ f₂ _ => by simp
+
+/-- Given a predicate `p` and an equivalence class `[f]`, return true if `p` holds of `f a`
+for almost all `a` -/
+def LiftPred (p : (ι → β) → Prop) (f : α →ₚ[μ, 𝓕] β) : Prop :=
+  f.toGerm.LiftPred p
+
+/-- Given a relation `r` and equivalence class `[f]` and `[g]`, return true if `r` holds of
+`(f a, g a)` for almost all `a` -/
+def LiftRel (r : (ι → β) → (ι → γ) → Prop) (f : α →ₚ[μ, 𝓕] β) (g : α →ₚ[μ, 𝓕] γ) : Prop :=
+  f.toGerm.LiftRel r g.toGerm
+
+theorem liftRel_mk_mk {r : (ι → β) → (ι → γ) → Prop} {f : ι → α → β} {g : ι → α → γ} {hf hg} :
+    LiftRel r (mk f hf : α →ₚ[μ, 𝓕] β) (mk g hg) ↔ ∀ᵐ a ∂μ, r (f · a) (g · a) :=
+  Iff.rfl
+
+theorem liftRel_iff_coeFn {r : (ι → β) → (ι → γ) → Prop} {f : α →ₚ[μ, 𝓕] β} {g : α →ₚ[μ, 𝓕] γ} :
+    LiftRel r f g ↔ ∀ᵐ a ∂μ, r (f · a) (g · a) := by
+  rw [← liftRel_mk_mk (hf := f.aestronglyAdapted) (hg := g.aestronglyAdapted),
+    mk_coeFn, mk_coeFn]
+
+variable (α)
+
+/-- The equivalence class of a constant function: `[fun _ : α => b]`, based on the equivalence
+relation of being almost everywhere equal -/
+def const (b : β) : α →ₚ[μ, 𝓕] β :=
+  mk (fun _ _ ↦ b) .const
+
+theorem coeFn_const (b : β) : (const α b : α →ₚ[μ, 𝓕] β) ≡ᵐ[μ] (fun _ _ ↦ b) :=
+  coeFn_mk _ _
+
+/-- If the measure is nonzero, we can strengthen `coeFn_const` to get an equality. -/
+@[simp]
+theorem coeFn_const_eq [NeZero μ] (b : β) (t : ι) (x : α) : (const α b : α →ₚ[μ, 𝓕] β) t x = b := by
+  simp only [cast]
+  split_ifs with h
+  case neg => exact h.elim ⟨b, rfl⟩
+  have := h.choose_spec
+  set b := h.choose with hb
+  simp_rw [const, mk_eq_mk, ProbabilityTheory.Indistinguishable] at this
+  have ⟨_, h1⟩ := Eventually.exists this
+  rw [h1 t]
+
+theorem coeFn_const_eq' (b : β) : ∃ b', ((const α b : α →ₚ[μ, 𝓕] β) : ι → α → β) = fun _ ↦ b' := by
+  simp only [cast]
+  split_ifs with h
+  case neg => exact h.elim ⟨b, rfl⟩
+  exact ⟨fun _ ↦ h.choose, by ext; simp⟩
+
+variable {α}
+
+instance instInhabited [Inhabited β] : Inhabited (α →ₚ[μ, 𝓕] β) :=
+  ⟨const α default⟩
+
+@[to_additive]
+instance instOne [One β] : One (α →ₚ[μ, 𝓕] β) :=
+  ⟨const α 1⟩
+
+@[to_additive]
+theorem one_def [One β] : (1 : α →ₚ[μ, 𝓕] β) = mk (fun _ _ => 1) .const :=
+  rfl
+
+@[to_additive]
+theorem coeFn_one [One β] : ⇑(1 : α →ₚ[μ, 𝓕] β) ≡ᵐ[μ] 1 :=
+  coeFn_const ..
+
+@[to_additive (attr := simp)]
+theorem coeFn_one_eq [NeZero μ] [One β] {t : ι} {x : α} : (1 : α →ₚ[μ, 𝓕] β) t x = 1 :=
+  coeFn_const_eq ..
+
+@[to_additive (attr := simp)]
+theorem one_toGerm [One β] : (1 : α →ₚ[μ, 𝓕] β).toGerm = 1 :=
+  rfl
+
+-- Note we set up the scalar actions before the `Monoid` structures in case we want to
+-- try to override the `nsmul` or `zsmul` fields in future.
+section SMul
+
+variable {𝕜 𝕜' : Type*}
+variable [SMul 𝕜 γ] [ContinuousConstSMul 𝕜 γ]
+variable [SMul 𝕜' γ] [ContinuousConstSMul 𝕜' γ]
+
+instance instSMul : SMul 𝕜 (α →ₚ[μ, 𝓕] γ) :=
+  ⟨fun c f => comp (c • ·) (continuous_id.const_smul c) f⟩
+
+@[simp]
+theorem smul_mk (c : 𝕜) (f : ι → α → γ) (hf : AEStronglyAdapted f 𝓕 μ) :
+    c • (mk f hf : α →ₚ[μ, 𝓕] γ) = mk (c • f) hf.const_smul :=
+  rfl
+
+theorem coeFn_smul (c : 𝕜) (f : α →ₚ[μ, 𝓕] γ) : ⇑(c • f) ≡ᵐ[μ] c • ⇑f :=
+  coeFn_comp _ _ _
+
+theorem smul_toGerm (c : 𝕜) (f : α →ₚ[μ, 𝓕] γ) : (c • f).toGerm = c • f.toGerm :=
+  comp_toGerm _ _ _
+
+instance instSMulCommClass [SMulCommClass 𝕜 𝕜' γ] : SMulCommClass 𝕜 𝕜' (α →ₚ[μ, 𝓕] γ) :=
+  ⟨fun a b f => induction_on f fun f hf => by simp_rw [smul_mk, smul_comm]⟩
+
+instance instIsScalarTower [SMul 𝕜 𝕜'] [IsScalarTower 𝕜 𝕜' γ] : IsScalarTower 𝕜 𝕜' (α →ₚ[μ, 𝓕] γ) :=
+  ⟨fun a b f => induction_on f fun f hf => by simp_rw [smul_mk, smul_assoc]⟩
+
+instance instIsCentralScalar [SMul 𝕜ᵐᵒᵖ γ] [IsCentralScalar 𝕜 γ] :
+    IsCentralScalar 𝕜 (α →ₚ[μ, 𝓕] γ) :=
+  ⟨fun a f => induction_on f fun f hf => by simp_rw [smul_mk, op_smul_eq_smul]⟩
+
+end SMul
+
+section Mul
+
+variable [Mul γ] [ContinuousMul γ]
+
+@[to_additive]
+instance instMul : Mul (α →ₚ[μ, 𝓕] γ) :=
+  ⟨comp₂ (· * ·) continuous_mul⟩
+
+@[to_additive (attr := simp)]
+theorem mk_mul_mk (f g : ι → α → γ) (hf : AEStronglyAdapted f 𝓕 μ) (hg : AEStronglyAdapted g 𝓕 μ) :
+    (mk f hf : α →ₚ[μ, 𝓕] γ) * mk g hg = mk (f * g) (hf.mul hg) :=
+  rfl
+
+@[to_additive]
+theorem coeFn_mul (f g : α →ₚ[μ, 𝓕] γ) : ⇑(f * g) ≡ᵐ[μ] f * g :=
+  coeFn_comp₂ _ _ _ _
+
+@[to_additive (attr := simp)]
+theorem mul_toGerm (f g : α →ₚ[μ, 𝓕] γ) : (f * g).toGerm = f.toGerm * g.toGerm :=
+  comp₂_toGerm _ _ _ _
+
+end Mul
+
+instance instAddMonoid [AddMonoid γ] [ContinuousAdd γ] : AddMonoid (α →ₚ[μ, 𝓕] γ) :=
+  toGerm_injective.addMonoid toGerm zero_toGerm add_toGerm fun _ _ => smul_toGerm _ _
+
+instance instAddCommMonoid [AddCommMonoid γ] [ContinuousAdd γ] : AddCommMonoid (α →ₚ[μ, 𝓕] γ) :=
+  toGerm_injective.addCommMonoid toGerm zero_toGerm add_toGerm fun _ _ => smul_toGerm _ _
+
+section Monoid
+
+variable [Monoid γ] [ContinuousMul γ]
+
+instance instPowNat : Pow (α →ₚ[μ, 𝓕] γ) ℕ :=
+  ⟨fun f n => comp _ (continuous_pow n) f⟩
+
+@[simp]
+theorem mk_pow (f : ι → α → γ) (hf) (n : ℕ) :
+    (mk f hf : α →ₚ[μ, 𝓕] γ) ^ n =
+      mk (f ^ n) ((_root_.continuous_pow n).comp_aestronglyAdapted hf) :=
+  rfl
+
+theorem coeFn_pow (f : α →ₚ[μ, 𝓕] γ) (n : ℕ) : ⇑(f ^ n) ≡ᵐ[μ] (⇑f) ^ n :=
+  coeFn_comp _ _ _
+
+@[simp]
+theorem pow_toGerm (f : α →ₚ[μ, 𝓕] γ) (n : ℕ) : (f ^ n).toGerm = f.toGerm ^ n :=
+  comp_toGerm _ _ _
+
+@[to_additive existing]
+instance instMonoid : Monoid (α →ₚ[μ, 𝓕] γ) :=
+  toGerm_injective.monoid toGerm one_toGerm mul_toGerm pow_toGerm
+
+/-- `AEEqProcess.toGerm` as a `MonoidHom`. -/
+@[to_additive (attr := simps) /-- `AEEqProcess.toGerm` as an `AddMonoidHom`. -/]
+def toGermMonoidHom : (α →ₚ[μ, 𝓕] γ) →* (ae μ).Germ (ι → γ) where
+  toFun := toGerm
+  map_one' := one_toGerm
+  map_mul' := mul_toGerm
+
+end Monoid
+
+@[to_additive existing]
+instance instCommMonoid [CommMonoid γ] [ContinuousMul γ] : CommMonoid (α →ₚ[μ, 𝓕] γ) :=
+  toGerm_injective.commMonoid toGerm one_toGerm mul_toGerm pow_toGerm
+
+@[to_additive]
+theorem coeFn_finsetProd [CommMonoid γ] [ContinuousMul γ]
+    {η : Type*} (s : Finset η) (f : η → α →ₚ[μ, 𝓕] γ) :
+    ⇑(∏ i ∈ s, f i) ≡ᵐ[μ] ∏ i ∈ s, ⇑(f i) := by
+  classical
+  induction s using Finset.induction with
+  | empty => simp [coeFn_one]
+  | insert a s ha ih =>
+    simp only [ha, not_false_eq_true, Finset.prod_insert]
+    grw [coeFn_mul, ih]
+
+@[to_additive]
+theorem coeFn_fun_finsetProd [CommMonoid γ] [ContinuousMul γ]
+    {ι : Type*} (s : Finset ι) (f : ι → α →ₚ[μ, 𝓕] γ) :
+    ⇑(∏ i ∈ s, f i) ≡ᵐ[μ] fun x ↦ ∏ i ∈ s, f i x := by
+  grw [coeFn_finsetProd]
+  filter_upwards with x using by simp
+
+section Group
+
+variable [Group γ] [IsTopologicalGroup γ]
+
+section Inv
+
+@[to_additive]
+instance instInv : Inv (α →ₚ[μ, 𝓕] γ) :=
+  ⟨comp Inv.inv continuous_inv⟩
+
+@[to_additive (attr := simp)]
+theorem inv_mk (f : ι → α → γ) (hf) : (mk f hf : α →ₚ[μ, 𝓕] γ)⁻¹ = mk f⁻¹ hf.inv :=
+  rfl
+
+@[to_additive]
+theorem coeFn_inv (f : α →ₚ[μ, 𝓕] γ) : ⇑f⁻¹ ≡ᵐ[μ] f⁻¹ :=
+  coeFn_comp _ _ _
+
+@[to_additive]
+theorem inv_toGerm (f : α →ₚ[μ, 𝓕] γ) : f⁻¹.toGerm = f.toGerm⁻¹ :=
+  comp_toGerm _ _ _
+
+end Inv
+
+section Div
+
+@[to_additive]
+instance instDiv : Div (α →ₚ[μ, 𝓕] γ) :=
+  ⟨comp₂ Div.div continuous_div'⟩
+
+@[to_additive (attr := simp)]
+theorem mk_div (f g : ι → α → γ) (hf : AEStronglyAdapted f 𝓕 μ) (hg : AEStronglyAdapted g 𝓕 μ) :
+    mk (f / g) (hf.div' hg) = (mk f hf : α →ₚ[μ, 𝓕] γ) / mk g hg :=
+  rfl
+
+@[to_additive]
+theorem coeFn_div (f g : α →ₚ[μ, 𝓕] γ) : ⇑(f / g) ≡ᵐ[μ] f / g :=
+  coeFn_comp₂ _ _ _ _
+
+@[to_additive]
+theorem div_toGerm (f g : α →ₚ[μ, 𝓕] γ) : (f / g).toGerm = f.toGerm / g.toGerm :=
+  comp₂_toGerm _ _ _ _
+
+end Div
+
+section ZPow
+
+instance instPowInt : Pow (α →ₚ[μ, 𝓕] γ) ℤ :=
+  ⟨fun f n => comp _ (continuous_zpow n) f⟩
+
+@[simp]
+theorem mk_zpow (f : ι → α → γ) (hf) (n : ℤ) :
+    (mk f hf : α →ₚ[μ, 𝓕] γ) ^ n = mk (f ^ n) ((continuous_zpow n).comp_aestronglyAdapted hf) :=
+  rfl
+
+theorem coeFn_zpow (f : α →ₚ[μ, 𝓕] γ) (n : ℤ) : ⇑(f ^ n) ≡ᵐ[μ] (⇑f) ^ n :=
+  coeFn_comp _ _ _
+
+@[simp]
+theorem zpow_toGerm (f : α →ₚ[μ, 𝓕] γ) (n : ℤ) : (f ^ n).toGerm = f.toGerm ^ n :=
+  comp_toGerm _ _ _
+
+end ZPow
+
+end Group
+
+instance instAddGroup [AddGroup γ] [IsTopologicalAddGroup γ] : AddGroup (α →ₚ[μ, 𝓕] γ) :=
+  toGerm_injective.addGroup toGerm zero_toGerm add_toGerm neg_toGerm sub_toGerm
+    (fun _ _ => smul_toGerm _ _) fun _ _ => smul_toGerm _ _
+
+instance instAddCommGroup [AddCommGroup γ] [IsTopologicalAddGroup γ] :
+    AddCommGroup (α →ₚ[μ, 𝓕] γ) :=
+  { add_comm := add_comm }
+
+@[to_additive existing]
+instance instGroup [Group γ] [IsTopologicalGroup γ] : Group (α →ₚ[μ, 𝓕] γ) :=
+  toGerm_injective.group _ one_toGerm mul_toGerm inv_toGerm div_toGerm pow_toGerm zpow_toGerm
+
+@[to_additive existing]
+instance instCommGroup [CommGroup γ] [IsTopologicalGroup γ] : CommGroup (α →ₚ[μ, 𝓕] γ) :=
+  { mul_comm := mul_comm }
+
+section Module
+
+variable {𝕜 : Type*}
+
+instance instMulAction [Monoid 𝕜] [MulAction 𝕜 γ] [ContinuousConstSMul 𝕜 γ] :
+    MulAction 𝕜 (α →ₚ[μ, 𝓕] γ) :=
+  toGerm_injective.mulAction toGerm smul_toGerm
+
+instance instDistribMulAction [Monoid 𝕜] [AddMonoid γ] [ContinuousAdd γ] [DistribMulAction 𝕜 γ]
+    [ContinuousConstSMul 𝕜 γ] : DistribMulAction 𝕜 (α →ₚ[μ, 𝓕] γ) :=
+  toGerm_injective.distribMulAction (toGermAddMonoidHom : (α →ₚ[μ, 𝓕] γ) →+ _) fun c : 𝕜 =>
+    smul_toGerm c
+
+instance instModule [Semiring 𝕜] [AddCommMonoid γ] [ContinuousAdd γ] [Module 𝕜 γ]
+    [ContinuousConstSMul 𝕜 γ] : Module 𝕜 (α →ₚ[μ, 𝓕] γ) :=
+  toGerm_injective.module 𝕜 (toGermAddMonoidHom : (α →ₚ[μ, 𝓕] γ) →+ _) smul_toGerm
+
+end Module
+
+open ENNReal
+
+section Star
+
+variable {R : Type*} [TopologicalSpace R]
+
+instance [Star R] [ContinuousStar R] : Star (α →ₚ[μ, 𝓕] R) where
+  star f := (AEEqProcess.comp _ continuous_star f)
+
+lemma coeFn_star [Star R] [ContinuousStar R] (f : α →ₚ[μ, 𝓕] R) :
+    ↑(star f) ≡ᵐ[μ] (star f : ι → α → R) :=
+  coeFn_comp _ (continuous_star) f
+
+instance [InvolutiveStar R] [ContinuousStar R] : InvolutiveStar (α →ₚ[μ, 𝓕] R) where
+  star_involutive f := comp_comp _ _ _ _ f |>.trans <| by simp [star_involutive.comp_self]
+
+instance [Star R] [TrivialStar R] [ContinuousStar R] : TrivialStar (α →ₚ[μ, 𝓕] R) where
+  star_trivial f := show comp _ _ f = f by simp [funext star_trivial, ← Function.id_def]
+
+end Star
+
+end AEEqProcess
 
 end MeasureTheory

--- a/BrownianMotion/Auxiliary/AEEq.lean
+++ b/BrownianMotion/Auxiliary/AEEq.lean
@@ -1,0 +1,142 @@
+/-
+Copyright (c) 2026 Etienne Marion. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Etienne Marion
+-/
+module
+
+public import Mathlib.MeasureTheory.Measure.AEMeasurable
+
+/-!
+
+# Almost everywhere equal functions
+
+This is the same as `AEEqFun` but for `AEMeasurable` functions rather than `AEMeasurable`
+ones.
+
+-/
+
+@[expose] public section
+
+-- Guard against import creep
+assert_not_exists InnerProductSpace
+
+noncomputable section
+
+open Topology Set Filter MeasurableSpace ENNReal EMetric MeasureTheory Function
+
+variable {α β γ δ : Type*} {mα : MeasurableSpace α} {μ ν : Measure α}
+
+namespace MeasureTheory
+
+section MeasurableSpace
+
+variable [MeasurableSpace β]
+variable (β)
+
+/-- The equivalence relation of being almost everywhere equal for almost everywhere strongly
+measurable functions. -/
+@[implicit_reducible]
+def Measure.aeEqSetoid' (μ : Measure α) : Setoid { f : α → β // AEMeasurable f μ } :=
+  ⟨fun f g => (f : α → β) =ᵐ[μ] g, fun {f} => ae_eq_refl f.val, fun {_ _} => ae_eq_symm,
+    fun {_ _ _} => ae_eq_trans⟩
+
+variable (α)
+
+/-- The space of equivalence classes of almost everywhere measurable functions, where two
+measurable functions are equivalent if they agree almost everywhere, i.e.,
+they differ on a set of measure `0`. -/
+def AEEq (μ : Measure α) : Type _ :=
+  Quotient (μ.aeEqSetoid' β)
+
+variable {α β}
+
+@[inherit_doc MeasureTheory.AEEq]
+notation:25 α " →ₐₑ[" μ "] " β => AEEq α β μ
+
+end MeasurableSpace
+
+variable [MeasurableSpace δ]
+
+namespace AEEq
+
+section
+variable [MeasurableSpace β]
+
+/-- Construct the equivalence class `[f]` of an almost everywhere measurable function `f`, based
+on the equivalence relation of being almost everywhere equal. -/
+def mk {β : Type*} [MeasurableSpace β] (f : α → β) (hf : AEMeasurable f μ) : α →ₐₑ[μ] β :=
+  Quotient.mk'' ⟨f, hf⟩
+
+open scoped Classical in
+/-- Coercion from a space of equivalence classes of almost everywhere measurable
+functions to functions. We ensure that if `f` has a constant representative,
+then we choose that one. -/
+@[coe]
+def cast (f : α →ₐₑ[μ] β) : α → β :=
+  if h : ∃ (b : β), f = mk (const α b) aemeasurable_const then
+    const α <| Classical.choose h else
+    AEMeasurable.mk _ (Quotient.out f : { f : α → β // AEMeasurable f μ }).2
+
+/-- A measurable representative of an `AEEqFun` [f] -/
+instance instCoeFun : CoeFun (α →ₐₑ[μ] β) fun _ => α → β := ⟨cast⟩
+
+@[fun_prop]
+protected theorem measurable (f : α →ₐₑ[μ] β) : Measurable f := by
+  simp only [cast]
+  split_ifs with h
+  · exact measurable_const
+  · apply AEMeasurable.measurable_mk
+
+@[fun_prop]
+protected theorem aemeasurable (f : α →ₐₑ[μ] β) : AEMeasurable f μ :=
+  f.measurable.aemeasurable
+
+@[simp]
+theorem quot_mk_eq_mk (f : α → β) (hf) :
+    (Quot.mk (@Setoid.r _ <| μ.aeEqSetoid' β) ⟨f, hf⟩ : α →ₐₑ[μ] β) = mk f hf :=
+  rfl
+
+@[simp]
+theorem mk_eq_mk {f g : α → β} {hf hg} : (mk f hf : α →ₐₑ[μ] β) = mk g hg ↔ f =ᵐ[μ] g :=
+  Quotient.eq''
+
+@[simp]
+theorem mk_coeFn (f : α →ₐₑ[μ] β) : mk f f.aemeasurable = f := by
+  conv_lhs => simp only [cast]
+  split_ifs with h
+  · exact Classical.choose_spec h |>.symm
+  conv_rhs => rw [← Quotient.out_eq' f]
+  rw [← mk, mk_eq_mk]
+  exact (AEMeasurable.ae_eq_mk _).symm
+
+@[ext]
+theorem ext {f g : α →ₐₑ[μ] β} (h : f =ᵐ[μ] g) : f = g := by
+  rwa [← f.mk_coeFn, ← g.mk_coeFn, mk_eq_mk]
+
+theorem coeFn_mk (f : α → β) (hf) : (mk f hf : α →ₐₑ[μ] β) =ᵐ[μ] f := by
+  rw [← mk_eq_mk (hf := AEEq.aemeasurable ..) (hg := hf), mk_coeFn]
+
+@[elab_as_elim]
+theorem induction_on (f : α →ₐₑ[μ] β) {p : (α →ₐₑ[μ] β) → Prop} (H : ∀ f hf, p (mk f hf)) : p f :=
+  Quotient.inductionOn' f <| Subtype.forall.2 H
+
+@[elab_as_elim]
+theorem induction_on₂ {α' β' : Type*} [MeasurableSpace α'] [MeasurableSpace β'] {μ' : Measure α'}
+    (f : α →ₐₑ[μ] β) (f' : α' →ₐₑ[μ'] β') {p : (α →ₐₑ[μ] β) → (α' →ₐₑ[μ'] β') → Prop}
+    (H : ∀ f hf f' hf', p (mk f hf) (mk f' hf')) : p f f' :=
+  induction_on f fun f hf => induction_on f' <| H f hf
+
+@[elab_as_elim]
+theorem induction_on₃ {α' β' : Type*} [MeasurableSpace α'] [MeasurableSpace β'] {μ' : Measure α'}
+    {α'' β'' : Type*} [MeasurableSpace α''] [MeasurableSpace β''] {μ'' : Measure α''}
+    (f : α →ₐₑ[μ] β) (f' : α' →ₐₑ[μ'] β') (f'' : α'' →ₐₑ[μ''] β'')
+    {p : (α →ₐₑ[μ] β) → (α' →ₐₑ[μ'] β') → (α'' →ₐₑ[μ''] β'') → Prop}
+    (H : ∀ f hf f' hf' f'' hf'', p (mk f hf) (mk f' hf') (mk f'' hf'')) : p f f' f'' :=
+  induction_on f fun f hf => induction_on₂ f' f'' <| H f hf
+
+end
+
+end AEEq
+
+end MeasureTheory

--- a/BrownianMotion/Auxiliary/AEEq.lean
+++ b/BrownianMotion/Auxiliary/AEEq.lean
@@ -6,13 +6,6 @@ Authors: Etienne Marion
 module
 
 public import BrownianMotion.Auxiliary.Adapted
-public import BrownianMotion.Auxiliary.Indistinguishable
-public import Mathlib.Dynamics.Ergodic.MeasurePreserving
-public import Mathlib.MeasureTheory.Function.StronglyMeasurable.AEStronglyMeasurable
-public import Mathlib.MeasureTheory.Integral.Lebesgue.Add
-public import Mathlib.Order.Filter.Germ.Basic
-public import Mathlib.Probability.Process.Adapted
-public import Mathlib.Topology.ContinuousMap.Algebra
 
 /-!
 

--- a/BrownianMotion/Auxiliary/Adapted.lean
+++ b/BrownianMotion/Auxiliary/Adapted.lean
@@ -240,6 +240,8 @@ section AEStronglyAdapted
 variable {Ω ι E : Type*} {mΩ : MeasurableSpace Ω} [Preorder ι] {𝓕 : Filtration ι mΩ}
   {X Y : ι → Ω → E} {P : Measure Ω} [TopologicalSpace E]
 
+/-- A stochastic process is a.e. strongly adapted if it is undistinguishable from a
+strongly adapted process. -/
 def AEStronglyAdapted (X : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) : Prop :=
   ∃ Y, StronglyAdapted 𝓕 Y ∧ X ≡ᵐ[P] Y
 
@@ -254,6 +256,8 @@ lemma StronglyAdapted.aestronglyAdapted (hX : StronglyAdapted 𝓕 X) :
 lemma AEStronglyAdapted.const {c : E} : AEStronglyAdapted (fun _ _ ↦ c) 𝓕 P :=
   (stronglyAdapted_const 𝓕 c).aestronglyAdapted
 
+/-- Given a `hX : AEStronglyAdapted` process `X`, `hX.mk X` is a strongly adapted process
+that is indistinguishable from `X`.  -/
 noncomputable def AEStronglyAdapted.mk (X : ι → Ω → E) (hX : AEStronglyAdapted X 𝓕 P) :
     ι → Ω → E := hX.choose
 

--- a/BrownianMotion/Auxiliary/Adapted.lean
+++ b/BrownianMotion/Auxiliary/Adapted.lean
@@ -1,5 +1,6 @@
 module
 
+public import BrownianMotion.Auxiliary.Indistinguishable
 public import Mathlib.Probability.Process.Adapted
 public import Mathlib.Data.Setoid.Partition
 public import BrownianMotion.StochasticIntegral.Cadlag
@@ -233,5 +234,88 @@ lemma StronglyAdapted.isStronglyProgressive_of_rightContinuous {𝓕 : Filtratio
       have : (fun x => U x a) = (X · a.2) ∘ w := by
         ext; simp [U, w, IndexedPartition.piecewise_apply]
       simpa [this] using tends2.comp tends1
+
+section AEStronglyAdapted
+
+variable {Ω ι E : Type*} {mΩ : MeasurableSpace Ω} [Preorder ι] {𝓕 : Filtration ι mΩ}
+  {X Y : ι → Ω → E} {P : Measure Ω} [TopologicalSpace E]
+
+def AEStronglyAdapted (X : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) : Prop :=
+  ∃ Y, StronglyAdapted 𝓕 Y ∧ X ≡ᵐ[P] Y
+
+lemma AEStronglyAdapted.congr (hX : AEStronglyAdapted X 𝓕 P) (h : X ≡ᵐ[P] Y) :
+    AEStronglyAdapted Y 𝓕 P :=
+  ⟨hX.choose, hX.choose_spec.1, h.symm.trans hX.choose_spec.2⟩
+
+lemma StronglyAdapted.aestronglyAdapted (hX : StronglyAdapted 𝓕 X) :
+    AEStronglyAdapted X 𝓕 P :=
+  ⟨X, hX, .rfl⟩
+
+lemma AEStronglyAdapted.const {c : E} : AEStronglyAdapted (fun _ _ ↦ c) 𝓕 P :=
+  (stronglyAdapted_const 𝓕 c).aestronglyAdapted
+
+noncomputable def AEStronglyAdapted.mk (X : ι → Ω → E) (hX : AEStronglyAdapted X 𝓕 P) :
+    ι → Ω → E := hX.choose
+
+lemma AEStronglyAdapted.stronglyAdapted_mk (hX : AEStronglyAdapted X 𝓕 P) :
+    StronglyAdapted 𝓕 (hX.mk X) := hX.choose_spec.1
+
+lemma AEStronglyAdapted.indist_mk (hX : AEStronglyAdapted X 𝓕 P) :
+    X ≡ᵐ[P] hX.mk X := hX.choose_spec.2
+
+lemma Continuous.comp_stronglyAdapted {F : Type*} [TopologicalSpace F] {g : E → F}
+    (hg : Continuous g) (hX : StronglyAdapted 𝓕 X) :
+    StronglyAdapted 𝓕 (fun t ↦ g ∘ (X t)) :=
+  fun t ↦ hg.comp_stronglyMeasurable (hX t)
+
+lemma Continuous.comp_aestronglyAdapted {F : Type*} [TopologicalSpace F] {g : E → F}
+    (hg : Continuous g) (hX : AEStronglyAdapted X 𝓕 P) :
+    AEStronglyAdapted (fun t ↦ g ∘ (X t)) 𝓕 P :=
+  ⟨fun t ↦ g ∘ (hX.mk X t), hg.comp_stronglyAdapted hX.stronglyAdapted_mk,
+    hX.indist_mk.fun_comp g⟩
+
+lemma StronglyAdapted.prodMk {F : Type*} [TopologicalSpace F] {Y : ι → Ω → F}
+    (hX : StronglyAdapted 𝓕 X) (hY : StronglyAdapted 𝓕 Y) :
+    StronglyAdapted 𝓕 (fun t ω ↦ (X t ω, Y t ω)) :=
+  fun t ↦ (hX t).prodMk (hY t)
+
+lemma AEStronglyAdapted.prodMk {F : Type*} [TopologicalSpace F] {Y : ι → Ω → F}
+    (hX : AEStronglyAdapted X 𝓕 P) (hY : AEStronglyAdapted Y 𝓕 P) :
+    AEStronglyAdapted (fun t ω ↦ (X t ω, Y t ω)) 𝓕 P :=
+  ⟨fun t ω ↦ (hX.mk X t ω, hY.mk Y t ω), hX.stronglyAdapted_mk.prodMk hY.stronglyAdapted_mk,
+    hX.indist_mk.prodMk hY.indist_mk⟩
+
+@[to_additive]
+lemma StronglyAdapted.const_smul {R : Type*} [SMul R E] [ContinuousConstSMul R E] {c : R}
+    (hX : StronglyAdapted 𝓕 X) :
+    StronglyAdapted 𝓕 (c • X) :=
+  fun t ↦ (hX t).const_smul c
+
+@[to_additive]
+lemma AEStronglyAdapted.const_smul {R : Type*} [SMul R E] [ContinuousConstSMul R E] {c : R}
+    (hX : AEStronglyAdapted X 𝓕 P) :
+    AEStronglyAdapted (c • X) 𝓕 P :=
+  ⟨c • hX.mk X, hX.stronglyAdapted_mk.const_smul, hX.indist_mk.const_smul⟩
+
+@[to_additive]
+lemma AEStronglyAdapted.mul [Mul E] [ContinuousMul E]
+    (hX : AEStronglyAdapted X 𝓕 P) (hY : AEStronglyAdapted Y 𝓕 P) :
+    AEStronglyAdapted (X * Y) 𝓕 P :=
+  ⟨(hX.mk X) * (hY.mk Y), hX.stronglyAdapted_mk.mul hY.stronglyAdapted_mk,
+    hX.indist_mk.mul hY.indist_mk⟩
+
+@[to_additive]
+lemma AEStronglyAdapted.inv [Group E] [ContinuousInv E] (hX : AEStronglyAdapted X 𝓕 P) :
+    AEStronglyAdapted X⁻¹ 𝓕 P :=
+  ⟨(hX.mk X)⁻¹, hX.stronglyAdapted_mk.inv, hX.indist_mk.inv⟩
+
+@[to_additive sub]
+lemma AEStronglyAdapted.div' [Div E] [ContinuousDiv E]
+    (hX : AEStronglyAdapted X 𝓕 P) (hY : AEStronglyAdapted Y 𝓕 P) :
+    AEStronglyAdapted (X / Y) 𝓕 P :=
+  ⟨(hX.mk X) / (hY.mk Y), hX.stronglyAdapted_mk.div' hY.stronglyAdapted_mk,
+    hX.indist_mk.div hY.indist_mk⟩
+
+end AEStronglyAdapted
 
 end MeasureTheory

--- a/BrownianMotion/Auxiliary/Indistinguishable.lean
+++ b/BrownianMotion/Auxiliary/Indistinguishable.lean
@@ -81,7 +81,7 @@ protected lemma ae_eq (h : X ≡ᵐ[P] Y) : (fun ω t ↦ X t ω) =ᵐ[P] (fun �
   ext
   rw [h]
 
-protected lemma _root_.Filter.EventuallyEq.indist (h : (fun ω t ↦ X t ω) =ᵐ[P] (fun ω t ↦ Y t ω)) :
+lemma _root_.Filter.EventuallyEq.indist (h : (fun ω t ↦ X t ω) =ᵐ[P] (fun ω t ↦ Y t ω)) :
     X ≡ᵐ[P] Y := by
   filter_upwards [h] with ω h
   rwa [funext_iff] at h

--- a/BrownianMotion/Auxiliary/Indistinguishable.lean
+++ b/BrownianMotion/Auxiliary/Indistinguishable.lean
@@ -38,6 +38,8 @@ protected lemma trans (h1 : X ≡ᵐ[P] Y) (h2 : Y ≡ᵐ[P] Z) : X ≡ᵐ[P] Z 
   filter_upwards [h1, h2] with ω h t
   grind
 
+instance : IsTrans (ι → Ω → E) (· ≡ᵐ[P] ·) := ⟨fun _ _ _ ↦ .trans⟩
+
 protected lemma fun_comp {F : Type*} (h : X ≡ᵐ[P] Y) (f : E → F) :
     (fun t ω ↦ f (X t ω)) ≡ᵐ[P] (fun t ω ↦ f (Y t ω)) := by
   filter_upwards [h] with ω h t
@@ -49,26 +51,40 @@ protected lemma fun_comp₂ {F G : Type*} {Z T : ι → Ω → F} (h1 : X ≡ᵐ
   filter_upwards [h1, h2] with ω h1 h2 t
   rw [h1, h2]
 
-@[to_additive (attr := to_fun)]
+@[to_additive (attr := to_fun, gcongr)]
 protected lemma inv [Inv E] (h : X ≡ᵐ[P] Y) :
     X⁻¹ ≡ᵐ[P] Y⁻¹ := h.fun_comp _
 
-@[to_additive (attr := to_fun)]
+@[to_additive (attr := to_fun, gcongr)]
 protected lemma mul [Mul E] {Z T : ι → Ω → E} (h1 : X ≡ᵐ[P] Y) (h2 : Z ≡ᵐ[P] T) :
     X * Z ≡ᵐ[P] Y * T := h1.fun_comp₂ h2 _
 
-@[to_additive (attr := to_fun)]
+@[to_additive (attr := to_fun, gcongr)]
 protected lemma div [Div E] {Z T : ι → Ω → E} (h1 : X ≡ᵐ[P] Y) (h2 : Z ≡ᵐ[P] T) :
     X / Z ≡ᵐ[P] Y / T := h1.fun_comp₂ h2 _
 
-@[to_additive (attr := to_fun)]
+@[to_additive (attr := to_fun, gcongr)]
 protected lemma smul {F : Type*} {Z T : ι → Ω → F} [SMul F E] (h1 : X ≡ᵐ[P] Y)
     (h2 : Z ≡ᵐ[P] T) :
     Z • X ≡ᵐ[P] T • Y := h2.fun_comp₂ h1 _
 
-@[to_additive (attr := to_fun)]
+@[to_additive (attr := to_fun, gcongr)]
 protected lemma const_smul {F : Type*} [SMul F E] {c : F} (h : X ≡ᵐ[P] Y) :
     c • X ≡ᵐ[P] c • Y := h.fun_comp _
+
+protected lemma prodMk {F : Type*} {Z T : ι → Ω → F} (h1 : X ≡ᵐ[P] Y) (h2 : Z ≡ᵐ[P] T) :
+    (fun t ω ↦ (X t ω, Z t ω)) ≡ᵐ[P] (fun t ω ↦ (Y t ω, T t ω)) :=
+  h1.fun_comp₂ h2 _
+
+protected lemma ae_eq (h : X ≡ᵐ[P] Y) : (fun ω t ↦ X t ω) =ᵐ[P] (fun ω t ↦ Y t ω) := by
+  filter_upwards [h] with ω h
+  ext
+  rw [h]
+
+protected lemma _root_.Filter.EventuallyEq.indist (h : (fun ω t ↦ X t ω) =ᵐ[P] (fun ω t ↦ Y t ω)) :
+    X ≡ᵐ[P] Y := by
+  filter_upwards [h] with ω h
+  rwa [funext_iff] at h
 
 end Indistinguishable
 

--- a/BrownianMotion/StochasticIntegral/SquareIntegrable.lean
+++ b/BrownianMotion/StochasticIntegral/SquareIntegrable.lean
@@ -5,6 +5,7 @@ Authors: Rémy Degenne
 -/
 module
 
+public import BrownianMotion.Auxiliary.AEEq
 public import BrownianMotion.Auxiliary.Indistinguishable
 public import BrownianMotion.Auxiliary.Martingale
 public import BrownianMotion.StochasticIntegral.LocalMartingale
@@ -20,7 +21,7 @@ import BrownianMotion.Gaussian.StochasticProcesses
 
 @[expose] public section
 
-open MeasureTheory Filter Function TopologicalSpace
+open MeasureTheory Filter Function TopologicalSpace AEEqProcess
 open scoped ENNReal Topology RealInnerProductSpace
 
 namespace ProbabilityTheory
@@ -56,6 +57,10 @@ lemma IsSquareIntegrable.const [IsFiniteMeasure P] {c : E} :
 square integrable martingale, see `IsSquareIntegrable`. -/
 def IsAESquareIntegrable (X : ι → Ω → E) (𝓕 : Filtration ι mΩ) (P : Measure Ω) : Prop :=
   ∃ Y : ι → Ω → E, IsSquareIntegrable Y 𝓕 P ∧ X ≡ᵐ[P] Y
+
+lemma IsAESquareIntegrable.aestronglyAdapted (hX : IsAESquareIntegrable X 𝓕 P) :
+    AEStronglyAdapted X 𝓕 P :=
+  hX.choose_spec.1.martingale.stronglyAdapted.aestronglyAdapted.congr hX.choose_spec.2.symm
 
 lemma IsSquareIntegrable.isAESquareIntegrable (hX : IsSquareIntegrable X 𝓕 P) :
     IsAESquareIntegrable X 𝓕 P := ⟨X, hX, by rfl⟩
@@ -261,22 +266,11 @@ TODO: we rely on the already existing `AEEqFun` machinery, but this is about equ
 of strongly measurable functions, while here we are interested in indistinguishability only
 so measurablility is the way to go. It seems we will need to duplicate `AEEqFun` for the measurable
 case. -/
-def SquareIntegrable : Submodule ℝ (Ω →ₘ[P] (ι → E)) where
-  carrier := {X | ∃ Y : ι → Ω → E, IsSquareIntegrable Y 𝓕 P ∧ (fun ω t ↦ Y t ω) =ᵐ[P] X}
-  add_mem' {X Y} hX hY := by
-    obtain ⟨Z, hZ1, hZ2⟩ := hX
-    obtain ⟨T, hT1, hT2⟩ := hY
-    refine ⟨Z + T, hZ1.add hT1, ?_⟩
-    filter_upwards [hZ2, hT2, X.coeFn_add Y] with ω h1 h2 h3
-    rw [funext_iff] at h1 h2 ⊢
-    simp_all
-  zero_mem' := ⟨0, .const, AEEqFun.coeFn_zero.symm⟩
-  smul_mem' c {X} hX := by
-    obtain ⟨Y, hY1, hY2⟩ := hX
-    refine ⟨c • Y, hY1.smul c, ?_⟩
-    filter_upwards [hY2, X.coeFn_smul c] with ω h1 h2
-    rw [funext_iff] at h1 ⊢
-    simp_all
+def SquareIntegrable : Submodule ℝ (Ω →ₚ[P, 𝓕] E) where
+  carrier := {X | IsAESquareIntegrable X 𝓕 P}
+  add_mem' {X Y} hX hY := (hX.add hY).congr (coeFn_add X Y).symm
+  zero_mem' := IsAESquareIntegrable.const.congr coeFn_zero.symm
+  smul_mem' c {X} hX := (hX.smul c).congr (coeFn_smul c X).symm
 
 /- This uses `sorry` because a martingale is not necessarily strongly measurable as a map from
 `Ω` to `ι → E`. -/
@@ -284,97 +278,63 @@ def SquareIntegrable : Submodule ℝ (Ω →ₘ[P] (ι → E)) where
 martingale. -/
 noncomputable def SquareIntegrable.mk (X : ι → Ω → E) (hX : IsAESquareIntegrable X 𝓕 P) :
     SquareIntegrable ι E P 𝓕 :=
-  ⟨.mk (fun ω t ↦ X t ω) sorry, ⟨hX.choose, hX.choose_spec.1, by
-      grw [AEEqFun.coeFn_mk]
-      filter_upwards [hX.choose_spec.2] with ω h1
-      simp [h1]⟩⟩
+  ⟨.mk X hX.aestronglyAdapted, ⟨hX.choose, hX.choose_spec.1, by grw [coeFn_mk, hX.choose_spec.2]⟩⟩
 
 open scoped Classical in
 /-- Given an equivalence class of square integrable martingales, this is a version that satisfies
 `IsSquareIntegrable`. Don't use this directly, use the coercion system instead. -/
 @[coe]
 noncomputable def SquareIntegrable.out (X : SquareIntegrable ι E P 𝓕) : ι → Ω → E :=
-  if h : ∃ c, X = SquareIntegrable.mk (fun _ _ ↦ c) .const
-    then (fun _ _ ↦ h.choose)
-    else X.2.choose
+  X.2.choose
 
 noncomputable instance : CoeFun (SquareIntegrable ι E P 𝓕) (fun _ ↦ ι → Ω → E) where
   coe := SquareIntegrable.out
 
 lemma SquareIntegrable.isSquareIntegrable_coe (X : SquareIntegrable ι E P 𝓕) :
-    IsSquareIntegrable X 𝓕 P := by
-  rw [SquareIntegrable.out]
-  split_ifs
-  · exact .const
-  · exact X.2.choose_spec.1
+    IsSquareIntegrable X 𝓕 P := X.2.choose_spec.1
 
 lemma SquareIntegrable.val_indist_coe (X : SquareIntegrable ι E P 𝓕) :
-    (fun t ω ↦ X.1 ω t) ≡ᵐ[P] X := by
-  rw [SquareIntegrable.out]
-  split_ifs with h
-  · have := AEEqFun.ext_iff.1 (Subtype.coe_inj.2 h.choose_spec)
-    filter_upwards [this,
-      AEEqFun.coeFn_mk (fun _ _ ↦ h.choose) aestronglyMeasurable_const] with ω h1 h2 t
-    rw [h1, SquareIntegrable.mk, h2]
-  filter_upwards [X.2.choose_spec.2] with ω h t
-  rw [funext_iff] at h
-  rw [← h]
+    X.1 ≡ᵐ[P] ↑X := by
+  grw [X.2.choose_spec.2]
+  rfl
 
 @[ext]
 lemma SquareIntegrable.ext {X Y : SquareIntegrable ι E P 𝓕} (h : ↑X ≡ᵐ[P] ↑Y) :
     X = Y := by
   ext
-  filter_upwards [h, val_indist_coe X, val_indist_coe Y] with ω h1 h2 h3
-  ext t
-  rw [h2, h1, h3]
+  grw [val_indist_coe, val_indist_coe, h]
 
 lemma SquareIntegrable.coe_add (X Y : SquareIntegrable ι E P 𝓕) :
     ↑(X + Y) ≡ᵐ[P] ↑X + ↑Y := by
-  filter_upwards [val_indist_coe X, val_indist_coe Y, val_indist_coe (X + Y),
-    X.1.coeFn_add Y] with ω h1 h2 h3 h4 t
-  rw [← h3, Submodule.coe_add, h4]
-  simp_all
+  grw [← val_indist_coe, Submodule.coe_add, coeFn_add, val_indist_coe, val_indist_coe]
 
 lemma SquareIntegrable.coe_smul (X : SquareIntegrable ι E P 𝓕) (c : ℝ) :
     ↑(c • X) ≡ᵐ[P] c • ↑X := by
-  filter_upwards [val_indist_coe X, val_indist_coe (c • X), X.1.coeFn_smul c] with ω h1 h2 h3 t
-  rw [← h2, Submodule.coe_smul, h3]
-  simp [h1 t]
+  grw [← val_indist_coe, Submodule.coe_smul, coeFn_smul, val_indist_coe]
 
 lemma SquareIntegrable.coe_neg (X : SquareIntegrable ι E P 𝓕) :
     ↑(-X) ≡ᵐ[P] -↑X := by
-  convert SquareIntegrable.coe_smul X (-1 : ℝ) using 1
-  · congr
-    exact (neg_one_smul ℝ X).symm
-  exact (neg_one_smul ℝ _).symm
+  grw [← val_indist_coe, Submodule.coe_neg, coeFn_neg, val_indist_coe]
 
 lemma SquareIntegrable.val_mk (X : ι → Ω → E) (hX : IsAESquareIntegrable X 𝓕 P)
-    (h : AEStronglyMeasurable (fun ω t ↦ X t ω) P) :
-    (mk X hX).1 = .mk (fun ω t ↦ X t ω) h := rfl
+    (h : AEStronglyAdapted X 𝓕 P) :
+    (mk X hX).1 = .mk X h := rfl
 
 /- This uses `sorry` because a martingale is not necessarily strongly measurable as a map from
 `Ω` to `ι → E`. -/
 lemma SquareIntegrable.mk_ae_eq {X : ι → Ω → E} (hX : IsAESquareIntegrable X 𝓕 P) :
     mk X hX ≡ᵐ[P] X := by
-  filter_upwards [SquareIntegrable.val_indist_coe (mk X hX),
-    AEEqFun.coeFn_mk (fun ω t ↦ X t ω) sorry] with ω h1 h2 t
-  rw [SquareIntegrable.val_mk] at h1
-  · rw [funext_iff] at h2
-    rw [← h1, h2]
-  sorry
+  grw [← val_indist_coe, val_mk X hX hX.aestronglyAdapted, coeFn_mk]
 
 lemma SquareIntegrable.mk_eq_mk {X Y : ι → Ω → E} {hX : IsAESquareIntegrable X 𝓕 P}
     {hY : IsAESquareIntegrable Y 𝓕 P} :
-    SquareIntegrable.mk X hX = SquareIntegrable.mk Y hY ↔ X ≡ᵐ[P] Y where
+    mk X hX = mk Y hY ↔ X ≡ᵐ[P] Y where
   mp h := by
-    rw [Subtype.ext_iff] at h
-    simp only [mk] at h
-    filter_upwards [AEEqFun.mk_eq_mk.1 h] with ω h1
-    rwa [← funext_iff]
+    rw [Subtype.ext_iff, mk, mk] at h
+    rwa [AEEqProcess.mk_eq_mk] at h
   mpr h := by
     ext
-    filter_upwards [mk_ae_eq hX, h, mk_ae_eq hY] with ω h1 h2 h3 t
-    rw [h1, h2, h3]
+    grw [mk_ae_eq, mk_ae_eq, h]
 
 variable (E P 𝓕) in
 lemma SquareIntegrable.coe_const (c : E) :
@@ -384,25 +344,7 @@ lemma SquareIntegrable.coe_const (c : E) :
 variable (E P 𝓕) in
 lemma SquareIntegrable.coe_zero :
     (0 : SquareIntegrable ι E P 𝓕) ≡ᵐ[P] 0 := by
-  filter_upwards [val_indist_coe (0 : SquareIntegrable ι E P 𝓕),
-    AEEqFun.coeFn_zero (β := ι → E)] with ω h1 h2 t
-  rw [funext_iff] at h2
-  rw [← h1, Submodule.coe_zero, h2]
-  simp
-
-variable (E P 𝓕) in
-lemma SquareIntegrable.coe_const_eq [NeZero P] (c : E) :
-    (mk (fun _ _ ↦ c) .const : SquareIntegrable ι E P 𝓕) = (fun _ _ ↦ c : ι → Ω → E) := by
-  obtain h | ⟨⟨t⟩⟩ := isEmpty_or_nonempty ι
-  · ext t; exact h.elim t
-  rw [out]
-  split_ifs with h
-  swap; · exact h.elim ⟨c, rfl⟩
-  have := h.choose_spec
-  set b := h.choose with hb
-  simp_rw [mk_eq_mk, Indistinguishable] at this
-  have ⟨_, h1⟩ := Eventually.exists this
-  rw [h1 t]
+  grw [← val_indist_coe, Submodule.coe_zero, coeFn_zero]
 
 @[to_fun limitProcess_fun_add]
 lemma IsSquareIntegrable.limitProcess_add {ι Ω E : Type*} {mΩ : MeasurableSpace Ω} {P : Measure Ω}


### PR DESCRIPTION
Define the equivalence classes of strongly adapted processes, mimicking the type `AEEqFun` in mathlib. Use this to fix the sorries in the type of square integrable martingales. Also define `AEStronglyAdapted` processes, i.e. processes that are indistinguishable from a strongly adapted process.