### PR TITLE
Characterization of stochastic integral

### DIFF
--- a/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
+++ b/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
@@ -3,6 +3,38 @@ module
 public import Mathlib.Probability.Process.Adapted
 public import Mathlib.Probability.Process.Filtration
 
+/-!
+# Characterization of the stochastic integral.
+
+This file contains an axiomatic characterization of the stochastic integral
+against a process `Y : ι → Ω → ℝ`. Ideally, any reasonable definition of a
+stochastic integral should satisfy the following properties, packaged together
+into the definition `IsRiemannStieltjesExtension`.
+
+* `IntegralElementary`: the integral agrees with the Riemann-Stieltjes integral
+  on a very elementary set of processes.
+* `IntegralAdd`, `IntegralMul`: the integral should be linear.
+* `IntegralDCT`: if `X` is integrable, the the pointwise limit of any sequence
+of integrable processes which is dominated by `X` should again be integrable, and
+in this case the integral should commute with the limit.
+* `IntegralIndistinguishable`: a process which is indistinguishable from an integrable
+process should be integrable.
+
+In order to prevent nonuniqueness, we additionally impose a condition on the domain:
+* `IsConsistentDomain`: a domain `S` is consistent for `Y` if any two extensions of the
+  Riemann-Stieltjes integral with domain `S` must agree almost surely.
+In practice, `IsConsistentDomain` can be shown whenever every element in `S` can be
+pointwise approximated by simple processes in a dominated way (in this case, uniqueness
+is easily shown using `IntegralDCT`).
+
+A `stochastic integral` is then given by the structure `StochasticIntegral`,
+guaranteeing that it satisfies all the above properties.
+Note that none of the definitions impose that the domain `S` should be maximal.
+As a consequence, it is possible to define stochastic integrals w.r.t `Y`.
+However, any two such integrals will necessarily agree (almost surely)
+on the intersection of their domains.
+-/
+
 @[expose] public section
 
 namespace ProbabilityTheory

--- a/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
+++ b/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
@@ -41,7 +41,7 @@ of their domains.
 
 namespace ProbabilityTheory
 
-open ProbabilityTheory MeasureTheory Real Filtration Filter Topology
+open MeasureTheory Filter Topology
 
 variable {Ω : Type*} {mΩ : MeasurableSpace Ω} (P : Measure Ω)
 variable {ι : Type*} [LinearOrder ι] [OrderBot ι]
@@ -60,27 +60,27 @@ structure IsRiemannStieltjesExtension (I : SIntegral) (S : Domain) : Prop where
   measurable : (X : ι → Ω → ℝ) → (X ∈ S) → AEStronglyMeasurable (I X) P
   /-- Elementary functions are in the domain and the value of the integral is the
   expected one. -/
-  elementary_ioc : (i j : ι) → (i ≤ j) → (X : Ω → ℝ) → (StronglyMeasurable[𝓕 i] X) →
+  elementary_ioc : (i j : ι) → (i ≤ j) → (X : @SimpleFunc Ω (𝓕 i) ℝ) →
     (fun k ω ↦ if (k ∈ Set.Ioc i j) then X ω else 0) ∈ S ∧
     I (fun k ω ↦ if (k ∈ Set.Ioc i j) then X ω else 0) =ᵐ[P] X * (Y j - Y i)
-  elementary_iic : (i : ι) → (X : Ω → ℝ) → (StronglyMeasurable[𝓕 ⊥] X) →
+  elementary_iic : (i : ι) → (X : @SimpleFunc Ω (𝓕 ⊥) ℝ) →
     (fun j ω ↦ if (j ∈ Set.Iic i) then X ω else 0) ∈ S ∧
     I (fun j ω ↦ if (j ∈ Set.Iic i) then X ω else 0) =ᵐ[P] X * (Y i - Y ⊥)
   /-- The integral and the domain respect addition. -/
-  integral_add : (X Y : ι → Ω → ℝ) → (X ∈ S) → (Y ∈ S) →
-    X + Y ∈ S ∧ I (X + Y) =ᵐ[P] I X + I Y
+  integral_add : (X₁ X₂ : ι → Ω → ℝ) → (X₁ ∈ S) → (X₂ ∈ S) →
+    X₁ + X₂ ∈ S ∧ I (X₁ + X₂) =ᵐ[P] I X₁ + I X₂
   /-- The integral and the domain respect scalar multiplication. -/
   integral_smul : (X : ι → Ω → ℝ) → (X ∈ S) → (α : ℝ) →
     α • X ∈ S ∧ I (α • X) =ᵐ[P] α • I X
   /-- The integral and its domain respect indistinguishability. -/
-  integral_indistinguishable : (X Y : ι → Ω → ℝ) → (X ∈ S) →
-    (X ≡ᵐ[P] Y) → Y ∈ S ∧ I X =ᵐ[P] I Y
+  integral_indistinguishable : (X₁ X₂ : ι → Ω → ℝ) → (X₁ ∈ S) →
+    (X₁ ≡ᵐ[P] X₂) → X₂ ∈ S ∧ I X₁ =ᵐ[P] I X₂
   /-- The domain is closed under dominated convergence, and in this case the integral
   commutes with the limit. -/
-  integral_dct : (X : ℕ → ι → Ω → ℝ) → (Y Z : ι → Ω → ℝ) →
-    (∀ n, X n ∈ S) → (Y ∈ S) → (∀ n i ω, |X n i ω| ≤ |Y i ω|) →
-    (∀ i ω, Tendsto (fun n ↦ X n i ω) atTop (𝓝 (Z i ω))) →
-    (Z ∈ S) ∧ TendstoInMeasure P (fun n ↦ I (X n)) atTop (I Z)
+  integral_dct : (X : ℕ → ι → Ω → ℝ) → (X_dom X_lim : ι → Ω → ℝ) →
+    (∀ n, X n ∈ S) → (X_dom ∈ S) → (∀ n i ω, |X n i ω| ≤ |X_dom i ω|) →
+    (∀ i ω, Tendsto (X · i ω) atTop (𝓝 (X_lim i ω))) →
+    (X_lim ∈ S) ∧ TendstoInMeasure P (fun n ↦ I (X n)) atTop (I X_lim)
 
 /-- An SIntegral `I` with domain `S` is a *stochastic integral* if it is an extension of the
 Riemann-Stieltjes integral and it agrees with any other extension on the intersection

--- a/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
+++ b/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
@@ -8,38 +8,33 @@ module
 
 public import Mathlib.Probability.Process.Adapted
 public import Mathlib.Probability.Process.Filtration
+public import BrownianMotion.Auxiliary.Indistinguishable
 
 /-!
 # Characterization of the stochastic integral.
 
 This file contains an axiomatic characterization of the stochastic integral
-against a process `Y : ι → Ω → ℝ`. Ideally, any reasonable definition of a
-stochastic integral should satisfy the following properties, packaged together
-into the definition `IsRiemannStieltjesExtension`.
+against a process `Y : ι → Ω → ℝ`. We ask for the following properties, which we expect
+any good stochastic integral `I` to have:
+* The integral agrees with the Riemann-Stieltjes integral for elementary processes.
+* Linearity for the integral and its domain.
+* The integral and its domain respect indistinguishability.
+* Dominated convergence: if a process `X` is integrable, then any pointwise limit of a
+sequence of integrable processes which is dominated by `X` should again be integrable.
 
