### PR TITLE
refactor: remove backward.isDefEq.respectTransparency workarounds

### DIFF
--- a/BrownianMotion/Auxiliary/ContinuousBilinForm.lean
+++ b/BrownianMotion/Auxiliary/ContinuousBilinForm.lean
@@ -238,14 +238,11 @@ lemma isPosSemidef_iff_bilinForm :
 
 variable {f} [Fintype n] [DecidableEq n]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma _root_.LinearMap.BilinForm.isPosSemidef_iff_posSemidef_toMatrix (f : LinearMap.BilinForm ℝ E)
     (b : Basis n ℝ E) :
     f.IsPosSemidef ↔ (LinearMap.BilinForm.toMatrix b f).PosSemidef := by
-  classical
-  rw [LinearMap.BilinForm.isPosSemidef_iff, LinearMap.BilinForm.toMatrix]
-  rw [LinearMap.isPosSemidef_iff_posSemidef_toMatrix b]
-  rfl
+  rw [LinearMap.BilinForm.isPosSemidef_iff, LinearMap.BilinForm.toMatrix,
+    LinearMap.isPosSemidef_iff_posSemidef_toMatrix b]
 
 lemma isPosSemidef_iff_posSemidef_toMatrix : f.IsPosSemidef ↔ (f.toMatrix b).PosSemidef := by
   rw [isPosSemidef_iff, Matrix.posSemidef_iff_dotProduct_mulVec]

--- a/BrownianMotion/Auxiliary/HasGaussianLaw.lean
+++ b/BrownianMotion/Auxiliary/HasGaussianLaw.lean
@@ -17,7 +17,6 @@ section charFun
 
 variable [Fintype ι]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma HasGaussianLaw.charFun_toLp_pi {X : ι → Ω → ℝ} (hX : HasGaussianLaw (fun ω ↦ (X · ω)) P)
     (ξ : EuclideanSpace ℝ ι) :
     charFun (P.map (fun ω ↦ toLp 2 (X · ω))) ξ =
@@ -36,7 +35,6 @@ lemma HasGaussianLaw.charFun_toLp_pi {X : ι → Ω → ℝ} (hX : HasGaussianLa
     · exact aestronglyMeasurable_id
   · exact fun i ↦ (hX.eval i).memLp_two
 
-set_option backward.isDefEq.respectTransparency false in
 lemma HasGaussianLaw.charFun_toLp_prodMk {X Y : Ω → ℝ} (hXY : HasGaussianLaw (fun ω ↦ (X ω, Y ω)) P)
     (ξ : WithLp 2 (ℝ × ℝ)) :
     charFun (P.map (fun ω ↦ toLp 2 (X ω, Y ω))) ξ =

--- a/BrownianMotion/Auxiliary/Jensen.lean
+++ b/BrownianMotion/Auxiliary/Jensen.lean
@@ -101,7 +101,6 @@ theorem ae_bdd_condExp_of_ae_bdd' {R : ℝ} {f : Ω → E} (hbdd : ∀ᵐ ω ∂
     (integrable_const _) hbdd] with ω hω1 hω2
   grw [hω1, hω2, condExp_const hm]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Given an integrable function `g`, the conditional expectations of `g` with respect to
 a sequence of sub-σ-algebras is uniformly integrable. -/
 theorem Integrable.uniformIntegrable_condExp' {ι : Type*} {g : Ω → E}
@@ -121,8 +120,12 @@ theorem Integrable.uniformIntegrable_condExp' {ι : Type*} {g : Ω → E}
     filter_upwards [condExp_congr_ae (m := ℱ n) hne] with x hx
     simp only [zero_le, Set.ofPred_true, Set.indicator_univ, Pi.zero_apply, hx, condExp_zero]
   obtain ⟨δ, hδ, h⟩ := hg.eLpNorm_indicator_le le_rfl ENNReal.one_ne_top hε
