### PR TITLE
fix: restore the local monad on stable properties

### DIFF
--- a/BrownianMotion/StochasticIntegral/LocalMonad.lean
+++ b/BrownianMotion/StochasticIntegral/LocalMonad.lean
@@ -32,32 +32,26 @@ abbrev StableCat (E : Type*) [Zero E] (𝓕 : Filtration ι mΩ) :=
 def Local (P : Measure Ω) (p : StableCat E 𝓕) : StableCat E 𝓕 :=
   ⟨(Locally p.1 𝓕 · P), p.2.locally⟩
 
--- TODO: restore the lemmas below. They broke after a bump to 4.27.0
+/-- The local functor is monotone. -/
+lemma LocalMono (P : Measure Ω) {p q : StableCat E 𝓕} (h : p ⟶ q) (u : ι → Ω → E) :
+    (Local P p).1 u ≤ (Local P q).1 u :=
+  Locally.mono <| fun v ↦ leOfHom <| h.hom v
 
--- /-- The local functor is monotone. -/
--- lemma LocalMono (P : Measure Ω) {p q : StableCat E 𝓕} (h : p ⟶ q) (u : ι → Ω → E) :
---     (Local P p).1 u ≤ (Local P q).1 u :=
---   Locally.mono <| fun v ↦ leOfHom <| h v
+/-- The local functor. -/
+def LocalFunctor (P : Measure Ω) : StableCat E 𝓕 ⥤ StableCat E 𝓕 where
+  obj X := Local P X
+  map f := ObjectProperty.homMk fun _ ↦ homOfLE <| LocalMono P f _
+  map_id _ := rfl
+  map_comp _ _ := rfl
 
--- /-- The local functor. -/
--- noncomputable
--- def LocalFunctor (P : Measure Ω) : StableCat E 𝓕 ⥤ StableCat E 𝓕 where
---   obj X := Local P X
---   map f _ := homOfLE <| LocalMono P f _
---   map_id _ := rfl
---   map_comp _ _ := rfl
+variable [IsFiniteMeasure P] [DenselyOrdered ι] [NoMaxOrder ι] [SecondCountableTopology ι]
 
--- variable [IsFiniteMeasure P] [DenselyOrdered ι] [FirstCountableTopology ι] [NoMaxOrder ι]
---     [SecondCountableTopology ι]
-
--- /-- The Stable properties form a monad with the local functor. -/
--- noncomputable
--- def StableMonad (h𝓕 : IsRightContinuous 𝓕) :
---     Monad (StableCat E 𝓕) where
---   toFunctor := LocalFunctor P
---   η := { app _ _ := homOfLE locally_of_prop
---          naturality _ _ _ := rfl }
---   μ := { app p _ := homOfLE (locally_locally h𝓕 p.2).1
---          naturality _ _ _ := rfl }
+/-- The Stable properties form a monad with the local functor. -/
+def StableMonad [𝓕.IsRightContinuous] : Monad (StableCat E 𝓕) where
+  toFunctor := LocalFunctor P
+  η := { app _ := ObjectProperty.homMk fun _ ↦ homOfLE Locally.of_prop
+         naturality _ _ _ := rfl }
+  μ := { app p := ObjectProperty.homMk fun _ ↦ homOfLE p.2.locally_locally_iff.1
+         naturality _ _ _ := rfl }
 
 end ProbabilityTheory


### PR DESCRIPTION
Restores the three declarations in `LocalMonad.lean` that were commented as broken since the 4.27.0 bump.

The cause was `InducedCategory` becoming a structure: morphisms in `ObjectProperty.FullSubcategory` are now wrappers rather than the ambient morphism, so they are taken apart with `.hom` and built with `ObjectProperty.homMk`. Since the ambient category on `(ι → Ω → E) → Prop` is the pi category, it is the underlying morphism that is a function of the process — `h.hom v` where the old code wrote `h v`. The rest was renaming: `Locally.of_prop` and `IsStable.locally_locally_iff`.