-* `IntegralElementary`: the integral agrees with the Riemann-Stieltjes integral
-  on a very elementary set of processes.
-* `IntegralAdd`, `IntegralMul`: the integral should be linear.
-* `IntegralDCT`: if `X` is integrable, the the pointwise limit of any sequence
-of integrable processes which is dominated by `X` should again be integrable, and
-in this case the integral should commute with the limit.
-* `IntegralIndistinguishable`: a process which is indistinguishable from an integrable
-process should be integrable.
+The properties above are encoded in the predicate `IsRiemannStieltjesExtension`.
+However, this predicate does not ensure that the integral is canonical or unique.
+To get a true stochastic integral `I`, we additionally impose the following.
+* Any extension of the Riemann-Stieltjes integral must agree with `I` on
+the intersection of their domains.
 
-In order to prevent nonuniqueness, we additionally impose a condition on the domain:
-* `IsConsistent`: the stochastic integral `I` should be canonical, i.e., any other Riemann-Stieltjes
-extension satisfying the above axioms should agree with `I` on the intersection of their domains.
-In practice, `IsConsistentDomain` can be shown whenever every element in `S` can be
-pointwise approximated by simple processes in a dominated way (in this case, uniqueness
-is easily shown using `IntegralDCT`).
-
-A `stochastic integral` is then given by the structure `StochasticIntegral`,
-guaranteeing that it satisfies all the above properties.
+This additional condition is encoded in `IsStochasticIntegral` which extends
+`IsRiemannStieltjesExtension`.
 
 Note that none of the definitions impose that the domain `S` should be maximal.
-As a consequence, it is possible to define different stochastic integrals w.r.t `Y`.
-However, any two such integrals will necessarily agree (almost surely)
-on the intersection of their domains.
+As a consequence, it is possible to define stochastic integrals with different domains.
+However, any two such integrals will necessarily agree (almost surely) on the intersection
+of their domains.
 -/
 
 @[expose] public section
@@ -57,90 +52,43 @@ abbrev Domain := Set (ι → Ω → ℝ)
 /-- An `SIntegral` maps processes to random variables. -/
 abbrev SIntegral := (X : ι → Ω → ℝ) → Ω → ℝ
 
-/-- An SIntegral `I` with domain `S` respects elementary processes w.r.t `Y`
-if for any `i ≤ j` and every `𝓕 i`-measurable random variable `X`, the elementary process
-constructed from `i`, `j`, and `X` lies in `S` and the value of `I` is the
-one we would expect. -/
-def IntegralElementary₁ (I : SIntegral) (S : Domain) :=
-  (α β : ι) → (α ≤ β) → (X : Ω → ℝ) →
-  (StronglyMeasurable[𝓕 α] X) →
-  (fun i ω ↦ if (i ∈ Set.Ioc α β) then X ω else 0) ∈ S ∧
-  ∀ᵐ ω ∂P, I (fun i ω ↦ if (i ∈ Set.Ioc α β) then X ω else 0) ω =
-    X ω * (Y β ω - Y α ω)
+/-- An SIntegral `I` with domain `S` is an extension of the Riemann-Stieltjes integral
+if it agrees with Riemann-Stieltjes on elementary processes and respects linearity,
+indistinguishability, and dominated convergence. -/
+structure IsRiemannStieltjesExtension (I : SIntegral) (S : Domain) : Prop where
+  /-- The stochastic integral is measurable. -/
+  measurable : (X : ι → Ω → ℝ) → (X ∈ S) → AEStronglyMeasurable (I X) P
+  /-- Elementary functions are in the domain and the value of the integral is the
+  expected one. -/
+  elementary_ioc : (i j : ι) → (i ≤ j) → (X : Ω → ℝ) → (StronglyMeasurable[𝓕 i] X) →
+    (fun k ω ↦ if (k ∈ Set.Ioc i j) then X ω else 0) ∈ S ∧
+    I (fun k ω ↦ if (k ∈ Set.Ioc i j) then X ω else 0) =ᵐ[P] X * (Y j - Y i)
+  elementary_iic : (i : ι) → (X : Ω → ℝ) → (StronglyMeasurable[𝓕 ⊥] X) →
+    (fun j ω ↦ if (j ∈ Set.Iic i) then X ω else 0) ∈ S ∧
+    I (fun j ω ↦ if (j ∈ Set.Iic i) then X ω else 0) =ᵐ[P] X * (Y i - Y ⊥)
+  /-- The integral and the domain respect addition. -/
+  integral_add : (X Y : ι → Ω → ℝ) → (X ∈ S) → (Y ∈ S) →
+    X + Y ∈ S ∧ I (X + Y) =ᵐ[P] I X + I Y
+  /-- The integral and the domain respect scalar multiplication. -/
+  integral_smul : (X : ι → Ω → ℝ) → (X ∈ S) → (α : ℝ) →
+    α • X ∈ S ∧ I (α • X) =ᵐ[P] α • I X
+  /-- The integral and its domain respect indistinguishability. -/
+  integral_indistinguishable : (X Y : ι → Ω → ℝ) → (X ∈ S) →
+    (X ≡ᵐ[P] Y) → Y ∈ S ∧ I X =ᵐ[P] I Y
+  /-- The domain is closed under dominated convergence, and in this case the integral
+  commutes with the limit. -/
+  integral_dct : (X : ℕ → ι → Ω → ℝ) → (Y Z : ι → Ω → ℝ) →
+    (∀ n, X n ∈ S) → (Y ∈ S) → (∀ n i ω, |X n i ω| ≤ |Y i ω|) →
+    (∀ i ω, Tendsto (fun n ↦ X n i ω) atTop (𝓝 (Z i ω))) →
+    (Z ∈ S) ∧ TendstoInMeasure P (fun n ↦ I (X n)) atTop (I Z)
 