-  set C : ℝ≥0 := ⟨δ, hδ.le⟩⁻¹ * (eLpNorm g 1 μ).toNNReal with hC
-  have hCpos : 0 < C := mul_pos (inv_pos.2 hδ) (ENNReal.toNNReal_pos hne hg.eLpNorm_lt_top.ne)
+  set C : ℝ≥0 := δ.toNNReal⁻¹ * (eLpNorm g 1 μ).toNNReal with hC
+  have hCpos : 0 < C := mul_pos (inv_pos.2 (Real.toNNReal_pos.2 hδ))
+    (ENNReal.toNNReal_pos hne hg.eLpNorm_lt_top.ne)
+  have hδC : ENNReal.ofReal δ * (C : ℝ≥0∞) = eLpNorm g 1 μ := by
+    rw [← Real.coe_toNNReal δ hδ.le, ← ENNReal.coe_nnreal_eq, ← ENNReal.coe_mul, hC,
+      mul_inv_cancel_left₀ (Real.toNNReal_pos.2 hδ).ne', ENNReal.coe_toNNReal hg.eLpNorm_lt_top.ne]
   have : ∀ n, μ {x : Ω | C ≤ ‖(μ[g|ℱ n]) x‖₊} ≤ ENNReal.ofReal δ := by
     intro n
     have : C ^ ENNReal.toReal 1 * μ {x | ENNReal.ofNNReal C ≤ ‖μ[g|ℱ n] x‖₊} ≤
@@ -138,14 +141,8 @@ theorem Integrable.uniformIntegrable_condExp' {ι : Type*} {g : Ω → E}
     simp_rw [ENNReal.coe_le_coe] at this
     refine this.trans ?_
     rw [ENNReal.div_le_iff_le_mul (Or.inl (ENNReal.coe_ne_zero.2 hCpos.ne'))
-        (Or.inl ENNReal.coe_lt_top.ne),
-      hC, Nonneg.inv_mk, ENNReal.coe_mul, ENNReal.coe_toNNReal hg.eLpNorm_lt_top.ne, ← mul_assoc,
-      ENNReal.coe_nnreal_eq, ← ENNReal.ofReal_mul hδ.le, rpow_one]
-    convert eLpNorm_condExp_le_eLpNorm _ le_rfl
-    · convert one_mul _
-      simp only [ofReal_eq_one]
-      exact mul_inv_cancel₀ hδ.ne'
-    · infer_instance
+        (Or.inl ENNReal.coe_lt_top.ne), hδC, rpow_one]
+    exact eLpNorm_condExp_le_eLpNorm _ le_rfl
   refine ⟨C, fun n => le_trans ?_ (h {x : Ω | C ≤ ‖(μ[g|ℱ n]) x‖₊} (hmeas n C) (this n))⟩
   have hmeasℱ : MeasurableSet[ℱ n] {x : Ω | C ≤ ‖(μ[g|ℱ n]) x‖₊} :=
     @StronglyMeasurable.measurableSet_le _ _ (ℱ n) _ _ _ _ _ _ stronglyMeasurable_const

--- a/BrownianMotion/Auxiliary/LinearAlgebra.lean
+++ b/BrownianMotion/Auxiliary/LinearAlgebra.lean
@@ -69,7 +69,6 @@ theorem OrthonormalBasis.norm_sq_eq_sum_sq_inner_left {ι E : Type*} [NormedAddC
     ‖x‖ ^ 2 = ∑ i, ⟪x, b i⟫_ℝ ^ 2 := by
   simp_rw [b.norm_sq_eq_sum_sq_inner_right, real_inner_comm]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma EuclideanSpace.real_inner_eq {ι : Type*} [Fintype ι] (x y : EuclideanSpace ℝ ι) :
     ⟪x, y⟫_ℝ = ∑ i, x i * y i := by
   nth_rw 1 [← (EuclideanSpace.basisFun ι ℝ).sum_repr' x, sum_inner]

--- a/BrownianMotion/Auxiliary/NNReal.lean
+++ b/BrownianMotion/Auxiliary/NNReal.lean
@@ -6,7 +6,6 @@ public import Mathlib.Data.NNReal.Basic
 
 namespace NNReal
 
-set_option backward.isDefEq.respectTransparency false in
 lemma add_sub_two_mul_min_eq_max (s t : ℝ≥0) : s + t - 2 * min s t = max (s - t) (t - s) := by
   wlog hst : s ≤ t
   · convert this t s (le_of_not_ge hst) using 1

--- a/BrownianMotion/Choquet/AnalyticSet.lean
+++ b/BrownianMotion/Choquet/AnalyticSet.lean
@@ -831,8 +831,8 @@ lemma aux'_Icc {ι : Type*} [Nonempty ι]
       refine ⟨fun i ↦ Set.univ ×ˢ B i, fun n ↦ ?_, rfl⟩
       exact ⟨Set.univ, .univ, B n, hB n, rfl⟩
 
-set_option backward.isDefEq.respectTransparency false in
-lemma borel_eq_generateFrom_isCompact : borel ℝ = MeasurableSpace.generateFrom IsCompact := by
+lemma borel_eq_generateFrom_isCompact :
+    borel ℝ = MeasurableSpace.generateFrom {s : Set ℝ | IsCompact s} := by
   refine le_antisymm ?_ ?_
   · rw [borel_eq_generateFrom_Icc]
     refine MeasurableSpace.generateFrom_mono fun s hs ↦ ?_

--- a/BrownianMotion/Choquet/Debut.lean
+++ b/BrownianMotion/Choquet/Debut.lean
@@ -441,7 +441,6 @@ lemma debut_eq_iff_of_nhdsGT_eq_bot
     refine csInf_le ?_ ⟨hnt, h_mem⟩
     exact ⟨n, by simp [mem_lowerBounds]; grind⟩
 
-set_option backward.isDefEq.respectTransparency false in
 /-- **Debut Theorem**: The debut of a progressively measurable set `E` is a stopping time. -/
 theorem isStoppingTime_debut [MeasurableSpace ι] [ConditionallyCompleteLinearOrder ι]
     [TopologicalSpace ι] [OrderTopology ι] [PolishSpace ι] [BorelSpace ι]
@@ -511,8 +510,7 @@ theorem isStoppingTime_debut [MeasurableSpace ι] [ConditionallyCompleteLinearOr
       obtain ⟨m, hm⟩ := h_exists_lt i hti
       exact (iInf_le _ m).trans (𝓕.mono hm.le)
   rw [h𝓕_eq_iInf]
-  simp only [MeasurableSpace.measurableSet_sInf, Set.mem_range, forall_exists_index,
-    forall_apply_eq_imp_iff]
+  simp only [MeasurableSpace.measurableSet_iInf]
   intro k
   have h_eq_k : ⋂ m, {ω | debut E n ω < s m} =
       ⋂ (m) (hm : s m ≤ s k), {ω | debut E n ω < s m} := by

--- a/BrownianMotion/Choquet/MeasurableSection.lean
+++ b/BrownianMotion/Choquet/MeasurableSection.lean
@@ -23,6 +23,9 @@ namespace MeasureTheory
 
 instance : MeasurableInf₂ (WithTop ℝ≥0) := inferInstanceAs (MeasurableInf₂ ℝ≥0∞)
 
+lemma supClosed_measurableSet {α : Type*} [MeasurableSpace α] :
+    SupClosed {t : Set α | MeasurableSet t} := fun _ hs _ ht ↦ hs.union ht
+
 lemma infClosed_insert_empty_Icc {ι : Type} [LinearOrder ι] :
     InfClosed (insert ∅ {t | ∃ a b : ι, Set.Icc a b = t}) := by
   intro s hs t ht
@@ -38,14 +41,13 @@ lemma infClosed_insert_empty_Icc {ι : Type} [LinearOrder ι] :
       simp only [Set.inf_eq_inter, Set.mem_ofPred_eq]
       exact ⟨a₁ ⊔ a₂, b₁ ⊓ b₂, Set.Icc_inter_Icc.symm⟩
 
-set_option backward.isDefEq.respectTransparency false in
 lemma exists_nullMeasurable_section_measure_ge (hs : IsPavingAnalytic {t | MeasurableSet t} s)
     (a : ℝ≥0∞) (ha : a < μ {ω | debut s 0 ω ≠ ⊤}) :
     ∃ τ : Ω → WithTop ℝ≥0, NullMeasurable τ μ ∧ (∀ ω, τ ω ≠ ⊤ → ((τ ω).untopA, ω) ∈ s) ∧
       a ≤ μ {ω | τ ω ≠ ⊤} ∧ debut s 0 ≤ τ := by
   let I : Capacity (supClosure
       (Set.image2 (· ×ˢ ·) {t | MeasurableSet t} (insert ∅ {t | ∃ a b, Set.Icc a b = t}))) :=
-    μ.capacity.comp_fst MeasurableSet.empty (fun _ hs _ ht ↦  MeasurableSet.union hs ht) (by simp)
+    μ.capacity.comp_fst MeasurableSet.empty supClosed_measurableSet (by simp)
       (isCompactSystem_insert_empty_Icc ℝ≥0)
   have I_apply (t : Set (Ω × ℝ≥0)) : I t = μ {ω | ∃ u, (ω, u) ∈ t} := by
     unfold I

--- a/BrownianMotion/Continuity/HasBoundedInternalCoveringNumber.lean
+++ b/BrownianMotion/Continuity/HasBoundedInternalCoveringNumber.lean
@@ -81,7 +81,6 @@ structure IsCoverWithBoundedCoveringNumber (C : ℕ → Set T) (A : Set T) (c : 
   mono : ∀ n m, n ≤ m → C n ⊆ C m
   subset_iUnion : A ⊆ ⋃ i, C i
 
-set_option backward.isDefEq.respectTransparency false in
 open scoped Pointwise in
 lemma isCoverWithBoundedCoveringNumber_Ico_nnreal :
     IsCoverWithBoundedCoveringNumber (fun n ↦ Set.Ico (0 : ℝ≥0) (n + 1)) Set.univ

--- a/BrownianMotion/Continuity/KolmogorovChentsovInequality.lean
+++ b/BrownianMotion/Continuity/KolmogorovChentsovInequality.lean
@@ -39,7 +39,6 @@ lemma Set.FiniteExhaustion.subset {α : Type*} {s : Set α} (K : FiniteExhaustio
   simp_rw [← K.iUnion_eq]
   exact Set.subset_iUnion K n
 
-set_option backward.isDefEq.respectTransparency false in
 lemma measure_add_ge_le_add_measure_ge {Ω : Type*} {_ : MeasurableSpace Ω} {P : Measure Ω}
     {f g : Ω → ℝ≥0∞} {x u : ℝ≥0∞} (hu : u ≤ x) :
     P {ω | x ≤ f ω + g ω} ≤ P {ω | u ≤ f ω} + P {ω | x - u ≤ g ω} := by

--- a/BrownianMotion/Gaussian/Gaussian.lean
+++ b/BrownianMotion/Gaussian/Gaussian.lean
@@ -18,7 +18,6 @@ namespace ProbabilityTheory
 variable {E : Type*} [NormedAddCommGroup E] [NormedSpace ℝ E] [SecondCountableTopology E]
   [CompleteSpace E] [MeasurableSpace E] [BorelSpace E] {μ : Measure E}
 
-set_option backward.isDefEq.respectTransparency false in
 lemma HasGaussianLaw.charFun_map_real {Ω : Type*} {mΩ : MeasurableSpace Ω} {P : Measure Ω}
     {X : Ω → ℝ} (h : HasGaussianLaw X P) (t : ℝ) :
     charFun (P.map X) t = cexp (t * P[X] * I - t ^ 2 * Var[X; P] / 2) := by

--- a/BrownianMotion/Gaussian/MultivariateGaussian.lean
+++ b/BrownianMotion/Gaussian/MultivariateGaussian.lean
@@ -26,13 +26,9 @@ variable {E : Type*} [NormedAddCommGroup E] [InnerProductSpace ℝ E] [FiniteDim
 
 variable [BorelSpace E]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma covMatrix_stdGaussian : covMatrix (stdGaussian E) = 1 := by
-  rw [covMatrix, covarianceBilin_stdGaussian] --  ContinuousBilinForm.inner_toMatrix_eq_one
-  ext i j
-  simp only [LinearMap.BilinForm.toMatrix_apply, OrthonormalBasis.coe_toBasis,
-    ContinuousLinearMap.toBilinForm_apply, one_apply]
-  rw [innerSL_apply_apply, (stdOrthonormalBasis ℝ E).inner_eq]
+  rw [covMatrix, covarianceBilin_stdGaussian]
+  exact ContinuousBilinForm.inner_toMatrix_eq_one (stdOrthonormalBasis ℝ E)
 
 variable {ι : Type*} [Fintype ι] [DecidableEq ι]
   {μ : EuclideanSpace ℝ ι} {S : Matrix ι ι ℝ} {hS : S.PosSemidef}

--- a/BrownianMotion/StochasticIntegral/DoobLp.lean
+++ b/BrownianMotion/StochasticIntegral/DoobLp.lean
@@ -90,7 +90,6 @@ lemma _root_.tendsto_inv_add_atTop_nhds_zero_nat {𝕜 : Type*} [DivisionSemirin
     Tendsto (fun n : ℕ ↦ ((n : 𝕜) + 1)⁻¹) atTop (𝓝 0) :=
   by simpa using tendsto_one_div_add_atTop_nhds_zero_nat (𝕜 := 𝕜)
 
-set_option backward.isDefEq.respectTransparency false in
 lemma maximal_ineq_countable_ennreal (hsub : Submartingale Y 𝓕 P) (hnonneg : 0 ≤ Y) (ε : ℝ≥0)
     (n : ι) :
     ε • P.real {ω | (ε : ℝ≥0∞) ≤ ⨆ i ≤ n, ENNReal.ofReal (Y i ω)} ≤
@@ -105,6 +104,7 @@ lemma maximal_ineq_countable_ennreal (hsub : Submartingale Y 𝓕 P) (hnonneg : 
   let J (k : ℕ) : Finset ι := insert n ((range k).image f |>.filter (· ≤ n))
   have hJn (k) : ∀ i ∈ J k, i ≤ n := by simp [J]
   have hnJ (k) : n ∈ J k := by simp [J]
+  have hJne (k) : (J k).Nonempty := Finset.insert_nonempty ..
   have hJmono {k l : ℕ} (hkl : k ≤ l) : J k ⊆ J l := by unfold J; gcongr
   have hmemJ (k) (h : f k ≤ n) : f k ∈ J (k + 1) := by
     simpa [J, h] using .inr ⟨k, by omega, rfl⟩
@@ -112,7 +112,7 @@ lemma maximal_ineq_countable_ennreal (hsub : Submartingale Y 𝓕 P) (hnonneg : 
   have hlt (ε' : ℝ≥0) (hε' : ε' < ε) :
     ε' • P.real {ω | (ε' : ℝ≥0∞) < supY ω} ≤ ∫ ω in {ω | (ε' : ℝ≥0∞) ≤ supY ω}, Y n ω ∂P := by
     have hbdd : BddAbove <| Set.range fun k ↦
-        ∫ ω in {ω | (ε' : ℝ) ≤ (J k).sup' ⟨n, hnJ k⟩ fun i ↦ Y i ω}, Y n ω ∂P := by
+        ∫ ω in {ω | (ε' : ℝ) ≤ (J k).sup' (hJne k) fun i ↦ Y i ω}, Y n ω ∂P := by
       use ∫ ω, Y n ω ∂P
       simpa [upperBounds] using fun k ↦
         setIntegral_le_integral (hsub.integrable n) (.of_forall (hnonneg n))
@@ -123,7 +123,7 @@ lemma maximal_ineq_countable_ennreal (hsub : Submartingale Y 𝓕 P) (hnonneg : 
         simp_rw [supY, lt_iSup_iff]
         lift Y to ι → Ω → ℝ≥0 using hnonneg
         simp
-      _ = ε' • P.real (⋃ k, {ω | (ε' : ℝ) < (J k).sup' ⟨n, hnJ k⟩ fun i ↦ Y i ω}) := by
+      _ = ε' • P.real (⋃ k, {ω | (ε' : ℝ) < (J k).sup' (hJne k) fun i ↦ Y i ω}) := by
         congr!
         ext ω
         simp only [Set.mem_iUnion, Set.mem_ofPred_eq, exists_prop, lt_sup'_iff]
@@ -133,14 +133,14 @@ lemma maximal_ineq_countable_ennreal (hsub : Submartingale Y 𝓕 P) (hnonneg : 
           use k + 1, f k, hmemJ k hi
         · rintro ⟨k, i, hi, h⟩
           use i, by simp [hJn k i hi]
-      _ = ⨆ k, ε' • P.real {ω | (ε' : ℝ) < (J k).sup' ⟨n, hnJ k⟩ fun i ↦ Y i ω} := by
+      _ = ⨆ k, ε' • P.real {ω | (ε' : ℝ) < (J k).sup' (hJne k) fun i ↦ Y i ω} := by
         rw [Measure.real, Monotone.measure_iUnion, ENNReal.toReal_iSup]
         · apply Real.mul_iSup_of_nonneg
           simp
         · finiteness
         intro k l hkl
         simpa using fun ω i hi h ↦ ⟨i, hJmono hkl hi, h⟩
-      _ ≤ ⨆ k, ε' • P.real {ω | (ε' : ℝ) ≤ (J k).sup' ⟨n, hnJ k⟩ fun i ↦ Y i ω} := by
+      _ ≤ ⨆ k, ε' • P.real {ω | (ε' : ℝ) ≤ (J k).sup' (hJne k) fun i ↦ Y i ω} := by
         gcongr
         · use ε' • P.real Set.univ
           simp only [upperBounds, le_sup'_iff, Set.mem_range, forall_exists_index,
@@ -151,7 +151,7 @@ lemma maximal_ineq_countable_ennreal (hsub : Submartingale Y 𝓕 P) (hnonneg : 
           simp
         · finiteness -- gcongr bug?
         · exact fun h ↦ h.le
-      _ ≤ ⨆ k, ∫ ω in {ω | (ε' : ℝ) ≤ (J k).sup' ⟨n, hnJ k⟩ fun i ↦ Y i ω}, Y n ω ∂P := by
+      _ ≤ ⨆ k, ∫ ω in {ω | (ε' : ℝ) ≤ (J k).sup' (hJne k) fun i ↦ Y i ω}, Y n ω ∂P := by
         gcongr with k
         exact maximal_ineq_finset hsub hnonneg ε' (hJn k) (hnJ k)
       _ ≤ ∫ ω in {ω | (ε' : ℝ≥0∞) ≤ supY ω}, Y n ω ∂P := by
@@ -365,7 +365,6 @@ theorem measurable_iSup_of_rightContinuous {β : Type*} {f : ι → Ω → β}
     obtain ⟨k, hk⟩ := hS.exists_mem_open isOpen_Ioo this
     exact Set.mem_biUnion hk.1 (hu.2 hk.2)
 
-set_option backward.isDefEq.respectTransparency false in
 theorem maximal_ineq_ennreal (hsub : Submartingale Y 𝓕 P) (hnonneg : 0 ≤ Y) (ε : ℝ≥0) (n : ι)
     (hY_cont : ∀ ω, IsRightContinuous (Y · ω)) :
     ε * P.real {ω | (ε : ℝ≥0∞) ≤ ⨆ i : Set.Iic n, ENNReal.ofReal (Y i ω)} ≤
@@ -404,7 +403,9 @@ theorem maximal_ineq_ennreal (hsub : Submartingale Y 𝓕 P) (hnonneg : 0 ≤ Y)
         obtain ⟨k, hk⟩ := hS.exists_mem_open isOpen_Ioo this
         exact ⟨⟨k, hk.1⟩, hu.2 hk.2⟩
   have h2 (ω : Ω) : ⨆ s : S, ENNReal.ofReal (Y s ω) =
-    ⨆ s ≤ (⟨⟨n, le_rfl⟩, hn⟩ : S), ENNReal.ofReal (Y s ω) := by simp_all [iSup_subtype]
+    ⨆ s ≤ (⟨⟨n, le_rfl⟩, hn⟩ : S), ENNReal.ofReal (Y s ω) := by
+    have hle (s : S) : s ≤ (⟨⟨n, le_rfl⟩, hn⟩ : S) := s.1.2
+    simp [hle]
   calc
   _ = ε * P.real {ω | ε ≤ ⨆ s : S, ENNReal.ofReal (Y s ω)} := by simp [h1]
   _ = ε * P.real {ω | ε ≤ ⨆ s ≤ (⟨⟨n, le_rfl⟩, hn⟩ : S), ENNReal.ofReal (Y s ω)} := by simp [h2]

--- a/BrownianMotion/StochasticIntegral/DoobMeyer.lean
+++ b/BrownianMotion/StochasticIntegral/DoobMeyer.lean
@@ -97,7 +97,7 @@ section Estimate
 def meshFiltration {ι Ω : Type*} [TopologicalSpace ι] [SecondCountableTopology ι] [LinearOrder ι]
     [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω} (𝓕 : Filtration ι mΩ) (n : ℕ) :
     Filtration (mesh ι n) mΩ :=
-  𝓕.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
+  𝓕.indexComap (Subtype.mono_coe (· ∈ (mesh ι n)))
 
 instance sigmaFiniteFiltration_meshFiltration {ι Ω : Type*} [TopologicalSpace ι]
     [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
@@ -228,7 +228,6 @@ lemma integrable_predictableSeqTop {ι Ω E : Type*} [TopologicalSpace ι]
     Integrable (predictableSeqTop S 𝓕 P n) P :=
   integrable_predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P ⊤
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The terminal values of the predictable parts of a martingale vanish on every mesh. -/
 lemma predictableSeqTop_eq_zero_of_martingale {ι Ω E : Type*} [TopologicalSpace ι]
     [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
@@ -238,7 +237,7 @@ lemma predictableSeqTop_eq_zero_of_martingale {ι Ω E : Type*} [TopologicalSpac
     predictableSeqTop S 𝓕 P n =ᵐ[P] 0 := by
   simp only [predictableSeqTop, meshFiltration]
   apply predictablePart_eq_zero_of_martingale _ ⊤
-  exact (hS.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n))))
+  exact (hS.indexComap (Subtype.mono_coe (· ∈ (mesh ι n))))
 
 /-- Sequence of terminal values of the martingale part. -/
 noncomputable def martingaleSeqTop {ι Ω E : Type*} [TopologicalSpace ι] [SecondCountableTopology ι]
@@ -256,7 +255,6 @@ lemma martingaleSeqTop_add {ι Ω E : Type*} [TopologicalSpace ι] [SecondCounta
       martingaleSeqTop S₁ 𝓕 P n + martingaleSeqTop S₂ 𝓕 P n :=
   martingalePart_add (fun t : mesh ι n ↦ hS₁ t) (fun t ↦ hS₂ t) ⊤
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The terminal values of the martingale parts of a martingale are its terminal value on every
 mesh. -/
 lemma martingaleSeqTop_eq_self_of_martingale {ι Ω E : Type*} [TopologicalSpace ι]
@@ -267,7 +265,7 @@ lemma martingaleSeqTop_eq_self_of_martingale {ι Ω E : Type*} [TopologicalSpace
     martingaleSeqTop S 𝓕 P n =ᵐ[P] S ⊤ := by
   simp only [martingaleSeqTop, meshFiltration]
   apply martingalePart_eq_self_of_martingale _ ⊤
-  exact (hS.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n))))
+  exact (hS.indexComap (Subtype.mono_coe (· ∈ (mesh ι n))))
 
 /-- If `S = 0` a.e., then the martingale part’s terminal value equals the negative of the
 predictable part’s terminal value. -/
@@ -395,7 +393,6 @@ lemma stoppedValue_le_neg_condExp_predictableSeqTop_add_const {ι Ω : Type*} [T
   rw [heqω]
   exact add_le_add_right (stoppedValue_predictablePart_tauMesh_le S 𝓕 P n hc ω) _
 
-set_option backward.isDefEq.respectTransparency false in
 /-- `{τₙ(c) < 1} = {c < Aⁿ₁}`. -/
 lemma MeasureTheory.Submartingale.tauMesh_lt_top_eq_lt_predictableSeqTop {ι Ω : Type*}
     [TopologicalSpace ι] [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
@@ -404,7 +401,7 @@ lemma MeasureTheory.Submartingale.tauMesh_lt_top_eq_lt_predictableSeqTop {ι Ω 
     {ω | tauMesh S 𝓕 P n c ω < (⊤ : mesh ι n)} =ᵐ[P] {ω | c < predictableSeqTop S 𝓕 P n ω} := by
   refine eventuallyEq_set.2 ?_
   have hs_mesh : Submartingale (S ∘ Subtype.val) (meshFiltration 𝓕 n) P :=
-    hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
+    hs.indexComap (Subtype.mono_coe (· ∈ (mesh ι n)))
   filter_upwards [hs_mesh.monotone_predictablePart_ae] with ω hmono
   let A : mesh ι n → Ω → ℝ := _root_.predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P
   by_cases htop_bot : (⊤ : mesh ι n) = ⊥
@@ -434,7 +431,6 @@ lemma MeasureTheory.Submartingale.integrableOn_const_tauMesh_lt_top {ι Ω : Typ
     rw [measure_congr (hs.tauMesh_lt_top_eq_lt_predictableSeqTop n hc)]
     exact (integrable_predictableSeqTop S 𝓕 P n).measure_gt_lt_top (lt_of_le_of_ne hc hc0.symm)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Stopping `S` at the bounded mesh time `τₙ(c)` preserves integrability. -/
 lemma MeasureTheory.Submartingale.integrable_stoppedValue_tauMesh {ι Ω : Type*} [TopologicalSpace ι]
     [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι] {mΩ : MeasurableSpace Ω}
@@ -442,7 +438,7 @@ lemma MeasureTheory.Submartingale.integrable_stoppedValue_tauMesh {ι Ω : Type*
     (c : ℝ) :
     Integrable (stoppedValue (S ∘ Subtype.val) (tauMesh S 𝓕 P n c)) P :=
   integrable_stoppedValue (mesh ι n) (isStoppingTime_tauMesh S 𝓕 P n c)
-    (hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))).integrable
+    (hs.indexComap (Subtype.mono_coe (· ∈ (mesh ι n)))).integrable
     (tauMesh_le_top S 𝓕 P n c)
 
 /-- The first estimate before equation 5. -/
@@ -496,7 +492,6 @@ lemma integrable_stoppedValue_predictablePart_tauMesh {ι Ω : Type*} [Topologic
     (integrable_predictablePart (S ∘ Subtype.val) (meshFiltration 𝓕 n) P)
     (tauMesh_le_top S 𝓕 P n c)
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The second estimate before equation 5. -/
 lemma second_estimate {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
@@ -531,7 +526,7 @@ lemma second_estimate {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
       refine setIntegral_mono_set ?_ ?_ ?_
       · exact (hpred_int.sub hstopped_pred_int).integrableOn
       · have hs_mesh : Submartingale (S ∘ Subtype.val) (meshFiltration 𝓕 n) P :=
-          hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
+          hs.indexComap (Subtype.mono_coe (· ∈ (mesh ι n)))
         filter_upwards [ae_restrict_le hs_mesh.monotone_predictablePart_ae] with ω hmono
         simpa [predictableSeqTop, stoppedValue] using hmono le_top
       · exact (tauMesh_lt_top_subset_of_lt S 𝓕 P n (by linarith)).eventuallyLE
@@ -644,7 +639,6 @@ lemma integral_predictableSeqTop_eq_neg_integral_bot {ι Ω : Type*} [Topologica
       (bot_le (a := ⊤)) MeasurableSet.univ]
     simp [_root_.martingalePart]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- Estimate for the hitting event `{τₙ(c) < 1}`. -/
 lemma measure_tauMesh_lt_top_le {ι Ω : Type*} [TopologicalSpace ι]
     [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
@@ -664,12 +658,11 @@ lemma measure_tauMesh_lt_top_le {ι Ω : Type*} [TopologicalSpace ι]
   _ = ENNReal.ofReal (∫ ω, predictableSeqTop S 𝓕 P n ω ∂P) / ENNReal.ofReal c := by
     rw [ofReal_integral_eq_lintegral_ofReal (integrable_predictableSeqTop S 𝓕 P n)]
     have hs_mesh : Submartingale (S ∘ Subtype.val) (meshFiltration 𝓕 n) P :=
-      hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
+      hs.indexComap (Subtype.mono_coe (· ∈ (mesh ι n)))
     filter_upwards [hs_mesh.predictablePart_nonneg'] with ω hω using hω ⊤
   _ = ENNReal.ofReal (- ∫ ω, S ⊥ ω ∂P) / ENNReal.ofReal c := by
     rw [integral_predictableSeqTop_eq_neg_integral_bot hstop n]
 
-set_option backward.isDefEq.respectTransparency false in
 /-- The terminal values of the predictable parts are uniformly integrable. -/
 lemma uniformIntegrable_predictableSeqTop {ι Ω : Type*} [TopologicalSpace ι] [T1Space ι]
     [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
@@ -683,7 +676,7 @@ lemma uniformIntegrable_predictableSeqTop {ι Ω : Type*} [TopologicalSpace ι] 
   · exact (stronglyAdapted_predictablePart
       (S ∘ Subtype.val) (meshFiltration 𝓕 n) P).stronglyMeasurable.aestronglyMeasurable
   · have hs_mesh : Submartingale (S ∘ Subtype.val) (meshFiltration 𝓕 n) P :=
-      hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
+      hs.indexComap (Subtype.mono_coe (· ∈ (mesh ι n)))
     filter_upwards [hs_mesh.predictablePart_nonneg'] with ω hω using hω ⊤
   · exact integrable_predictableSeqTop S 𝓕 P n
   · refine tendsto_of_tendsto_of_tendsto_of_le_of_le' (a := 0) (h := fun c : ℝ≥0 ↦
@@ -1061,14 +1054,13 @@ lemma predictableSeqStep_apply {ι Ω : Type*} [TopologicalSpace ι] [SecondCoun
   · exact absurd (lt_of_le_of_lt ht.2 (lt_of_le_of_lt
       (Subtype.coe_le_coe.2 (Order.le_pred_of_lt h')) hv.1)) (lt_irrefl t)
 
-set_option backward.isDefEq.respectTransparency false in
 lemma predictableSeqStep_monotone_ae {ι Ω : Type*} [TopologicalSpace ι]
     [SecondCountableTopology ι] [LinearOrder ι] [OrderBot ι] [OrderTop ι]
     {mΩ : MeasurableSpace Ω} {P : Measure Ω} {S : ι → Ω → ℝ}
     {𝓕 : Filtration ι mΩ} (hs : Submartingale S 𝓕 P) (n : ℕ) :
     ∀ᵐ ω ∂P, Monotone fun t ↦ predictableSeqStep P S 𝓕 n t ω := by
   have hsub : Submartingale (S ∘ Subtype.val) (meshFiltration 𝓕 n) P :=
-    hs.indexComap (Subtype.mono_coe (SetLike.coe (mesh ι n)))
+    hs.indexComap (Subtype.mono_coe (· ∈ (mesh ι n)))
   have hne (s : ι) : (Finset.univ.filter fun u : mesh ι n ↦ s ≤ (u : ι)).Nonempty := ⟨⊤, by simp⟩
   set ceil : ι → mesh ι n :=
     fun s ↦ (Finset.univ.filter fun u : mesh ι n ↦ s ≤ (u : ι)).min' (hne s)

--- a/BrownianMotion/StochasticIntegral/Komlos.lean
+++ b/BrownianMotion/StochasticIntegral/Komlos.lean
@@ -90,7 +90,6 @@ lemma komlos_convex (R : Type*) [Semifield R] [LinearOrder R] [IsStrictOrderedRi
     (by positivity) (by norm_cast; grind : (n : ℝ) + 1 ≥ N + 1), inv_anti₀
       (by positivity) (by norm_cast; grind : (m : ℝ) + 1 ≥ N + 1)]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma komlos_norm [NormedAddCommGroup E] [InnerProductSpace ℝ E] [CompleteSpace E]
     {f : ℕ → E} (h_bdd : ∃ M : ℝ, ∀ n, ‖f n‖ ≤ M) :
     ∃ (g : ℕ → E), (∀ n, g n ∈ convexHull ℝ (Set.range fun m ↦ f (n + m))) ∧

--- a/BrownianMotion/StochasticIntegral/SimpleProcess.lean
+++ b/BrownianMotion/StochasticIntegral/SimpleProcess.lean
@@ -177,13 +177,13 @@ namespace SimpleProcess
 attribute [fun_prop] measurable_valueBot
 
 -- todo: replace the condition on W by IsPredictable
-set_option backward.isDefEq.respectTransparency false in
 def ofNat {𝓕 : Filtration ℕ mΩ} (W : ℕ → Ω → E) (n : ℕ)
     (hW0 : Measurable[𝓕 0] (W 0)) (hW : ∀ k < n, Measurable[𝓕 k] (W (k + 1)))
     {C : ℝ} (hC : ∀ k ≤ n, ∀ ω, ‖W k ω‖ ≤ C) :
     SimpleProcess E 𝓕 where
   valueBot := W 0
-  value := Finsupp.onFinset ((Finset.range n).map ⟨fun k ↦ (k, k + 1), fun _ ↦ by grind⟩)
+  value := Finsupp.onFinset ((Finset.range n).map
+      ⟨fun k ↦ (k, k + 1), Function.LeftInverse.injective (g := Prod.fst) fun _ ↦ rfl⟩)
       (fun p ↦ if p.1 < n ∧ p.2 = p.1 + 1 then W p.2 else 0)
       (fun p ↦ by simp; grind)
   le_of_mem_support_value p hp := by simp at hp; grind
@@ -458,7 +458,6 @@ theorem stoppedProcess_integral (V : SimpleProcess E 𝓕) (X : ι → Ω → F)
   conv_rhs => rw [stoppedProcess_stoppedProcess]
   simp [stoppedProcess, WithTop.untopA_eq_untop]
 
-set_option backward.isDefEq.respectTransparency false in
 lemma integral_ofNat {𝓕 : Filtration ℕ mΩ} (W : ℕ → Ω → E) (n : ℕ)
     (hW0 : Measurable[𝓕 0] (W 0)) (hW : ∀ k < n, Measurable[𝓕 k] (W (k + 1)))
     {C : ℝ} (hC : ∀ k ≤ n, ∀ ω, ‖W k ω‖ ≤ C)


### PR DESCRIPTION
Removes all 26 uses of `set_option backward.isDefEq.respectTransparency false in`.

## Definition change: `meshFiltration`

`Subtype.mono_coe` wants a membership test, not a set, so `SetLike.coe (mesh ι n)` became `(· ∈ mesh ι n)` in nine places in `DoobMeyer.lean` — including the body of `def meshFiltration`.

That body elaborates to the same term either way. The declared type `Filtration (mesh ι n) mΩ` is untouched, and it pins the index type to `↥(mesh ι n)`, which is by definition `{x // x ∈ mesh ι n}` — so both spellings give the same subtype, the old one only by unfolding `Set ι` into `ι → Prop`. The only other argument is a proof of `Monotone`, and Lean identifies any two proofs of the same statement, so the two bodies are definitionally equal.