-/-- An SIntegral `I` with domain `S` respects elementary processes w.r.t `Y`
-if for any `i ≤ j` and every `𝓕 i`-measurable random variable `X`, the elementary process
-constructed from `i`, `j`, and `X` lies in `S` and the value of `I` is the
-one we would expect. -/
-def IntegralElementary₂ (I : SIntegral) (S : Domain) :=
-  (α : ι) → (X : Ω → ℝ) → (StronglyMeasurable[𝓕 ⊥] X) →
-  (fun i ω ↦ if (i ∈ Set.Iic α) then X ω else 0) ∈ S ∧
-  ∀ᵐ ω ∂P, I (fun i ω ↦ if (i ∈ Set.Iic α) then X ω else 0) ω =
-    X ω * Y α ω - X ω * Y ⊥ ω
-
-/-- An SIntegral `I` with domain `S` respects addition if
-`S` is closed under addition and `I` commutes with addition. -/
-def IntegralAdd (I : SIntegral) (S : Domain) :=
-  (X Y : ι → Ω → ℝ) → (X ∈ S) → (Y ∈ S) →
-  X + Y ∈ S ∧ ∀ᵐ ω ∂P, I (X + Y) ω = I X ω + I Y ω
-
-/-- An SIntegral `I` with domain `S` respects scalar multiplication if `S` is
-closed under scalar multiplication and `I` commutes with scalar multiplication. -/
-def IntegralSMul (I : SIntegral) (S : Domain) :=
-  (X : ι → Ω → ℝ) → (X ∈ S) → (α : ℝ) →
-  α • X ∈ S ∧ ∀ᵐ ω ∂P, I (α • X) ω = α * I X ω
-
-/-- An SIntegral `I` with domain `S` respects indistinguishability
-if for every `Y` which is indistinguishable from some `X ∈ S` it holds that
-`Y ∈ S` and `I Y = I X` almost surely. -/
-def IntegralIndistinguishable (I : SIntegral) (S : Domain) :=
-  (X Y : ι → Ω → ℝ) → (X ∈ S) → (∀ᵐ ω ∂P, ∀ i, X i ω = Y i ω) →
-  Y ∈ S ∧ ∀ᵐ ω ∂P, I X ω = I Y ω
-
-/-- An SIntegral `I` with domain `S` respects dominated convergence if, for any
-sequence of processes `X n ∈ S` which are dominated by some `Y ∈ S` and
-converge to some process `Z`, it holds that `Z ∈ S` and `I X n` converges in
-probability to `I Z`. -/
-def IntegralDCT (I : SIntegral) (S : Domain) :=
-  (X : ℕ → ι → Ω → ℝ) → (Y Z : ι → Ω → ℝ) →
-  (∀ n, X n ∈ S) → (Y ∈ S) →
-  (∀ n i ω, |X n i ω| ≤ |Y i ω|) →
-  (∀ i ω, Tendsto (fun n ↦ X n i ω) atTop (𝓝 (Z i ω))) →
-  (Z ∈ S) ∧ TendstoInMeasure P (fun n ↦ I (X n)) atTop (I Z)
-
-/-- An SIntegral `I` with domain `S` is an extension of the Riemann-Stieltjes
-integral if it respects indistinguishability, addition, scalar multiplication,
-dominated converge, and elementary processes.
--/
-def IsRiemannStieltjesExtension (I : SIntegral) (S : Domain) :=
-  ∀ X ∈ S, AEStronglyMeasurable (I X) P ∧
-  IntegralElementary₁ P Y 𝓕 I S ∧
-  IntegralElementary₂ P Y 𝓕 I S ∧
-  IntegralAdd P I S ∧
-  IntegralSMul P I S ∧
-  IntegralIndistinguishable P I S ∧
-  IntegralDCT P I S
-
-/--
-An SIntegral `I` with domain `S` is *consistent* if any Riemann-Stieltjes extension
-with domain `S'` must almost surely agree with `I` on `S ∩ S'`.
-This condition ensures that `S` is not accidentally 'too large'.
--/
-def IsConsistent (I : SIntegral) (S : Domain) :=
-  (I' : SIntegral) → (S' : Domain) →
-  IsRiemannStieltjesExtension P Y 𝓕 I' S' →
-  (X : ι → Ω → ℝ) → (X ∈ S ∩ S') →
-  ∀ᵐ ω ∂P, I X ω = I' X ω
-
-/-- A `stochastic integral` against `Y` consists of a pre-integral `I`
-and a pre-domain `S`, such that `S` is a consistent domain and `I` is a
-Riemann-Stieltjes extension w.r.t `Y`.
--/
-structure StochasticIntegral where
-  I : SIntegral
-  S : Domain
-  is_extension : IsRiemannStieltjesExtension P Y 𝓕 I S
-  is_consistent : IsConsistent P Y 𝓕 I S
+/-- An SIntegral `I` with domain `S` is a *stochastic integral* if it is an extension of the
+Riemann-Stieltjes integral and it agrees with any other extension on the intersection
+of their domains. -/
+structure IsStochasticIntegral (I : SIntegral) (S : Domain) extends
+    IsRiemannStieltjesExtension P Y 𝓕 I S where
+  consistent : (I' : SIntegral) → (S' : Domain) → IsRiemannStieltjesExtension P Y 𝓕 I' S' →
+    (X : ι → Ω → ℝ) → (X ∈ S ∩ S') → I X =ᵐ[P] I' X
 
 end ProbabilityTheory
 

--- a/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
+++ b/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
@@ -12,16 +12,15 @@ variable {Ω : Type*} {mΩ : MeasurableSpace Ω} (P : Measure Ω)
 variable {ι : Type*} [LinearOrder ι]
 variable (Y : ι → Ω → ℝ) (𝓕 : Filtration ι mΩ)
 
-/-- A `domain` is a subset of stochastic processes. -/
+/-- A `pre-domain` is a subset of stochastic processes. -/
 abbrev PreDomain := Set (ι → Ω → ℝ)
 /-- A `pre-integral` maps processes to random variables. -/
 abbrev PreIntegral := (X : ι → Ω → ℝ) → Ω → ℝ
 
---- We now write down some properties which any reasonable stochastic integral
---- should satisfy.
-
-/-- A pre-integral `I` with domain `S` respects elementary processes
-if ...
+/--
+A pre-integral `S` respects elementary processes if for any `i ≤ j` and every
+`𝓕 i`-measurable random variable `X`, the elementary process constructed from
+`i`, `j`, and `X` lies in `S` and the value of `I` is the one we would expect.
 -/
 def IntegralElementary (I : PreIntegral) (S : PreDomain) :=
     (α β : ι) → (α ≤ β) → (X : Ω → ℝ) →
@@ -33,23 +32,20 @@ def IntegralElementary (I : PreIntegral) (S : PreDomain) :=
 /-- A pre-integral `I` with domain `S` respects addition if
 `S` is closed under addition and `I` commutes with addition. -/
 def IntegralAdd (I : PreIntegral) (S : PreDomain) :=
-    (X : ι → Ω → ℝ) → (Y : ι → Ω → ℝ) →
-    (X ∈ S) → (Y ∈ S) →
+    (X Y : ι → Ω → ℝ) → (X ∈ S) → (Y ∈ S) →
     X + Y ∈ S ∧ ∀ᵐ ω ∂P, I (X + Y) ω = I X ω + I Y ω
 
 /-- A pre-integral `I` with domain `S` respects scalar multiplication if `S` is
 closed under scalar multiplication and `I` commutes with scalar multiplication. -/
 def IntegralSMul (I : PreIntegral) (S : PreDomain) :=
-    (α : ℝ) → (X : ι → Ω → ℝ) → (X ∈ S) →
+    (X : ι → Ω → ℝ) → (X ∈ S) → (α : ℝ) →
     α • X ∈ S ∧ ∀ᵐ ω ∂P, I (α • X) ω = α * I X ω
 
 /-- A pre-integral `I` with domain `S` respects indistinguishability
 if for every `Y` which is indistinguishable from some `X ∈ S` it holds that
 `Y ∈ S` and `I Y = I X` almost surely. -/
 def IntegralIndistinguishable (I : PreIntegral) (S : PreDomain) :=
-    (X Y : ι → Ω → ℝ) →
-    (h₁ : X ∈ S) →
-    (h₂ : ∀ᵐ ω ∂P, ∀ i, X i ω = X i ω) →
+    (X Y : ι → Ω → ℝ) → (X ∈ S) → (∀ᵐ ω ∂P, ∀ i, X i ω = Y i ω) →
     Y ∈ S ∧ ∀ᵐ ω ∂P, I X ω = I Y ω
 
 /-- A pre-integral `I` with domain `S` respects dominated convergence if, for any
@@ -64,11 +60,11 @@ def IntegralDCT (I : PreIntegral) (S : PreDomain) :=
     (Z ∈ S) ∧ TendstoInMeasure P (fun n ↦ I (X n)) atTop (I Z)
 
 /--
-A pre-integral `I` with domain `S` is a stochastic integral if it
-respects indistinguishability, addition, scalar multiplication, dominated
-converge, and elementary processes.
+A pre-integral `I` with domain `S` is an extension of the Riemann-Stieltjes
+integral if it respects indistinguishability, addition, scalar multiplication,
+dominated converge, and elementary processes.
 -/
-def IsStochasticIntegral (I : PreIntegral) (S : PreDomain) :=
+def IsRiemannStieltjesExtension (I : PreIntegral) (S : PreDomain) :=
     IntegralElementary P Y 𝓕 I S ∧
     IntegralAdd P I S ∧
     IntegralSMul P I S ∧
@@ -76,23 +72,25 @@ def IsStochasticIntegral (I : PreIntegral) (S : PreDomain) :=
     IntegralDCT P I S
 
 /--
-A pre-domain `S` is consistent for `Y` if any two stochastic integrals for `Y`
-with domain `S` must necessarily agree. Using `IntegralDCT` it can be shown that
-this condition holds if every `X ∈ S` can be approximated pointwise by a sequence
-of elementary processes which are dominated by some element of `S`.
+A pre-domain `S` is consistent for `Y` if any there can exists at most one
+extension of the Riemann-Stieltjes integral on `S` (up to a.s. equality).
+This condition ensures that `S` is not accidentally 'too large'.
+It can be shown that `S` is consistent if any function in `S` can be
+approximated pointwise by a sequence of elementary functions in a dominated way.
 -/
 def IsConsistentDomain (S : PreDomain) :=
     (I₁ I₂ : PreIntegral) →
-    IsStochasticIntegral P Y 𝓕 I₁ S →
-    IsStochasticIntegral P Y 𝓕 I₂ S →
+    IsRiemannStieltjesExtension P Y 𝓕 I₁ S →
+    IsRiemannStieltjesExtension P Y 𝓕 I₂ S →
     (X : ι → Ω → ℝ) → (X ∈ S) →
     ∀ᵐ ω ∂P, I₁ X ω = I₂ X ω
 
-def CMSpace (B : NNReal → Ω → ℝ) (hB : IsBrownianReal B P) :=
-    {X : NNReal → Ω → ℝ | IsStronglyPredictable (m := mΩ) (natural B sorry) X}
-
-theorem exists_sintegral (B : NNReal → Ω → ℝ) (𝓕 : Filtration NNReal mΩ)
-    (hB : IsBrownianReal B P) (hB₂ : IsFilteredPreBrownian B 𝓕 P) :
-    ∃ I : PreIntegral, ∃ S : PreDomain,
-    IsStochasticIntegral P B 𝓕 I S ∧ IsConsistentDomain P B 𝓕 S :=
-  sorry
+/-- A `stochastic integral` against `Y` consists of a pre-integral `I`
+and a pre-domain `S`, such that `S` is a consistent domain and `I` is a
+Riemann-Stieltjes extension w.r.t `Y`.
+-/
+structure StochasticIntegral where
+    I : PreIntegral
+    S : PreDomain
+    is_extension : IsRiemannStieltjesExtension P Y 𝓕 I S
+    is_consistent : IsConsistentDomain P Y 𝓕 S

--- a/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
+++ b/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
@@ -27,16 +27,17 @@ in this case the integral should commute with the limit.
 process should be integrable.
 
 In order to prevent nonuniqueness, we additionally impose a condition on the domain:
-* `IsConsistentDomain`: a domain `S` is consistent for `Y` if any two extensions of the
-  Riemann-Stieltjes integral with domain `S` must agree almost surely.
+* `IsConsistent`: the stochastic integral `I` should be canonical, i.e., any other Riemann-Stieltjes
+extension satisfying the above axioms should agree with `I` on the intersection of their domains.
 In practice, `IsConsistentDomain` can be shown whenever every element in `S` can be
 pointwise approximated by simple processes in a dominated way (in this case, uniqueness
 is easily shown using `IntegralDCT`).
 
 A `stochastic integral` is then given by the structure `StochasticIntegral`,
 guaranteeing that it satisfies all the above properties.
+
 Note that none of the definitions impose that the domain `S` should be maximal.
-As a consequence, it is possible to define stochastic integrals w.r.t `Y`.
+As a consequence, it is possible to define different stochastic integrals w.r.t `Y`.
 However, any two such integrals will necessarily agree (almost surely)
 on the intersection of their domains.
 -/
@@ -124,8 +125,6 @@ def IsRiemannStieltjesExtension (I : SIntegral) (S : Domain) :=
 An SIntegral `I` with domain `S` is *consistent* if any Riemann-Stieltjes extension
 with domain `S'` must almost surely agree with `I` on `S ∩ S'`.
 This condition ensures that `S` is not accidentally 'too large'.
-It can be shown that `S` is consistent if any function in `S` can be
-approximated pointwise by a sequence of elementary functions in a dominated way.
 -/
 def IsConsistent (I : SIntegral) (S : Domain) :=
   (I' : SIntegral) → (S' : Domain) →

--- a/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
+++ b/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
@@ -57,38 +57,37 @@ if it agrees with Riemann-Stieltjes on elementary processes and respects lineari
 indistinguishability, and dominated convergence. -/
 structure IsRiemannStieltjesExtension (I : SIntegral) (S : Domain) : Prop where
   /-- The stochastic integral is measurable. -/
-  measurable : (X : ι → Ω → ℝ) → (X ∈ S) → AEStronglyMeasurable (I X) P
+  measurable X (h : X ∈ S) : AEStronglyMeasurable (I X) P
   /-- Elementary functions are in the domain and the value of the integral is the
   expected one. -/
-  elementary_ioc : (i j : ι) → (i ≤ j) → (X : @SimpleFunc Ω (𝓕 i) ℝ) →
+  elementary_ioc i j (h : i ≤ j) (X : @SimpleFunc Ω (𝓕 i) ℝ) :
     (fun k ω ↦ if (k ∈ Set.Ioc i j) then X ω else 0) ∈ S ∧
     I (fun k ω ↦ if (k ∈ Set.Ioc i j) then X ω else 0) =ᵐ[P] X * (Y j - Y i)
-  elementary_iic : (i : ι) → (X : @SimpleFunc Ω (𝓕 ⊥) ℝ) →
+  elementary_iic i (X : @SimpleFunc Ω (𝓕 ⊥) ℝ) :
     (fun j ω ↦ if (j ∈ Set.Iic i) then X ω else 0) ∈ S ∧
     I (fun j ω ↦ if (j ∈ Set.Iic i) then X ω else 0) =ᵐ[P] X * (Y i - Y ⊥)
   /-- The integral and the domain respect addition. -/
-  integral_add : (X₁ X₂ : ι → Ω → ℝ) → (X₁ ∈ S) → (X₂ ∈ S) →
+  integral_add X₁ X₂ (h₁ : X₁ ∈ S) (h₂ : X₂ ∈ S) :
     X₁ + X₂ ∈ S ∧ I (X₁ + X₂) =ᵐ[P] I X₁ + I X₂
   /-- The integral and the domain respect scalar multiplication. -/
-  integral_smul : (X : ι → Ω → ℝ) → (X ∈ S) → (α : ℝ) →
+  integral_smul X (α : ℝ) (h : X ∈ S) :
     α • X ∈ S ∧ I (α • X) =ᵐ[P] α • I X
   /-- The integral and its domain respect indistinguishability. -/
-  integral_indistinguishable : (X₁ X₂ : ι → Ω → ℝ) → (X₁ ∈ S) →
-    (X₁ ≡ᵐ[P] X₂) → X₂ ∈ S ∧ I X₁ =ᵐ[P] I X₂
+  integral_indistinguishable X₁ X₂ (h₁ : X₁ ∈ S) (h₂ : X₁ ≡ᵐ[P] X₂) :
+    X₂ ∈ S ∧ I X₁ =ᵐ[P] I X₂
   /-- The domain is closed under dominated convergence, and in this case the integral
   commutes with the limit. -/
-  integral_dct : (X : ℕ → ι → Ω → ℝ) → (X_dom X_lim : ι → Ω → ℝ) →
-    (∀ n, X n ∈ S) → (X_dom ∈ S) → (∀ n i ω, |X n i ω| ≤ |X_dom i ω|) →
-    (∀ i ω, Tendsto (X · i ω) atTop (𝓝 (X_lim i ω))) →
-    (X_lim ∈ S) ∧ TendstoInMeasure P (fun n ↦ I (X n)) atTop (I X_lim)
+  integral_dct (X : ℕ → ι → Ω → ℝ) X_dom X_lim
+      (h₁ : ∀ n, X n ∈ S) (h₂ : X_dom ∈ S) (h_dom : ∀ n i ω, |X n i ω| ≤ |X_dom i ω|)
+      (h_lim : ∀ i ω, Tendsto (X · i ω) atTop (𝓝 (X_lim i ω))) :
+    X_lim ∈ S ∧ TendstoInMeasure P (fun n ↦ I (X n)) atTop (I X_lim)
 
 /-- An SIntegral `I` with domain `S` is a *stochastic integral* if it is an extension of the
 Riemann-Stieltjes integral and it agrees with any other extension on the intersection
 of their domains. -/
-structure IsStochasticIntegral (I : SIntegral) (S : Domain) extends
-    IsRiemannStieltjesExtension P Y 𝓕 I S where
-  consistent : (I' : SIntegral) → (S' : Domain) → IsRiemannStieltjesExtension P Y 𝓕 I' S' →
-    (X : ι → Ω → ℝ) → (X ∈ S ∩ S') → I X =ᵐ[P] I' X
+structure IsStochasticIntegral I S extends IsRiemannStieltjesExtension P Y 𝓕 I S where
+  consistent I' S' (h : IsRiemannStieltjesExtension P Y 𝓕 I' S') X (hX : X ∈ S ∩ S') :
+    I X =ᵐ[P] I' X
 
 end ProbabilityTheory
 

--- a/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
+++ b/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
@@ -112,6 +112,7 @@ integral if it respects indistinguishability, addition, scalar multiplication,
 dominated converge, and elementary processes.
 -/
 def IsRiemannStieltjesExtension (I : SIntegral) (S : Domain) :=
+  ∀ X ∈ S, AEStronglyMeasurable (I X) P ∧
   IntegralElementary₁ P Y 𝓕 I S ∧
   IntegralElementary₂ P Y 𝓕 I S ∧
   IntegralAdd P I S ∧
@@ -120,18 +121,17 @@ def IsRiemannStieltjesExtension (I : SIntegral) (S : Domain) :=
   IntegralDCT P I S
 
 /--
-A domain `S` is consistent for `Y` if there can exists at most one
-extension of the Riemann-Stieltjes integral w.r.t `Y` on `S` (up to a.s. equality).
+An SIntegral `I` with domain `S` is *consistent* if any Riemann-Stieltjes extension
+with domain `S'` must almost surely agree with `I` on `S ∩ S'`.
 This condition ensures that `S` is not accidentally 'too large'.
 It can be shown that `S` is consistent if any function in `S` can be
 approximated pointwise by a sequence of elementary functions in a dominated way.
 -/
-def IsConsistentDomain (S : Domain) :=
-  (I₁ I₂ : SIntegral) →
-  IsRiemannStieltjesExtension P Y 𝓕 I₁ S →
-  IsRiemannStieltjesExtension P Y 𝓕 I₂ S →
-  (X : ι → Ω → ℝ) → (X ∈ S) →
-  ∀ᵐ ω ∂P, I₁ X ω = I₂ X ω
+def IsConsistent (I : SIntegral) (S : Domain) :=
+  (I' : SIntegral) → (S' : Domain) →
+  IsRiemannStieltjesExtension P Y 𝓕 I' S' →
+  (X : ι → Ω → ℝ) → (X ∈ S ∩ S') →
+  ∀ᵐ ω ∂P, I X ω = I' X ω
 
 /-- A `stochastic integral` against `Y` consists of a pre-integral `I`
 and a pre-domain `S`, such that `S` is a consistent domain and `I` is a
@@ -141,7 +141,7 @@ structure StochasticIntegral where
   I : SIntegral
   S : Domain
   is_extension : IsRiemannStieltjesExtension P Y 𝓕 I S
-  is_consistent : IsConsistentDomain P Y 𝓕 S
+  is_consistent : IsConsistent P Y 𝓕 I S
 
 end ProbabilityTheory
 

--- a/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
+++ b/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
@@ -14,7 +14,10 @@ public import BrownianMotion.Auxiliary.Indistinguishable
 # Characterization of the stochastic integral.
 
 This file contains an axiomatic characterization of the stochastic integral
-against a process `Y : ι → Ω → ℝ`. We ask for the following properties, which we expect
+against a process `Y : ι → Ω → ℝ`. The integral is defined as a map from `ι → Ω → ℝ`
+to `Ω → ℝ`, meaning that we are evaluating the integral at some fixed, terminal time.
+
+We ask for the following properties, which we expect
 any good stochastic integral `I` to have:
 * The integral agrees with the Riemann-Stieltjes integral for elementary processes.
 * Linearity for the integral and its domain.

--- a/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
+++ b/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
@@ -2,9 +2,10 @@ module
 
 public import Mathlib.Probability.Process.Adapted
 public import Mathlib.Probability.Process.Filtration
-public import Mathlib.Probability.Process.Predictable
-public import Mathlib.Probability.BrownianMotion.Basic
-public import BrownianMotion.Gaussian.BrownianMotion
+
+@[expose] public section
+
+namespace ProbabilityTheory
 
 open ProbabilityTheory MeasureTheory Real Filtration Filter Topology
 
@@ -12,85 +13,87 @@ variable {Ω : Type*} {mΩ : MeasurableSpace Ω} (P : Measure Ω)
 variable {ι : Type*} [LinearOrder ι]
 variable (Y : ι → Ω → ℝ) (𝓕 : Filtration ι mΩ)
 
-/-- A `pre-domain` is a subset of stochastic processes. -/
-abbrev PreDomain := Set (ι → Ω → ℝ)
-/-- A `pre-integral` maps processes to random variables. -/
-abbrev PreIntegral := (X : ι → Ω → ℝ) → Ω → ℝ
+/-- A domain is a subset of stochastic processes. -/
+abbrev Domain := Set (ι → Ω → ℝ)
+/-- An `SIntegral` maps processes to random variables. -/
+abbrev SIntegral := (X : ι → Ω → ℝ) → Ω → ℝ
 
-/--
-A pre-integral `S` respects elementary processes if for any `i ≤ j` and every
-`𝓕 i`-measurable random variable `X`, the elementary process constructed from
-`i`, `j`, and `X` lies in `S` and the value of `I` is the one we would expect.
--/
-def IntegralElementary (I : PreIntegral) (S : PreDomain) :=
-    (α β : ι) → (α ≤ β) → (X : Ω → ℝ) →
-    (StronglyMeasurable[𝓕 α] X) →
-    (fun i ω ↦ if (i ∈ Set.Ioc α β) then X ω else 0) ∈ S ∧
-    ∀ᵐ ω ∂P, I (fun i ω ↦ if (i ∈ Set.Ioc α β) then X ω else 0) ω =
-      X ω * (Y β ω - Y α ω)
+/-- An SIntegral `I` with domain `S` respects elementary processes w.r.t `Y`
+if for any `i ≤ j` and every `𝓕 i`-measurable random variable `X`, the elementary process
+constructed from `i`, `j`, and `X` lies in `S` and the value of `I` is the
+one we would expect. -/
+def IntegralElementary (I : SIntegral) (S : Domain) :=
+  (α β : ι) → (α ≤ β) → (X : Ω → ℝ) →
+  (StronglyMeasurable[𝓕 α] X) →
+  (fun i ω ↦ if (i ∈ Set.Ioc α β) then X ω else 0) ∈ S ∧
+  ∀ᵐ ω ∂P, I (fun i ω ↦ if (i ∈ Set.Ioc α β) then X ω else 0) ω =
+    X ω * (Y β ω - Y α ω)
 
-/-- A pre-integral `I` with domain `S` respects addition if
+/-- An SIntegral `I` with domain `S` respects addition if
 `S` is closed under addition and `I` commutes with addition. -/
-def IntegralAdd (I : PreIntegral) (S : PreDomain) :=
-    (X Y : ι → Ω → ℝ) → (X ∈ S) → (Y ∈ S) →
-    X + Y ∈ S ∧ ∀ᵐ ω ∂P, I (X + Y) ω = I X ω + I Y ω
+def IntegralAdd (I : SIntegral) (S : Domain) :=
+  (X Y : ι → Ω → ℝ) → (X ∈ S) → (Y ∈ S) →
+  X + Y ∈ S ∧ ∀ᵐ ω ∂P, I (X + Y) ω = I X ω + I Y ω
 
-/-- A pre-integral `I` with domain `S` respects scalar multiplication if `S` is
+/-- An SIntegral `I` with domain `S` respects scalar multiplication if `S` is
 closed under scalar multiplication and `I` commutes with scalar multiplication. -/
-def IntegralSMul (I : PreIntegral) (S : PreDomain) :=
-    (X : ι → Ω → ℝ) → (X ∈ S) → (α : ℝ) →
-    α • X ∈ S ∧ ∀ᵐ ω ∂P, I (α • X) ω = α * I X ω
+def IntegralSMul (I : SIntegral) (S : Domain) :=
+  (X : ι → Ω → ℝ) → (X ∈ S) → (α : ℝ) →
+  α • X ∈ S ∧ ∀ᵐ ω ∂P, I (α • X) ω = α * I X ω
 
-/-- A pre-integral `I` with domain `S` respects indistinguishability
+/-- An SIntegral `I` with domain `S` respects indistinguishability
 if for every `Y` which is indistinguishable from some `X ∈ S` it holds that
 `Y ∈ S` and `I Y = I X` almost surely. -/
-def IntegralIndistinguishable (I : PreIntegral) (S : PreDomain) :=
-    (X Y : ι → Ω → ℝ) → (X ∈ S) → (∀ᵐ ω ∂P, ∀ i, X i ω = Y i ω) →
-    Y ∈ S ∧ ∀ᵐ ω ∂P, I X ω = I Y ω
+def IntegralIndistinguishable (I : SIntegral) (S : Domain) :=
+  (X Y : ι → Ω → ℝ) → (X ∈ S) → (∀ᵐ ω ∂P, ∀ i, X i ω = Y i ω) →
+  Y ∈ S ∧ ∀ᵐ ω ∂P, I X ω = I Y ω
 
-/-- A pre-integral `I` with domain `S` respects dominated convergence if, for any
-sequence of processes `X n ∈ S` which are pointwise dominated by some `Y ∈ S` and
-converge pointwise to some process `Z`, it holds that `Z ∈ S` and
-`I X n` converges in probability to `I Z`. -/
-def IntegralDCT (I : PreIntegral) (S : PreDomain) :=
-    (X : ℕ → ι → Ω → ℝ) → (Y Z : ι → Ω → ℝ) →
-    (∀ n, X n ∈ S) → (Y ∈ S) →
-    (∀ n i ω, |X n i ω| ≤ |Y i ω|) →
-    (∀ i ω, Tendsto (fun n ↦ X n i ω) atTop (𝓝 (Z i ω))) →
-    (Z ∈ S) ∧ TendstoInMeasure P (fun n ↦ I (X n)) atTop (I Z)
+/-- An SIntegral `I` with domain `S` respects dominated convergence if, for any
+sequence of processes `X n ∈ S` which are dominated by some `Y ∈ S` and
+converge to some process `Z`, it holds that `Z ∈ S` and `I X n` converges in
+probability to `I Z`. -/
+def IntegralDCT (I : SIntegral) (S : Domain) :=
+  (X : ℕ → ι → Ω → ℝ) → (Y Z : ι → Ω → ℝ) →
+  (∀ n, X n ∈ S) → (Y ∈ S) →
+  (∀ n i ω, |X n i ω| ≤ |Y i ω|) →
+  (∀ i ω, Tendsto (fun n ↦ X n i ω) atTop (𝓝 (Z i ω))) →
+  (Z ∈ S) ∧ TendstoInMeasure P (fun n ↦ I (X n)) atTop (I Z)
 
-/--
-A pre-integral `I` with domain `S` is an extension of the Riemann-Stieltjes
+/-- An SIntegral `I` with domain `S` is an extension of the Riemann-Stieltjes
 integral if it respects indistinguishability, addition, scalar multiplication,
 dominated converge, and elementary processes.
 -/
-def IsRiemannStieltjesExtension (I : PreIntegral) (S : PreDomain) :=
-    IntegralElementary P Y 𝓕 I S ∧
-    IntegralAdd P I S ∧
-    IntegralSMul P I S ∧
-    IntegralIndistinguishable P I S ∧
-    IntegralDCT P I S
+def IsRiemannStieltjesExtension (I : SIntegral) (S : Domain) :=
+  IntegralElementary P Y 𝓕 I S ∧
+  IntegralAdd P I S ∧
+  IntegralSMul P I S ∧
+  IntegralIndistinguishable P I S ∧
+  IntegralDCT P I S
 
 /--
-A pre-domain `S` is consistent for `Y` if any there can exists at most one
-extension of the Riemann-Stieltjes integral on `S` (up to a.s. equality).
+A domain `S` is consistent for `Y` if there can exists at most one
+extension of the Riemann-Stieltjes integral w.r.t `Y` on `S` (up to a.s. equality).
 This condition ensures that `S` is not accidentally 'too large'.
 It can be shown that `S` is consistent if any function in `S` can be
 approximated pointwise by a sequence of elementary functions in a dominated way.
 -/
-def IsConsistentDomain (S : PreDomain) :=
-    (I₁ I₂ : PreIntegral) →
-    IsRiemannStieltjesExtension P Y 𝓕 I₁ S →
-    IsRiemannStieltjesExtension P Y 𝓕 I₂ S →
-    (X : ι → Ω → ℝ) → (X ∈ S) →
-    ∀ᵐ ω ∂P, I₁ X ω = I₂ X ω
+def IsConsistentDomain (S : Domain) :=
+  (I₁ I₂ : SIntegral) →
+  IsRiemannStieltjesExtension P Y 𝓕 I₁ S →
+  IsRiemannStieltjesExtension P Y 𝓕 I₂ S →
+  (X : ι → Ω → ℝ) → (X ∈ S) →
+  ∀ᵐ ω ∂P, I₁ X ω = I₂ X ω
 
 /-- A `stochastic integral` against `Y` consists of a pre-integral `I`
 and a pre-domain `S`, such that `S` is a consistent domain and `I` is a
 Riemann-Stieltjes extension w.r.t `Y`.
 -/
 structure StochasticIntegral where
-    I : PreIntegral
-    S : PreDomain
-    is_extension : IsRiemannStieltjesExtension P Y 𝓕 I S
-    is_consistent : IsConsistentDomain P Y 𝓕 S
+  I : SIntegral
+  S : Domain
+  is_extension : IsRiemannStieltjesExtension P Y 𝓕 I S
+  is_consistent : IsConsistentDomain P Y 𝓕 S
+
+end ProbabilityTheory
+
+end

--- a/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
+++ b/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
@@ -1,0 +1,98 @@
+module
+
+public import Mathlib.Probability.Process.Adapted
+public import Mathlib.Probability.Process.Filtration
+public import Mathlib.Probability.Process.Predictable
+public import Mathlib.Probability.BrownianMotion.Basic
+public import BrownianMotion.Gaussian.BrownianMotion
+
+open ProbabilityTheory MeasureTheory Real Filtration Filter Topology
+
+variable {Ω : Type*} {mΩ : MeasurableSpace Ω} (P : Measure Ω)
+variable {ι : Type*} [LinearOrder ι]
+variable (Y : ι → Ω → ℝ) (𝓕 : Filtration ι mΩ)
+
+/-- A `domain` is a subset of stochastic processes. -/
+abbrev PreDomain := Set (ι → Ω → ℝ)
+/-- A `pre-integral` maps processes to random variables. -/
+abbrev PreIntegral := (X : ι → Ω → ℝ) → Ω → ℝ
+
+--- We now write down some properties which any reasonable stochastic integral
+--- should satisfy.
+
+/-- A pre-integral `I` with domain `S` respects elementary processes
+if ...
+-/
+def IntegralElementary (I : PreIntegral) (S : PreDomain) :=
+    (α β : ι) → (α ≤ β) → (X : Ω → ℝ) →
+    (StronglyMeasurable[𝓕 α] X) →
+    (fun i ω ↦ if (i ∈ Set.Ioc α β) then X ω else 0) ∈ S ∧
+    ∀ᵐ ω ∂P, I (fun i ω ↦ if (i ∈ Set.Ioc α β) then X ω else 0) ω =
+      X ω * (Y β ω - Y α ω)
+
+/-- A pre-integral `I` with domain `S` respects addition if
+`S` is closed under addition and `I` commutes with addition. -/
+def IntegralAdd (I : PreIntegral) (S : PreDomain) :=
+    (X : ι → Ω → ℝ) → (Y : ι → Ω → ℝ) →
+    (X ∈ S) → (Y ∈ S) →
+    X + Y ∈ S ∧ ∀ᵐ ω ∂P, I (X + Y) ω = I X ω + I Y ω
+
+/-- A pre-integral `I` with domain `S` respects scalar multiplication if `S` is
+closed under scalar multiplication and `I` commutes with scalar multiplication. -/
+def IntegralSMul (I : PreIntegral) (S : PreDomain) :=
+    (α : ℝ) → (X : ι → Ω → ℝ) → (X ∈ S) →
+    α • X ∈ S ∧ ∀ᵐ ω ∂P, I (α • X) ω = α * I X ω
+
+/-- A pre-integral `I` with domain `S` respects indistinguishability
+if for every `Y` which is indistinguishable from some `X ∈ S` it holds that
+`Y ∈ S` and `I Y = I X` almost surely. -/
+def IntegralIndistinguishable (I : PreIntegral) (S : PreDomain) :=
+    (X Y : ι → Ω → ℝ) →
+    (h₁ : X ∈ S) →
+    (h₂ : ∀ᵐ ω ∂P, ∀ i, X i ω = X i ω) →
+    Y ∈ S ∧ ∀ᵐ ω ∂P, I X ω = I Y ω
+
+/-- A pre-integral `I` with domain `S` respects dominated convergence if, for any
+sequence of processes `X n ∈ S` which are pointwise dominated by some `Y ∈ S` and
+converge pointwise to some process `Z`, it holds that `Z ∈ S` and
+`I X n` converges in probability to `I Z`. -/
+def IntegralDCT (I : PreIntegral) (S : PreDomain) :=
+    (X : ℕ → ι → Ω → ℝ) → (Y Z : ι → Ω → ℝ) →
+    (∀ n, X n ∈ S) → (Y ∈ S) →
+    (∀ n i ω, |X n i ω| ≤ |Y i ω|) →
+    (∀ i ω, Tendsto (fun n ↦ X n i ω) atTop (𝓝 (Z i ω))) →
+    (Z ∈ S) ∧ TendstoInMeasure P (fun n ↦ I (X n)) atTop (I Z)
+
+/--
+A pre-integral `I` with domain `S` is a stochastic integral if it
+respects indistinguishability, addition, scalar multiplication, dominated
+converge, and elementary processes.
+-/
+def IsStochasticIntegral (I : PreIntegral) (S : PreDomain) :=
+    IntegralElementary P Y 𝓕 I S ∧
+    IntegralAdd P I S ∧
+    IntegralSMul P I S ∧
+    IntegralIndistinguishable P I S ∧
+    IntegralDCT P I S
+
+/--
+A pre-domain `S` is consistent for `Y` if any two stochastic integrals for `Y`
+with domain `S` must necessarily agree. Using `IntegralDCT` it can be shown that
+this condition holds if every `X ∈ S` can be approximated pointwise by a sequence
+of elementary processes which are dominated by some element of `S`.
+-/
+def IsConsistentDomain (S : PreDomain) :=
+    (I₁ I₂ : PreIntegral) →
+    IsStochasticIntegral P Y 𝓕 I₁ S →
+    IsStochasticIntegral P Y 𝓕 I₂ S →
+    (X : ι → Ω → ℝ) → (X ∈ S) →
+    ∀ᵐ ω ∂P, I₁ X ω = I₂ X ω
+
+def CMSpace (B : NNReal → Ω → ℝ) (hB : IsBrownianReal B P) :=
+    {X : NNReal → Ω → ℝ | IsStronglyPredictable (m := mΩ) (natural B sorry) X}
+
+theorem exists_sintegral (B : NNReal → Ω → ℝ) (𝓕 : Filtration NNReal mΩ)
+    (hB : IsBrownianReal B P) (hB₂ : IsFilteredPreBrownian B 𝓕 P) :
+    ∃ I : PreIntegral, ∃ S : PreDomain,
+    IsStochasticIntegral P B 𝓕 I S ∧ IsConsistentDomain P B 𝓕 S :=
+  sorry

--- a/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
+++ b/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
@@ -48,7 +48,7 @@ namespace ProbabilityTheory
 open ProbabilityTheory MeasureTheory Real Filtration Filter Topology
 
 variable {Ω : Type*} {mΩ : MeasurableSpace Ω} (P : Measure Ω)
-variable {ι : Type*} [LinearOrder ι]
+variable {ι : Type*} [LinearOrder ι] [OrderBot ι]
 variable (Y : ι → Ω → ℝ) (𝓕 : Filtration ι mΩ)
 
 /-- A domain is a subset of stochastic processes. -/
@@ -60,12 +60,22 @@ abbrev SIntegral := (X : ι → Ω → ℝ) → Ω → ℝ
 if for any `i ≤ j` and every `𝓕 i`-measurable random variable `X`, the elementary process
 constructed from `i`, `j`, and `X` lies in `S` and the value of `I` is the
 one we would expect. -/
-def IntegralElementary (I : SIntegral) (S : Domain) :=
+def IntegralElementary₁ (I : SIntegral) (S : Domain) :=
   (α β : ι) → (α ≤ β) → (X : Ω → ℝ) →
   (StronglyMeasurable[𝓕 α] X) →
   (fun i ω ↦ if (i ∈ Set.Ioc α β) then X ω else 0) ∈ S ∧
   ∀ᵐ ω ∂P, I (fun i ω ↦ if (i ∈ Set.Ioc α β) then X ω else 0) ω =
     X ω * (Y β ω - Y α ω)
+
+/-- An SIntegral `I` with domain `S` respects elementary processes w.r.t `Y`
+if for any `i ≤ j` and every `𝓕 i`-measurable random variable `X`, the elementary process
+constructed from `i`, `j`, and `X` lies in `S` and the value of `I` is the
+one we would expect. -/
+def IntegralElementary₂ (I : SIntegral) (S : Domain) :=
+  (α : ι) → (X : Ω → ℝ) → (StronglyMeasurable[𝓕 ⊥] X) →
+  (fun i ω ↦ if (i ∈ Set.Iic α) then X ω else 0) ∈ S ∧
+  ∀ᵐ ω ∂P, I (fun i ω ↦ if (i ∈ Set.Iic α) then X ω else 0) ω =
+    X ω * Y α ω - X ω * Y ⊥ ω
 
 /-- An SIntegral `I` with domain `S` respects addition if
 `S` is closed under addition and `I` commutes with addition. -/
@@ -102,7 +112,8 @@ integral if it respects indistinguishability, addition, scalar multiplication,
 dominated converge, and elementary processes.
 -/
 def IsRiemannStieltjesExtension (I : SIntegral) (S : Domain) :=
-  IntegralElementary P Y 𝓕 I S ∧
+  IntegralElementary₁ P Y 𝓕 I S ∧
+  IntegralElementary₂ P Y 𝓕 I S ∧
   IntegralAdd P I S ∧
   IntegralSMul P I S ∧
   IntegralIndistinguishable P I S ∧

--- a/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
+++ b/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
@@ -20,13 +20,13 @@ any good stochastic integral `I` to have:
 * Linearity for the integral and its domain.
 * The integral and its domain respect indistinguishability.
 * Dominated convergence: if a process `X` is integrable, then any pointwise limit of a
-sequence of integrable processes which is dominated by `X` should again be integrable.
+  sequence of integrable processes which is dominated by `X` should again be integrable.
 
 The properties above are encoded in the predicate `IsRiemannStieltjesExtension`.
 However, this predicate does not ensure that the integral is canonical or unique.
 To get a true stochastic integral `I`, we additionally impose the following.
 * Any extension of the Riemann-Stieltjes integral must agree with `I` on
-the intersection of their domains.
+  the intersection of their domains.
 
 This additional condition is encoded in `IsStochasticIntegral` which extends
 `IsRiemannStieltjesExtension`.

--- a/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
+++ b/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
@@ -77,8 +77,8 @@ structure IsRiemannStieltjesExtension (I : SIntegral) (S : Domain) : Prop where
     X₂ ∈ S ∧ I X₁ =ᵐ[P] I X₂
   /-- The domain is closed under dominated convergence, and in this case the integral
   commutes with the limit. -/
-  integral_dct (X : ℕ → ι → Ω → ℝ) X_dom X_lim
-      (h₁ : ∀ n, X n ∈ S) (h₂ : X_dom ∈ S) (h_dom : ∀ n i ω, |X n i ω| ≤ |X_dom i ω|)
+  integral_dct (X : ℕ → ι → Ω → ℝ) X_dom X_lim (h₁ : ∀ n, X n ∈ S) (h₂ : X_dom ∈ S)
+      (h_dom : ∀ n i ω, |X n i ω| ≤ |X_dom i ω|)
       (h_lim : ∀ i ω, Tendsto (X · i ω) atTop (𝓝 (X_lim i ω))) :
     X_lim ∈ S ∧ TendstoInMeasure P (fun n ↦ I (X n)) atTop (I X_lim)
 

--- a/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
+++ b/BrownianMotion/StochasticIntegral/StochasticIntegral.lean
@@ -1,3 +1,9 @@
+/-
+Copyright (c) 2025 Joris van Winden. All rights reserved.
+Released under Apache 2.0 license as described in the file LICENSE.
+Authors: Joris van Winden
+-/
+
 module
 
 public import Mathlib.Probability.Process.Adapted


### PR DESCRIPTION
This PR provides a characterization of the (real-valued) stochastic integral in the form of the predicate `IsStochasticIntegral`.

The idea is that, if the auxiliary data (probability space, filtration, integrator, index set) are set up correctly, then it should be possible to construct an `SIntegral` and a `Domain` for which the predicate `IsStochasticIntegral` holds true. Moreover, any such `SIntegral` must be unique (on the domain).

The goal of the predicate `IsStochasticIntegral` is ultimately to provide a good target for the formalization, and to convince the reader that the (to be constructed) object is indeed the familiar stochastic integral.